### PR TITLE
patch szs archives and unlinked files on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.exe
 *.iso
 root
+pikminBMGtool.py

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@
 ### Building
 
 Prerequisites:
+1. [Lunaboy's RARC Tools](https://www.romhacking.net/utilities/1024/)
 1. ninja
-1. nodtool
+1. [nodtool](https://github.com/AxioDL/nod)
+1. [pikminBMG](https://github.com/RenolY2/pikminBMG)
 1. python3
 1. wine (if not on Windows)
 

--- a/build.py
+++ b/build.py
@@ -1,68 +1,126 @@
 import glob
+import json
 import os
-import re
 import shutil
 import subprocess
+import time
 
 
-DIRECTORY_PAIRS = [(os.path.join(os.getcwd(), 'pikmin2', 'include'), os.path.join(os.getcwd(), 'include')),
-                   (os.path.join(os.getcwd(), 'pikmin2', 'src'), os.path.join(os.getcwd(), 'src')),
-                   (os.path.join(os.getcwd(), 'root', 'files'), os.path.join(os.getcwd(), 'files'))]
+DECOMP_ROOT = os.path.join(os.getcwd(), 'pikmin2')
+DECOMP_INCLUDE = os.path.join(os.getcwd(), 'pikmin2', 'include')
+P2GZ_INCLUDE = os.path.join(os.getcwd(), 'include')
+DECOMP_SRC = os.path.join(os.getcwd(), 'pikmin2', 'src')
+P2GZ_SRC = os.path.join(os.getcwd(), 'src')
+ISO_ASSETS = os.path.join(os.getcwd(), 'root', 'files')
+P2GZ_ASSETS = os.path.join(os.getcwd(), 'files')
 
+start_time = time.time()
 
-def patch_directory(source_dir, patch_dir):
-    patched_files = []
+# extract iso
+try:
+    iso = glob.glob(os.path.join(os.getcwd(), '*.iso'))[0]
+except IndexError:
+    print('ERROR: No .iso file found in the current directory')
+    exit()
 
-    for patch_root, _, files in os.walk(patch_dir):
-        source_root = patch_root.replace(patch_dir, source_dir)
+if not os.path.exists(os.path.join(os.getcwd(), 'root')):
+    print(f'Extracting {iso}')
+    subprocess.run(f'nodtool extract "{iso}" root', shell=True)
 
-        for file in files:
-            source_file = os.path.join(source_root, file)
-            patch_file = os.path.join(patch_root, file)
+    for file in glob.glob(os.path.join(ISO_ASSETS, 'thp', '*.thp')):
+        os.remove(file)
 
-            if os.path.exists(source_file):
-                print(f'Replaced {source_file} with {patch_file}')
-            else:
-                print(f'Added {patch_file} to {source_root}')
-            patched_files.append(shutil.copy2(patch_file, source_file)) 
+# patch headers
+for p2gz_path, _, files in os.walk(P2GZ_INCLUDE):
+    decomp_path = p2gz_path.replace(P2GZ_INCLUDE, DECOMP_INCLUDE)
 
-    return patched_files
+    for file in files:
+        decomp_header = os.path.join(decomp_path, file)
+        p2gz_header = os.path.join(p2gz_path, file)
 
+        if os.path.exists(decomp_header):
+            print(f'Replaced {decomp_header} with {p2gz_header}')
+        else:
+            print(f'Added {p2gz_header} to {decomp_path}')
+        shutil.copy2(p2gz_header, decomp_header)
 
-def main():
-    try:
-        iso = glob.glob(os.path.join(os.getcwd(), '*.iso'))[0]
-    except IndexError:
-        print('No .iso file found in the current directory')
-        exit()
+libs = json.load(open(os.path.join(DECOMP_ROOT, 'libs.json')))
 
-    if not os.path.exists(os.path.join(os.getcwd(), 'root')):
-        subprocess.run(f'nodtool extract "{iso}" root', shell=True)
+# patch cpp files
+for p2gz_path, _, files in os.walk(P2GZ_SRC):
+    decomp_path = p2gz_path.replace(P2GZ_SRC, DECOMP_SRC)
 
-        for file in glob.glob(os.path.join('root', 'files', 'thp', '*.thp')):
-            os.remove(file)
-    
-    patched_files = []
-    for source_dir, patch_dir in DIRECTORY_PAIRS:
-        patched_files.extend(patch_directory(source_dir, patch_dir))
-    
-    unlinked_src_files = []
-    for decomp_src, _, files in os.walk(os.path.join(os.getcwd(), 'pikmin2', 'src')):
-        makefile = os.path.join(decomp_src, 'Makefile')
-        if len(files) and os.path.exists(makefile):
-            unlinked_src_files.extend([os.path.join(decomp_src, f'{match.group(1)}.cpp')
-                                       for line in open(makefile).readlines()
-                                       if (match := re.search(r'asm/[^/]+/([^/]+)\.o', line))])
+    for file in files:
+        decomp_cpp = os.path.join(decomp_path, file)
+        p2gz_cpp = os.path.join(p2gz_path, file)
+        filename = os.path.splitext(file)[0]
+
+        print(os.path.dirname(decomp_path), decomp_path)
+        
+        if os.path.exists(decomp_cpp) and not decomp_path.endswith('p2gz'):
+            print(f'Replaced {decomp_cpp} with {p2gz_cpp}')
+        elif decomp_path.endswith('p2gz'):
+            print(f'Added {p2gz_cpp} to {decomp_path}')
+            if libs[-1]['lib'] != 'p2gz':
+                libs.append({
+                    'lib': 'p2gz',
+                    'cflags': '$cflags_pikmin',
+                    'mw_version': '2.6',
+                    'host': True,
+                    'objects': []
+                })
+            if not any([filename in object[0] for object in libs[-1]['objects']]):
+                libs[-1]['objects'].append([f'p2gz/{filename}', True])
+            os.makedirs(os.path.dirname(decomp_cpp), exist_ok=True)
+        else:
+            print(f'ERROR: Extraneous file in {decomp_path}: {file}')
+            exit()
+
+        shutil.copy2(p2gz_cpp, decomp_cpp)
+        
+        for lib in libs:
+            for object in lib['objects']:
+                if object[0].endswith(filename):
+                    if not object[1]:
+                        print(f'WARNING: {decomp_cpp} is not linked')
+                        object[1] = True
+                    break
+
+with open(os.path.join(DECOMP_ROOT, 'libs.json'), 'w') as f:
+    f.write(json.dumps(libs, indent=2) + '\n')
+
+# patch assets
+for p2gz_path, dirs, _ in os.walk(P2GZ_ASSETS):
+    iso_path = p2gz_path.replace(P2GZ_ASSETS, ISO_ASSETS)
+
+    for dir in dirs:
+        patch_dir = os.path.join(p2gz_path, dir)
+        iso_dir = os.path.join(iso_path, dir)
+        
+        archive = iso_dir + '.szs'
+        if os.path.exists(archive):
+            existing_directories = set(next(os.walk(iso_path))[1])
+            subprocess.run(f'ArcExtract {archive}', shell=True, stdout=open(os.devnull, 'w'))
+            extracted_archive = os.path.join(iso_path, (set(next(os.walk(iso_path))[1]) - existing_directories).pop())
+
+            print(f'Copying {patch_dir} to {extracted_archive}')
+            shutil.copytree(patch_dir, extracted_archive, dirs_exist_ok=True,
+                            ignore=lambda _, contents: [file for file in contents if file.endswith('json')])
             
-    for file in patched_files:
-        if file in unlinked_src_files:
-            print(f'WARNING: {file} is not linked')
+            for root, _, files in os.walk(patch_dir):
+                for file in files:
+                    if file.endswith('json'):
+                        subprocess.run(f'python3 pikminBMGtool.py PACK {os.path.join(patch_dir, file)} \
+                                       {os.path.join(extracted_archive, file.replace("json", "bmg"))}', shell=True, stdout=open(os.devnull, 'w'))
+            
+            subprocess.run(f'ArcPack {extracted_archive}', shell=True, stdout=open(os.devnull, 'w'))
+            os.remove(archive)
+            os.rename(f'{extracted_archive}.arc', archive)
+            shutil.rmtree(extracted_archive)
 
-    subprocess.run('python3 configure.py --no-check', cwd='pikmin2', shell=True)
-    subprocess.run('ninja', cwd='pikmin2', shell=True)
-    
-    shutil.copy2('pikmin2/build/pikmin2.usa/main.dol', 'root/sys/main.dol')
+# patch dol
+subprocess.run('python3 configure.py --no-check', cwd=DECOMP_ROOT, shell=True)
+subprocess.run('ninja', cwd=DECOMP_ROOT, shell=True)
+shutil.copy2('pikmin2/build/pikmin2.usa/main.dol', 'root/sys/main.dol')
 
-
-if __name__ == '__main__':
-    main()
+print(f'Done! Build took {round(time.time() - start_time, 2)}s')


### PR DESCRIPTION
Pretty much a complete rewrite of `build.py`.
1. Links any unlinked file that has a patched version.
2. Traverses `files` and `root/files` looking for folders in the former that match the name of szs archives in the latter. If there is a match, the contents of the folder are copied into the archive, and any json files are automatically encoded as bmg. We will add support for other file types later.
3. Requires that new `src` files are in `p2gz` and creates a separate library for them in `libs.json`.

Unfortunately this adds three new dependencies which we will remove later after the release of `cube`. The szs patching code is also hopefully significantly more involved than what will be needed with `cube`.

I tested this by building the iso with a modified szs archive file at `files/messages/mesRes_eng/pikmin2.json`, a dummy file at `src/p2gz/test.cpp`, and an unlinked file at `src/plugProjectNishimuraU/ElecHiba.cpp`.