### PR TITLE
Crash fixes

### DIFF
--- a/include/Game/SingleGame.h
+++ b/include/Game/SingleGame.h
@@ -203,11 +203,13 @@ struct CaveState : public State {
 	u32 _14;           // _14, unknown
 	bool mDrawSave;    // _18
 
-	bool mResettingFloor;                 // @P2GZ
-	u32 mNumOtakaraCollectedOnCurFloor;   // @P2GZ
-	int mOtakaraCollectedOnCurFloor[64];  // @P2GZ
-	u32 mNumItemsCollectedOnCurFloor;     // @P2GZ
-	int mItemsCollectedOnCurFloor[64];    // @P2GZ
+	// @P2GZ Start
+	bool mResetting;
+	u32 mNumOtakaraCollectedOnCurFloor;
+	int mOtakaraCollectedOnCurFloor[64];
+	u32 mNumItemsCollectedOnCurFloor;
+	int mItemsCollectedOnCurFloor[64];
+	// @P2GZ End
 };
 
 struct DayEndArg : public StateArg {

--- a/src/plugProjectKandoU/singleGS_CaveGame.cpp
+++ b/src/plugProjectKandoU/singleGS_CaveGame.cpp
@@ -255,7 +255,9 @@ void CaveState::exec(SingleGameSection* game)
 
 	// @P2GZ Start - Skippable treasure cutscenes
 	if (moviePlayer->isPlaying("s22_cv_suck_treasure") || moviePlayer->isPlaying("s22_cv_suck_equipment")) {
-		if (!treasureCutsceneSkipRegistered && (strcmp(gameSystem->mMovieAction, "moviePl:skip") == 0)) {
+		if (!treasureCutsceneSkipRegistered
+		    && (gameSystem->mMovieAction != nullptr && strcmp(gameSystem->mMovieAction, "moviePl:skip") == 0))
+		{
 			Pellet* pellet = static_cast<Pellet*>(game->mDraw2DCreature);
 			Onyon* pod = ItemOnyon::mgr->mPod;
 			if (pellet != nullptr && pod != nullptr) {

--- a/src/plugProjectKandoU/singleGS_CaveGame.cpp
+++ b/src/plugProjectKandoU/singleGS_CaveGame.cpp
@@ -247,7 +247,6 @@ void CaveState::exec(SingleGameSection* game)
 		mResetting = nextFloor == 1;
 		onMovieCommand(game, 0);
 
-		while (Screen::gGame2DMgr->mScreenMgr->isCurrentSceneLoading()) {}
 		p2gz->warpToSelectedCave(squad);
 		return;
 	}


### PR DESCRIPTION
- Fix crash when letting a treasure cutscene play out
- Fix crash when using one of the retry floor options before the menu is loaded in