### PR TITLE
In-game timer

### DIFF
--- a/build.py
+++ b/build.py
@@ -141,7 +141,7 @@ for p2gz_path, dirs, _ in os.walk(P2GZ_ASSETS):
 subprocess.run('python3 configure.py --no-check', cwd=DECOMP_ROOT, shell=True)
 subprocess.run('ninja', cwd=DECOMP_ROOT, shell=True)
 shutil.copy2('pikmin2/build/pikmin2.usa/main.dol', 'root/sys/main.dol')
-subprocess.run('git reset', cwd=DECOMP_ROOT, shell=True)
+subprocess.run('git reset', cwd=DECOMP_ROOT, shell=True, stdout=open(os.devnull, 'w'))
 
 print(f'Done! Build took {round(time.time() - start_time, 2)}s')
 

--- a/build.py
+++ b/build.py
@@ -141,6 +141,7 @@ for p2gz_path, dirs, _ in os.walk(P2GZ_ASSETS):
 subprocess.run('python3 configure.py --no-check', cwd=DECOMP_ROOT, shell=True)
 subprocess.run('ninja', cwd=DECOMP_ROOT, shell=True)
 shutil.copy2('pikmin2/build/pikmin2.usa/main.dol', 'root/sys/main.dol')
+subprocess.run('git reset', cwd=DECOMP_ROOT, shell=True)
 
 print(f'Done! Build took {round(time.time() - start_time, 2)}s')
 

