### PR TITLE
Reset Pikmin squad when restarting sublevel

### DIFF
--- a/include/GlobalData.h
+++ b/include/GlobalData.h
@@ -6,11 +6,12 @@
 #include "gzCollections.h"
 #include "Game/PikiContainer.h"
 
-struct SeedRecord {
-	SeedRecord() {}
+struct SegmentRecord {
+	SegmentRecord() {}
 
 	u32 seed;
 	int floorIndex;
+	Game::PikiContainer squad;
 };
 
 struct P2GZ {
@@ -25,6 +26,8 @@ struct P2GZ {
 	bool isCameraScroll();
 	void setCameraScroll(bool);
 
+	void setSquad(Game::PikiContainer* squad, bool falling);
+
 	bool mIsScrollingCamera; // controlling camera for warping
 	f32 mAnimationCoefficient;
 	f32 mDirection;
@@ -38,7 +41,7 @@ struct P2GZ {
 	bool setCustomNextSeed; // whether to apply nextSeed next time a sublevel is generated
 	u32 nextSeed;           // the seed to use for the next sublevel if setCustomNextSeed is true
 	bool usePreviousSquad;
-	RingBuffer<64, SeedRecord>* seedHistory;
+	RingBuffer<64, SegmentRecord>* history;
 
 	u32 bugPokosCollectedSinceLoad;
 	u32 treasurePokosCollectedSinceLoad;

--- a/include/GlobalData.h
+++ b/include/GlobalData.h
@@ -26,8 +26,6 @@ struct P2GZ {
 	bool isCameraScroll();
 	void setCameraScroll(bool);
 
-	void setSquad(Game::PikiContainer* squad, bool falling);
-
 	bool mIsScrollingCamera; // controlling camera for warping
 	f32 mAnimationCoefficient;
 	f32 mDirection;

--- a/include/gzCollections.h
+++ b/include/gzCollections.h
@@ -25,8 +25,8 @@ struct RingBuffer {
 
 	/// @brief Returns a copy of the entry without removing it
 	/// @return The latest entry in the history
-	T peek() {
-        return buf[(bufHead - 1) % N];
+	T* peek() {
+        return &buf[(bufHead - 1) % N];
     }
 
 private:

--- a/src/p2gz/globalData.cpp
+++ b/src/p2gz/globalData.cpp
@@ -54,37 +54,3 @@ f32 P2GZ::getAnimationCoefficient()
 {
     return mAnimationCoefficient;
 }
-
-void P2GZ::setSquad(Game::PikiContainer* squad, bool falling) {
-    int oldBirthMode = PikiMgr::mBirthMode;
-    PikiMgr::mBirthMode = PikiMgr::PSM_Replace;
-    pikiMgr->killAllPikmins();
-
-    OSReport("total sum : %d\n", squad->getTotalSum());
-    
-    // Spawn the new squad
-    for (int color = 0; color < PikiColorCount; color++) {
-        for (int happa = 0; happa < PikiGrowthStageCount; happa++) {
-            for (int i = 0; i < squad->getCount(color, happa); i++) {
-                Piki* piki = pikiMgr->birth();
-
-                Game::PikiInitArg arg(PIKISTATE_Tane);
-                piki->init(&arg);
-                piki->changeHappa(happa);
-                piki->changeShape(color);
-
-                Vector3f pos = naviMgr->getActiveNavi()->getPosition();
-                piki->setPosition(pos, false);
-                piki->mNavi = naviMgr->getActiveNavi();
-                if (falling) {
-                    Vector3f temp = piki->getPosition();
-                    temp.y        = mapMgr->getMinY(temp);
-                    piki->setPosition(temp, false);
-                    piki->mVelocity       = 0.0f;
-                    piki->mTargetVelocity = 0.0f;
-                }
-            }
-        }
-    }
-    PikiMgr::mBirthMode = oldBirthMode;
-}

--- a/src/plugProjectKandoU/singleGS_CaveGame.cpp
+++ b/src/plugProjectKandoU/singleGS_CaveGame.cpp
@@ -188,13 +188,13 @@ void CaveState::exec(SingleGameSection* game)
 			// Same seed
 			retry = true;
 			useCustomSeed = true;
-			nextSeed = p2gz->seedHistory->peek().seed;
+			nextSeed = p2gz->history->peek()->seed;
 		}
 		else if (game->mControllerP1->getButtonDown() & Controller::PRESS_R) {
 			// Increment seed
 			retry = true;
 			useCustomSeed = true;
-			nextSeed = p2gz->seedHistory->peek().seed + 1;
+			nextSeed = p2gz->history->peek()->seed + 1;
 		}
 
 		if (retry) {
@@ -210,6 +210,7 @@ void CaveState::exec(SingleGameSection* game)
 			playData->mCavePokoCount -= p2gz->bugPokosCollectedSinceLoad;
 			playData->mCavePokoCount -= p2gz->treasurePokosCollectedSinceLoad;
 
+			p2gz->usePreviousSquad = true;
 			LoadArg arg(MapEnter_CaveGeyser, true, false, false);
 			transit(game, SGS_Load, &arg);
 		}
@@ -618,6 +619,13 @@ void CaveState::onMovieStart(SingleGameSection* game, MovieConfig* config, u32, 
 	// @P2GZ End
 
 	if (config->is("s0B_cv_coursein")) {
+		// @P2GZ - restore pikmin squad on restart sublevel
+		if (p2gz->usePreviousSquad) {
+			PikiContainer startingSquad = p2gz->history->peek()->squad;
+			p2gz->setSquad(&startingSquad, true);
+			p2gz->usePreviousSquad = false;
+		}
+
 		game->createFallPikminSound();
 		
 		// @P2GZ - reset poko counters
@@ -735,7 +743,6 @@ void CaveState::onMovieDone(Game::SingleGameSection* game, Game::MovieConfig* co
 		gameStart(game);
 		return;
 	} else if (config->is("s0B_cv_coursein")) {
-
 		Iterator<Piki> it(pikiMgr);
 		CI_LOOP(it)
 		{

--- a/src/plugProjectKandoU/singleGS_CaveGame.cpp
+++ b/src/plugProjectKandoU/singleGS_CaveGame.cpp
@@ -622,7 +622,9 @@ void CaveState::onMovieStart(SingleGameSection* game, MovieConfig* config, u32, 
 		// @P2GZ - restore pikmin squad on restart sublevel
 		if (p2gz->usePreviousSquad) {
 			PikiContainer startingSquad = p2gz->history->peek()->squad;
-			p2gz->setSquad(&startingSquad, true);
+			playData->mCaveSaveData.mCavePikis = startingSquad;
+			pikiMgr->killAllPikmins();
+			game->createFallPikmins();
 			p2gz->usePreviousSquad = false;
 		}
 

--- a/src/plugProjectNishimuraU/MapCreator.cpp
+++ b/src/plugProjectNishimuraU/MapCreator.cpp
@@ -25,18 +25,23 @@ void RoomMapMgr::nishimuraCreateRandomMap(MapUnitInterface* muiArray, int p2, Ca
 		isVersusHiba = true;
 	}
 
-	// @P2GZ Start - record sublevel seeds
+	// @P2GZ Start - record sublevel starting conditions
 	if (p2gz->setCustomNextSeed) {
 		srand(p2gz->nextSeed);
 		p2gz->setCustomNextSeed = false;
 	}
 	u32 seed = getSeed();
 
-	SeedRecord seedRecord;
-	seedRecord.seed = seed;
-	seedRecord.floorIndex = floorInfo->mParms.mFloorIndex1;
+	SegmentRecord record;
+	record.seed = seed;
+	record.floorIndex = floorInfo->mParms.mFloorIndex1;
 
-	p2gz->seedHistory->push(seedRecord);
+	record.squad = playData->mCaveSaveData.mCavePikis;
+	if (p2gz->usePreviousSquad) {
+		record.squad = p2gz->history->peek()->squad;
+	}
+
+	p2gz->history->push(record);
 	OSReport("Generating sublevel with seed %X\n", seed);
 	// @P2GZ End
 


### PR DESCRIPTION
Restores the original state of your squad when restarting the sublevel so any deaths or growths don't carry over into future attempts.