### PR TITLE
fix incorrect bgm after warping between caves in different areas

### DIFF
--- a/src/p2gz/ogObjSMenuWarp.cpp
+++ b/src/p2gz/ogObjSMenuWarp.cpp
@@ -426,6 +426,7 @@ bool ObjSMenuWarp::doUpdate()
 					game->saveToGeneratorCache(game->mCurrentCourseInfo);
 				}
 
+				game->mCurrentCourseInfo = Game::stageList->getCourseInfo(mSelectedArea);
 				game->mCurrentCave = cave;
 				game->mCaveID = caveID;
 				game->mCaveIndex = caveID.getID();


### PR DESCRIPTION
After warping to a cave in a different area (e.g., Hole of Beasts --> Shower Room), the music would play for the cave ID in the area you warped from (e.g., Bulblax Kingdom music would play in Shower Room). Fixed by setting `game->mCurrentCourseInfo` to the new area before warping. Consequence is you no longer remain in the area you warped from after exiting the cave.