--- a/include/Game/SingleGame.h
+++ b/include/Game/SingleGame.h
@@ -169,9 +169,7 @@ struct CaveResultState : public State {
 struct CaveState : public State {
 	inline CaveState()
 	    : State(SGS_Cave)
-	{
-		mCaveTimer = 0.0f; // @P2GZ
-	}
+	{}
 
 	virtual void init(SingleGameSection*, StateArg*);                                               // _08
 	virtual void exec(SingleGameSection*);                                                          // _0C
@@ -206,12 +204,12 @@ struct CaveState : public State {
 	u32 _14;           // _14, unknown
 	bool mDrawSave;    // _18
 
-	bool resettingFloor;                 // @P2GZ
+	bool mResettingFloor;                 // @P2GZ
 	u32 numOtakaraCollectedOnCurFloor;   // @P2GZ
 	int otakaraCollectedOnCurFloor[64];  // @P2GZ
 	u32 numItemsCollectedOnCurFloor;     // @P2GZ
 	int itemsCollectedOnCurFloor[64];    // @P2GZ
-	f32 mCaveTimer;                       // @P2GZ
+	s64 mCaveStartTimeMs;                // @P2GZ
 };
 
 struct DayEndArg : public StateArg {

--- a/include/Game/SingleGame.h
+++ b/include/Game/SingleGame.h
@@ -170,6 +170,7 @@ struct CaveState : public State {
 	inline CaveState()
 	    : State(SGS_Cave)
 	{
+		mCaveTimer = 0.0f; // @P2GZ
 	}
 
 	virtual void init(SingleGameSection*, StateArg*);                                               // _08
@@ -191,6 +192,8 @@ struct CaveState : public State {
 	bool hasCollectedItemOnCurrentFloor(int);    // @P2GZ
 	bool hasCollectedOtakaraOnCurrentFloor(int); // @P2GZ
 
+	void drawTimer(); // @P2GZ
+
 	void check_SMenu(SingleGameSection*);
 
 	// Unused/inlined:
@@ -206,8 +209,9 @@ struct CaveState : public State {
 	bool resettingFloor;                 // @P2GZ
 	u32 numOtakaraCollectedOnCurFloor;   // @P2GZ
 	int otakaraCollectedOnCurFloor[64];  // @P2GZ
-	u32 numItemsCollectedOnCurFloor;   // @P2GZ
-	int itemsCollectedOnCurFloor[64];  // @P2GZ
+	u32 numItemsCollectedOnCurFloor;     // @P2GZ
+	int itemsCollectedOnCurFloor[64];    // @P2GZ
+	f32 mCaveTimer;                       // @P2GZ
 };
 
 struct DayEndArg : public StateArg {
@@ -388,6 +392,8 @@ struct GameState : public State {
 	bool needRepayDemo();
 	void startRepayDemo();
 	RepayDemoState updateRepayDemo();
+
+	void drawTimer(); // @P2GZ
 
 	// Unused/inlined:
 	void drawRepayDemo(Graphics&);

--- a/include/GlobalData.h
+++ b/include/GlobalData.h
@@ -6,12 +6,16 @@
 #include "gzCollections.h"
 #include "Game/PikiContainer.h"
 
+
 struct SegmentRecord {
-	SegmentRecord() {}
+	SegmentRecord() {
+		timer = 0;
+	}
 
 	u32 seed;
 	int floorIndex;
 	Game::PikiContainer squad;
+	f32 timer;
 };
 
 struct P2GZ {
@@ -25,6 +29,8 @@ struct P2GZ {
 
 	bool isCameraScroll();
 	void setCameraScroll(bool);
+
+	void drawTimer();
 
 	bool mIsScrollingCamera; // controlling camera for warping
 	bool mIsSaveLoadPosition;

--- a/include/GlobalData.h
+++ b/include/GlobalData.h
@@ -63,6 +63,8 @@ struct P2GZ {
 	int mSelectedArea;
 	int mSelectedDestination;
 	int mSublevelNumber;
+	
+	bool showTimer;
 };
 
 extern P2GZ* p2gz;

--- a/include/GlobalData.h
+++ b/include/GlobalData.h
@@ -8,14 +8,13 @@
 
 
 struct SegmentRecord {
-	SegmentRecord() {
-		timer = 0;
-	}
+	SegmentRecord() {}
 
 	u32 seed;
 	int floorIndex;
 	Game::PikiContainer squad;
-	f32 timer;
+	s64 startTime;
+	s64 endTime;
 };
 
 struct P2GZ {
@@ -63,7 +62,7 @@ struct P2GZ {
 	int mSelectedArea;
 	int mSelectedDestination;
 	int mSublevelNumber;
-	
+
 	bool showTimer;
 };
 

--- a/include/gzCollections.h
+++ b/include/gzCollections.h
@@ -18,19 +18,10 @@ struct RingBuffer {
         if (length < N) length++;
     }
 
-	/// @brief Removes value from the history and returns it
-	/// @return The latest entry in the history
-	T pop() {
-        P2ASSERTLINE(24, length > 0);
-        bufHead = (bufHead - 1) % N;
-        length--;
-        return buf[bufHead];
-    }
-
 	/// @brief Returns a copy of the entry without removing it
 	/// @return The latest entry in the history
 	T* peek() {
-        P2ASSERTLINE(33, length > 0);
+        if (length == 0) return nullptr;
         return &buf[(bufHead - 1) % N];
     }
 

--- a/include/gzCollections.h
+++ b/include/gzCollections.h
@@ -11,7 +11,7 @@ struct RingBuffer {
         bufHead = 0;
     }
 
-    void push(T val) {
+    void push(T* val) {
         buf[bufHead] = val;
         bufHead = (bufHead + 1) % N;
     }
@@ -26,12 +26,12 @@ struct RingBuffer {
 	/// @brief Returns a copy of the entry without removing it
 	/// @return The latest entry in the history
 	T* peek() {
-        return &buf[(bufHead - 1) % N];
+        return buf[(bufHead - 1) % N];
     }
 
 private:
 	int bufHead;
-	T buf[N];
+	T* buf[N];
 };
 
 #endif

--- a/include/gzCollections.h
+++ b/include/gzCollections.h
@@ -9,29 +9,35 @@ struct RingBuffer {
     RingBuffer() {
         P2ASSERTLINE(10, N > 0);
         bufHead = 0;
+        length = 0;
     }
 
-    void push(T* val) {
+    void push(T val) {
         buf[bufHead] = val;
         bufHead = (bufHead + 1) % N;
+        if (length < N) length++;
     }
 
 	/// @brief Removes value from the history and returns it
 	/// @return The latest entry in the history
 	T pop() {
+        P2ASSERTLINE(24, length > 0);
         bufHead = (bufHead - 1) % N;
+        length--;
         return buf[bufHead];
     }
 
 	/// @brief Returns a copy of the entry without removing it
 	/// @return The latest entry in the history
 	T* peek() {
-        return buf[(bufHead - 1) % N];
+        P2ASSERTLINE(33, length > 0);
+        return &buf[(bufHead - 1) % N];
     }
 
 private:
-	int bufHead;
-	T* buf[N];
+    u32 length;
+	u32 bufHead;
+	T buf[N];
 };
 
 #endif

--- a/src/p2gz/globalData.cpp
+++ b/src/p2gz/globalData.cpp
@@ -3,6 +3,7 @@
 #include "Game/PikiMgr.h"
 #include "Game/PikiState.h"
 #include "Game/MapMgr.h"
+#include "JSystem/J2D/J2DPrint.h"
 
 using namespace Game;
 
@@ -80,4 +81,25 @@ void P2GZ::update()
 f32 P2GZ::getAnimationCoefficient()
 {
     return mAnimationCoefficient;
+}
+
+void P2GZ::drawTimer() {
+    f32 elapsedSeconds = history->peek()->timer;
+
+    Graphics* gfx = sys->getGfx();
+    gfx->initPerspPrintf(gfx->mCurrentViewport);
+    gfx->initPrimDraw(nullptr);
+    gfx->mOrthoGraph.setPort();
+
+    J2DPrint timerText(JFWSystem::systemFont, 0.0f);
+    timerText.initiate();
+    timerText.mCharColor.set(JUtility::TColor(255, 255, 255, 128));
+    timerText.mGradientColor.set(JUtility::TColor(255, 255, 255, 128));
+    timerText.mGlyphWidth = 16.0f;
+    timerText.mGlyphHeight = 16.0f;
+
+    int minutes = elapsedSeconds / 60.0f;
+    int seconds = (int)elapsedSeconds % 60;
+    int tenths  = (elapsedSeconds - (int)elapsedSeconds) * 10;
+    timerText.print(16, 16, "%d:%.2d.%.1d", minutes, seconds, tenths);
 }

--- a/src/p2gz/globalData.cpp
+++ b/src/p2gz/globalData.cpp
@@ -41,6 +41,8 @@ P2GZ::P2GZ()
     mSelectedArea = 0;
     mSelectedDestination = 0;
     mSublevelNumber = 1;
+    
+    showTimer = true;
 }
 
 void P2GZ::init()

--- a/src/p2gz/globalData.cpp
+++ b/src/p2gz/globalData.cpp
@@ -84,24 +84,3 @@ f32 P2GZ::getAnimationCoefficient()
 {
     return mAnimationCoefficient;
 }
-
-void P2GZ::drawTimer() {
-    f32 elapsedSeconds = history->peek()->timer;
-
-    Graphics* gfx = sys->getGfx();
-    gfx->initPerspPrintf(gfx->mCurrentViewport);
-    gfx->initPrimDraw(nullptr);
-    gfx->mOrthoGraph.setPort();
-
-    J2DPrint timerText(JFWSystem::systemFont, 0.0f);
-    timerText.initiate();
-    timerText.mCharColor.set(JUtility::TColor(255, 255, 255, 128));
-    timerText.mGradientColor.set(JUtility::TColor(255, 255, 255, 128));
-    timerText.mGlyphWidth = 16.0f;
-    timerText.mGlyphHeight = 16.0f;
-
-    int minutes = elapsedSeconds / 60.0f;
-    int seconds = (int)elapsedSeconds % 60;
-    int tenths  = (elapsedSeconds - (int)elapsedSeconds) * 10;
-    timerText.print(16, 16, "%d:%.2d.%.1d", minutes, seconds, tenths);
-}

--- a/src/plugProjectKandoU/singleGS_CaveGame.cpp
+++ b/src/plugProjectKandoU/singleGS_CaveGame.cpp
@@ -171,6 +171,9 @@ static bool treasureCutsceneSkipRegistered = false; // @P2GZ
  */
 void CaveState::exec(SingleGameSection* game)
 {
+	p2gz->history->peek()->timer += sys->getDeltaTime();
+	p2gz->drawTimer(); // @P2GZ
+
 	if (mFadeout)
 		return;
 

--- a/src/plugProjectKandoU/singleGS_CaveGame.cpp
+++ b/src/plugProjectKandoU/singleGS_CaveGame.cpp
@@ -171,9 +171,6 @@ static bool treasureCutsceneSkipRegistered = false; // @P2GZ
  */
 void CaveState::exec(SingleGameSection* game)
 {
-	p2gz->history->peek()->timer += sys->getDeltaTime();
-	p2gz->drawTimer(); // @P2GZ
-
 	if (mFadeout)
 		return;
 
@@ -230,6 +227,13 @@ void CaveState::exec(SingleGameSection* game)
 			pod->stimulate(interaction);
 			treasureCutsceneSkipRegistered = true;
 		}	
+	}
+	// @P2GZ End
+
+	// @P2GZ Start - In-game timer
+	p2gz->history->peek()->timer += sys->getDeltaTime();
+	if (p2gz->showTimer) {
+		p2gz->drawTimer();
 	}
 	// @P2GZ End
 

--- a/src/plugProjectKandoU/singleGS_MainGame.cpp
+++ b/src/plugProjectKandoU/singleGS_MainGame.cpp
@@ -27,6 +27,9 @@
 #include "nans.h"
 #include "utilityU.h"
 #include "Game/NaviState.h"
+#include "GlobalData.h" // @P2GZ
+#include "JSystem/J2D/J2DPrint.h" // @P2GZ
+#include "P2JME/P2JME.h" //@P2GZ
 
 // @P2GZ
 #include "Game/CameraMgr.h"
@@ -51,6 +54,12 @@ namespace SingleGame {
  */
 void GameState::init(SingleGameSection* game, StateArg* arg)
 {
+	// @P2GZ Start
+	SegmentRecord record;
+	record.squad = playData->mPikiContainer;
+	p2gz->history->push(record);
+	// @P2GZ End
+
 	DeathMgr::mSoundDeathCount = 0;
 	moviePlayer->reset();
 	gameSystem->setFlag(GAMESYS_IsGameWorldActive);
@@ -1289,12 +1298,39 @@ void GameState::drawRepayDemo(Graphics&)
 	// UNUSED FUNCTION
 }
 
+// @P2GZ
+void GameState::drawTimer() {
+    f32 timerS = p2gz->history->peek()->timer;
+
+    Graphics* gfx = sys->getGfx();
+    gfx->initPerspPrintf(gfx->mCurrentViewport);
+    gfx->initPrimDraw(nullptr);
+    gfx->mOrthoGraph.setPort();
+
+    J2DPrint caveTimerText(gP2JMEMgr->mFont, 0.0f);
+    caveTimerText.initiate();
+    caveTimerText.mCharColor.set(JUtility::TColor(255, 255, 255, 128));
+    caveTimerText.mGradientColor.set(JUtility::TColor(255, 255, 255, 128));
+    caveTimerText.mGlyphWidth = 16.0f;
+    caveTimerText.mGlyphHeight = 16.0f;
+
+	int minutes = (int)(timerS / 60.0f);
+	int seconds = (int)timerS % 60;
+	int tenths = (timerS - (int)timerS) * 10.0f;
+    caveTimerText.print(16, 16, "%d:%.2d.%.1d", minutes, seconds, tenths);
+}
+
 /**
  * @note Address: 0x802174B8
  * @note Size: 0x78
  */
 void GameState::draw(SingleGameSection* game, Graphics& gfx)
 {
+	// @P2GZ Start - timer
+	f32 dt = sys->getDeltaTime();
+	p2gz->history->peek()->timer += dt;
+	// @P2GZ End
+
 	if (mDoExit) {
 		return;
 	}
@@ -1307,6 +1343,8 @@ void GameState::draw(SingleGameSection* game, Graphics& gfx)
 	game->BaseGameSection::doDraw(gfx);
 	game->drawMainMapScreen();
 	game->test_draw_treasure_detector();
+
+	drawTimer(); // @P2GZ
 }
 
 /**

--- a/src/plugProjectKandoU/singleGS_MainGame.cpp
+++ b/src/plugProjectKandoU/singleGS_MainGame.cpp
@@ -30,6 +30,7 @@
 #include "GlobalData.h" // @P2GZ
 #include "JSystem/J2D/J2DPrint.h" // @P2GZ
 #include "P2JME/P2JME.h" //@P2GZ
+#include "Dolphin/os.h" // @P2GZ
 
 // @P2GZ
 #include "Game/CameraMgr.h"
@@ -57,6 +58,7 @@ void GameState::init(SingleGameSection* game, StateArg* arg)
 	// @P2GZ Start
 	SegmentRecord record;
 	record.squad = playData->mPikiContainer;
+	record.startTime = OSTicksToMilliseconds(OSGetTime());
 	p2gz->history->push(record);
 	// @P2GZ End
 
@@ -1300,7 +1302,8 @@ void GameState::drawRepayDemo(Graphics&)
 
 // @P2GZ
 void GameState::drawTimer() {
-    f32 timerS = p2gz->history->peek()->timer;
+	s64 currentTime = OSTicksToMilliseconds(OSGetTime());
+	s64 timerMs = currentTime - p2gz->history->peek()->startTime;
 
     Graphics* gfx = sys->getGfx();
     gfx->initPerspPrintf(gfx->mCurrentViewport);
@@ -1314,10 +1317,10 @@ void GameState::drawTimer() {
     caveTimerText.mGlyphWidth = 16.0f;
     caveTimerText.mGlyphHeight = 16.0f;
 
-	int minutes = (int)(timerS / 60.0f);
-	int seconds = (int)timerS % 60;
-	int tenths = (timerS - (int)timerS) * 10.0f;
-    caveTimerText.print(16, 16, "%d:%.2d.%.1d", minutes, seconds, tenths);
+	s64 minutes = timerMs / (60 * 1000);
+	s64 seconds = (timerMs / 1000) % 60;
+	s64 tenths = (timerMs / 100) % 10;
+    caveTimerText.print(16, 16, "%lld:%.2lld.%.1lld", minutes, seconds, tenths);
 }
 
 /**
@@ -1326,11 +1329,6 @@ void GameState::drawTimer() {
  */
 void GameState::draw(SingleGameSection* game, Graphics& gfx)
 {
-	// @P2GZ Start - timer
-	f32 dt = sys->getDeltaTime();
-	p2gz->history->peek()->timer += dt;
-	// @P2GZ End
-
 	if (mDoExit) {
 		return;
 	}

--- a/src/plugProjectKandoU/singleGS_MainGame.cpp
+++ b/src/plugProjectKandoU/singleGS_MainGame.cpp
@@ -56,9 +56,15 @@ namespace SingleGame {
 void GameState::init(SingleGameSection* game, StateArg* arg)
 {
 	// @P2GZ Start
+	s64 currentTime = OSTicksToMilliseconds(OSGetTime());
+	SegmentRecord* previousRecord = p2gz->history->peek();
+	if (previousRecord != nullptr) {
+		previousRecord->endTime = currentTime;
+	}
+
 	SegmentRecord record;
 	record.squad = playData->mPikiContainer;
-	record.startTime = OSTicksToMilliseconds(OSGetTime());
+	record.startTime = currentTime;
 	p2gz->history->push(record);
 	// @P2GZ End
 

--- a/src/plugProjectKandoU/singleGS_MainGame.cpp
+++ b/src/plugProjectKandoU/singleGS_MainGame.cpp
@@ -1316,17 +1316,17 @@ void GameState::drawTimer() {
     gfx->initPrimDraw(nullptr);
     gfx->mOrthoGraph.setPort();
 
-    J2DPrint caveTimerText(gP2JMEMgr->mFont, 0.0f);
-    caveTimerText.initiate();
-    caveTimerText.mCharColor.set(JUtility::TColor(255, 255, 255, 128));
-    caveTimerText.mGradientColor.set(JUtility::TColor(255, 255, 255, 128));
-    caveTimerText.mGlyphWidth = 16.0f;
-    caveTimerText.mGlyphHeight = 16.0f;
+    J2DPrint timerText(gP2JMEMgr->mFont, 0.0f);
+    timerText.initiate();
+    timerText.mCharColor.set(JUtility::TColor(255, 255, 255, 128));
+    timerText.mGradientColor.set(JUtility::TColor(255, 255, 255, 128));
+    timerText.mGlyphWidth = 16.0f;
+    timerText.mGlyphHeight = 16.0f;
 
 	s64 minutes = timerMs / (60 * 1000);
 	s64 seconds = (timerMs / 1000) % 60;
 	s64 tenths = (timerMs / 100) % 10;
-    caveTimerText.print(16, 16, "%lld:%.2lld.%.1lld", minutes, seconds, tenths);
+    timerText.print(16, 16, "%lld:%.2lld.%.1lld", minutes, seconds, tenths);
 }
 
 /**

--- a/src/plugProjectNishimuraU/MapCreator.cpp
+++ b/src/plugProjectNishimuraU/MapCreator.cpp
@@ -41,7 +41,7 @@ void RoomMapMgr::nishimuraCreateRandomMap(MapUnitInterface* muiArray, int p2, Ca
 		record.squad = p2gz->history->peek()->squad;
 	}
 
-	p2gz->history->push(record);
+	p2gz->history->push(&record);
 	OSReport("Generating sublevel with seed %X\n", seed);
 	// @P2GZ End
 

--- a/src/plugProjectNishimuraU/MapCreator.cpp
+++ b/src/plugProjectNishimuraU/MapCreator.cpp
@@ -27,6 +27,12 @@ void RoomMapMgr::nishimuraCreateRandomMap(MapUnitInterface* muiArray, int p2, Ca
 	}
 
 	// @P2GZ Start - record sublevel starting conditions
+	s64 currentTime = OSTicksToMilliseconds(OSGetTime());
+	SegmentRecord* previousRecord = p2gz->history->peek();
+	if (previousRecord != nullptr) {
+		previousRecord->endTime = currentTime;
+	}
+
 	if (p2gz->setCustomNextSeed) {
 		srand(p2gz->nextSeed);
 		p2gz->setCustomNextSeed = false;
@@ -36,7 +42,7 @@ void RoomMapMgr::nishimuraCreateRandomMap(MapUnitInterface* muiArray, int p2, Ca
 	SegmentRecord record;
 	record.seed = seed;
 	record.floorIndex = floorInfo->mParms.mFloorIndex1;
-	record.startTime = OSTicksToMilliseconds(OSGetTime());;
+	record.startTime = currentTime;
 
 	record.squad = playData->mCaveSaveData.mCavePikis;
 	if (p2gz->usePreviousSquad) {

--- a/src/plugProjectNishimuraU/MapCreator.cpp
+++ b/src/plugProjectNishimuraU/MapCreator.cpp
@@ -37,11 +37,12 @@ void RoomMapMgr::nishimuraCreateRandomMap(MapUnitInterface* muiArray, int p2, Ca
 	record.floorIndex = floorInfo->mParms.mFloorIndex1;
 
 	record.squad = playData->mCaveSaveData.mCavePikis;
+	OSReport("squad total count: %d\n", record.squad.getTotalSum());
 	if (p2gz->usePreviousSquad) {
 		record.squad = p2gz->history->peek()->squad;
 	}
 
-	p2gz->history->push(&record);
+	p2gz->history->push(record);
 	OSReport("Generating sublevel with seed %X\n", seed);
 	// @P2GZ End
 

--- a/src/plugProjectNishimuraU/MapCreator.cpp
+++ b/src/plugProjectNishimuraU/MapCreator.cpp
@@ -7,6 +7,7 @@
 #include "Dolphin/rand.h" // @P2GZ
 #include "Game/PikiContainer.h" // @P2GZ
 #include "Game/PikiMgr.h" // @P2GZ
+#include "Dolphin/os.h" // @P2GZ
 
 namespace Game {
 namespace Cave {
@@ -35,6 +36,7 @@ void RoomMapMgr::nishimuraCreateRandomMap(MapUnitInterface* muiArray, int p2, Ca
 	SegmentRecord record;
 	record.seed = seed;
 	record.floorIndex = floorInfo->mParms.mFloorIndex1;
+	record.startTime = OSTicksToMilliseconds(OSGetTime());;
 
 	record.squad = playData->mCaveSaveData.mCavePikis;
 	if (p2gz->usePreviousSquad) {

--- a/src/plugProjectNishimuraU/MapCreator.cpp
+++ b/src/plugProjectNishimuraU/MapCreator.cpp
@@ -37,7 +37,6 @@ void RoomMapMgr::nishimuraCreateRandomMap(MapUnitInterface* muiArray, int p2, Ca
 	record.floorIndex = floorInfo->mParms.mFloorIndex1;
 
 	record.squad = playData->mCaveSaveData.mCavePikis;
-	OSReport("squad total count: %d\n", record.squad.getTotalSum());
 	if (p2gz->usePreviousSquad) {
 		record.squad = p2gz->history->peek()->squad;
 	}


### PR DESCRIPTION
<img width="872" alt="image" src="https://github.com/user-attachments/assets/df193c94-56b5-41bd-95b2-41c824fdb398">

First one is for the full cave, second one is for the current sublevel. ~~I don't believe this is fully RTA equivalent yet - it seems to stop briefly between sublevels, so that's something we can improve in the future.~~ It's RTA accurate now, except for the start and end points. I consider this acceptable.

Also works above-ground, but only shows one timer obviously.
