### PR TITLE
Add upgrades to presets + more efficient flag repr

### DIFF
--- a/files/message/mesRes_eng/pikmin2.bmg.json
+++ b/files/message/mesRes_eng/pikmin2.bmg.json
@@ -11256,7 +11256,7 @@
       "attributes": "00000000"
     },
     {
-      "message": "PoD HoB5-WFG3",
+      "message": "PoD HoB5",
       "id": {
         "id": 3204,
         "sub_id": 0
@@ -11264,7 +11264,7 @@
       "attributes": "00000000"
     },
     {
-      "message": "PoD WFG4-Enter SH",
+      "message": "PoD WFG4-WFG5",
       "id": {
         "id": 3205,
         "sub_id": 0
@@ -11392,7 +11392,7 @@
       "attributes": "00000000"
     },
     {
-      "message": "PoD FC1-FC7",
+      "message": "PoD FC1-FC5",
       "id": {
         "id": 3221,
         "sub_id": 0
@@ -11400,7 +11400,7 @@
       "attributes": "00000000"
     },
     {
-      "message": "PoD FC1-FC7 (+5W)",
+      "message": "PoD FC1-FC5 (+5W)",
       "id": {
         "id": 3222,
         "sub_id": 0
@@ -11427,6 +11427,38 @@
       "message": "PoD CoS1-GK6 (+5W)",
       "id": {
         "id": 3225,
+        "sub_id": 0
+      },
+      "attributes": "00000000"
+    },
+    {
+      "message": "PoD Enter WFG-WFG3",
+      "id": {
+        "id": 3226,
+        "sub_id": 0
+      },
+      "attributes": "00000000"
+    },
+    {
+      "message": "PoD Enter SH",
+      "id": {
+        "id": 3227,
+        "sub_id": 0
+      },
+      "attributes": "00000000"
+    },
+    {
+      "message": "PoD FC6-FC7",
+      "id": {
+        "id": 3228,
+        "sub_id": 0
+      },
+      "attributes": "00000000"
+    },
+    {
+      "message": "PoD FC6-FC7 (+5W)",
+      "id": {
+        "id": 3229,
         "sub_id": 0
       },
       "attributes": "00000000"

--- a/include/DefaultPresets.h
+++ b/include/DefaultPresets.h
@@ -4,102 +4,113 @@
 
 using namespace Game;
 
-#define ARRLEN(a) sizeof(a) / sizeof(a[0])
-
 gzCollections::Vec<Preset> getDefaultPresets() {
-    u16 ec_cflags[] = {
-        DEMO_Pluck_First_Pikmin,
-        DEMO_Discover_Treasure,
-        DEMO_First_Gate_Down,
-        DEMO_First_Nectar_Use,
-        DEMO_Day_One_Start,
-        DEMO_Meet_Red_Pikmin,
-        DEMO_Louie_Finds_Red_Onion,
-        DEMO_Unlock_Captain_Switch,
-        DEMO_First_Use_Louie,
-        DEMO_Reunite_Captains,
-        DEMO_First_Number_Pellet
-    };
+    using namespace gzCollections;
 
-    u16 hob_cflags[] = {
-        DEMO_Find_Cave_Deeper_Hole,
-        DEMO_Find_Cave_Geyser,
-        DEMO_First_Cave_Enter,
-        DEMO_First_Cave_Return,
-        DEMO_First_Globe_Day_End,
-        DEMO_Purple_Candypop,
-        DEMO_Enter_Awakening_Wood,
-        DEMO_First_Corpse_In_Cave,
-        DEMO_Purples_In_Ship
-    };
+    IndexBitflag<u64> ec_cflags = IndexBitflag<u64>()
+        .set(DEMO_Pluck_First_Pikmin)
+        .set(DEMO_Discover_Treasure)
+        .set(DEMO_First_Gate_Down)
+        .set(DEMO_First_Nectar_Use)
+        .set(DEMO_Day_One_Start)
+        .set(DEMO_Meet_Red_Pikmin)
+        .set(DEMO_Louie_Finds_Red_Onion)
+        .set(DEMO_Unlock_Captain_Switch)
+        .set(DEMO_First_Use_Louie)
+        .set(DEMO_Reunite_Captains)
+        .set(DEMO_First_Number_Pellet);
 
-    u16 wfg_cflags[] = {
-        DEMO_Whites_Digging,
-        DEMO_White_Candypop
-    };
+    IndexBitflag<u64> hob_cflags = IndexBitflag<u64>(ec_cflags)
+        .set(DEMO_Find_Cave_Deeper_Hole)
+        .set(DEMO_Find_Cave_Geyser)
+        .set(DEMO_First_Cave_Enter)
+        .set(DEMO_First_Cave_Return)
+        .set(DEMO_First_Globe_Day_End)
+        .set(DEMO_Purple_Candypop)
+        .set(DEMO_Enter_Awakening_Wood)
+        .set(DEMO_First_Corpse_In_Cave)
+        .set(DEMO_Purples_In_Ship);
+    IndexBitflag<u32> hob_upgrades = IndexBitflag<u32>().set(OlimarData::ODII_SphericalAtlas);
 
-    u16 sh_cflags[] = {
-        DEMO_Pikmin_In_Danger_Poison,
-        DEMO_Find_Blue_Onion
-    };
+    IndexBitflag<u64> wfg_cflags = IndexBitflag<u64>(hob_cflags)
+        .set(DEMO_Whites_Digging)
+        .set(DEMO_White_Candypop);
+    IndexBitflag<u32> wfg_upgrades = IndexBitflag<u32>(hob_upgrades).set(OlimarData::ODII_PrototypeDetector);
 
-    u16 bk_cflags[] = { DEMO_Max_Pikmin_On_Field, };
+    IndexBitflag<u64> sh_cflags = IndexBitflag<u64>(wfg_cflags)
+        .set(DEMO_Pikmin_In_Danger_Poison)
+        .set(DEMO_Find_Blue_Onion);
+    IndexBitflag<u32> sh_upgrades = IndexBitflag<u32>(wfg_upgrades).set(OlimarData::ODII_FiveManNapsack);
 
-    u16 vor2_cflags[] = { DEMO_Whites_In_Ship, };
+    IndexBitflag<u64> bk_cflags = IndexBitflag<u64>(sh_cflags).set(DEMO_Max_Pikmin_On_Field);
+    IndexBitflag<u32> bk_upgrades = IndexBitflag<u32>(sh_upgrades).set(OlimarData::ODII_JusticeAlloy);
 
-    u16 pp_cflags[] = { DEMO_Enter_Perplexing_Pool };
+    IndexBitflag<u64> vor2_cflags = IndexBitflag<u64>(bk_cflags).set(DEMO_Whites_In_Ship);
+    IndexBitflag<u32> vor2_upgrades = IndexBitflag<u32>(bk_upgrades).set(OlimarData::ODII_ForgedCourage);
 
+    IndexBitflag<u64> pp_cflags = IndexBitflag<u64>(vor2_cflags).set(DEMO_Enter_Perplexing_Pool);
+    IndexBitflag<u32> pp_upgrades = IndexBitflag<u32>(vor2_upgrades).set(OlimarData::ODII_BruteKnuckles);
 
     Preset defaultPresets[] = {
         // PoD EC
         Preset().setMsgId('3200_00')
             .setPikmin(Flower, Red,    46)
             .setPikmin(Leaf,   Red,     6)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags)),
+            .addCutsceneFlags(ec_cflags),
         // PoD Enter HoB
         Preset().setMsgId('3201_00')
             .setOnionPikmin(Flower, Red,    46)
             .setOnionPikmin(Leaf,   Red,     6)
             .setOnionPikmin(Leaf,   Purple, 10)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags))
-            .addCutsceneFlags(hob_cflags, ARRLEN(hob_cflags)),
+            .addCutsceneFlags(hob_cflags)
+            .addUpgrades(hob_upgrades),
         // PoD HoB1
         Preset().setMsgId('3202_00')
             .setPikmin(Flower, Red,    62)
             .setPikmin(Flower, Purple, 10)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags))
-            .addCutsceneFlags(hob_cflags, ARRLEN(hob_cflags)),
+            .addCutsceneFlags(hob_cflags)
+            .addUpgrades(hob_upgrades),
         // PoD HoB2-4
         Preset().setMsgId('3203_00')
             .setPikmin(Flower, Red,    52)
             .setPikmin(Flower, Purple, 10)
             .setPikmin(Leaf,   Purple, 10)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags))
-            .addCutsceneFlags(hob_cflags, ARRLEN(hob_cflags)),
-        // PoD HoB5-WFG3
+            .addCutsceneFlags(hob_cflags)
+            .addUpgrades(hob_upgrades),
+        // PoD HoB5
         Preset().setMsgId('3204_00')
             .setPikmin(Flower, Red,    52)
             .setPikmin(Flower, Purple, 20)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags))
-            .addCutsceneFlags(hob_cflags, ARRLEN(hob_cflags)),
-        // PoD WFG4-Enter SH
+            .addCutsceneFlags(hob_cflags)
+            .addUpgrades(hob_upgrades),
+        // PoD Enter WFG-WFG3
+        Preset().setMsgId('3226_00')
+            .setPikmin(Flower, Red,    52)
+            .setPikmin(Flower, Purple, 20)
+            .addCutsceneFlags(hob_cflags)
+            .addUpgrades(wfg_upgrades),
+        // PoD WFG4-WFG5
         Preset().setMsgId('3205_00')
             .setPikmin(Flower, Red,    37)
             .setPikmin(Flower, Purple, 20)
             .setPikmin(Flower, White,  15)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags))
-            .addCutsceneFlags(hob_cflags, ARRLEN(hob_cflags))
-            .addCutsceneFlags(wfg_cflags, ARRLEN(wfg_cflags)),
+            .addCutsceneFlags(wfg_cflags)
+            .addUpgrades(wfg_upgrades),
+        // PoD Enter SH
+        Preset().setMsgId('3227_00')
+            .setPikmin(Flower, Red,    37)
+            .setPikmin(Flower, Purple, 20)
+            .setPikmin(Flower, White,  15)
+            .addCutsceneFlags(wfg_cflags)
+            .addUpgrades(sh_upgrades),
         // PoD SH1-2
         Preset().setMsgId('3206_00')
             .setPikmin(     Flower, Red,    34)
             .setPikmin(     Flower, Purple, 18)
             .setPikmin(     Flower, White,  15)
             .setOnionPikmin(Leaf,   Blue,   16)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags))
-            .addCutsceneFlags(hob_cflags, ARRLEN(hob_cflags))
-            .addCutsceneFlags(wfg_cflags, ARRLEN(wfg_cflags))
-            .addCutsceneFlags(sh_cflags, ARRLEN(sh_cflags)),
+            .addCutsceneFlags(sh_cflags)
+            .addUpgrades(sh_upgrades),
         // PoD SH3-7
         Preset().setMsgId('3207_00')
             .setPikmin(     Flower, Red,    29)
@@ -107,10 +118,8 @@ gzCollections::Vec<Preset> getDefaultPresets() {
             .setPikmin(     Flower, White,  15)
             .setPikmin(     Leaf,   White,   5)
             .setOnionPikmin(Leaf,   Blue,   16)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags))
-            .addCutsceneFlags(hob_cflags, ARRLEN(hob_cflags))
-            .addCutsceneFlags(wfg_cflags, ARRLEN(wfg_cflags))
-            .addCutsceneFlags(sh_cflags, ARRLEN(sh_cflags)),
+            .addCutsceneFlags(sh_cflags)
+            .addUpgrades(sh_upgrades),
         // PoD SH7 (+5W)
         Preset().setMsgId('3208_00')
             .setPikmin(     Flower, Red,    24)
@@ -118,10 +127,8 @@ gzCollections::Vec<Preset> getDefaultPresets() {
             .setPikmin(     Flower, White,  15)
             .setPikmin(     Leaf,   White,  10)
             .setOnionPikmin(Leaf,   Blue,   16)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags))
-            .addCutsceneFlags(hob_cflags, ARRLEN(hob_cflags))
-            .addCutsceneFlags(wfg_cflags, ARRLEN(wfg_cflags))
-            .addCutsceneFlags(sh_cflags, ARRLEN(sh_cflags)),
+            .addCutsceneFlags(sh_cflags)
+            .addUpgrades(sh_upgrades),
         // PoD Enter BK
         Preset().setMsgId('3209_00')
             .setPikmin(     Flower, Red,    26)
@@ -131,10 +138,8 @@ gzCollections::Vec<Preset> getDefaultPresets() {
             .setOnionPikmin(Leaf,   Blue,   16)
             .setOnionPikmin(Flower, Red,     3)
             .setOnionPikmin(Flower, Purple,  2)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags))
-            .addCutsceneFlags(hob_cflags, ARRLEN(hob_cflags))
-            .addCutsceneFlags(wfg_cflags, ARRLEN(wfg_cflags))
-            .addCutsceneFlags(sh_cflags, ARRLEN(sh_cflags)),
+            .addCutsceneFlags(sh_cflags)
+            .addUpgrades(bk_upgrades),
         // PoD Enter BK (+2B)
         Preset().setMsgId('3210_00')
             .setPikmin(     Flower, Red,    26)
@@ -144,10 +149,8 @@ gzCollections::Vec<Preset> getDefaultPresets() {
             .setOnionPikmin(Leaf,   Blue,   18)
             .setOnionPikmin(Flower, Red,     3)
             .setOnionPikmin(Flower, Purple,  2)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags))
-            .addCutsceneFlags(hob_cflags, ARRLEN(hob_cflags))
-            .addCutsceneFlags(wfg_cflags, ARRLEN(wfg_cflags))
-            .addCutsceneFlags(sh_cflags, ARRLEN(sh_cflags)),
+            .addCutsceneFlags(sh_cflags)
+            .addUpgrades(bk_upgrades),
         // PoD Enter BK (+5W)
         Preset().setMsgId('3211_00')
             .setPikmin(     Flower, Red,    21)
@@ -157,10 +160,8 @@ gzCollections::Vec<Preset> getDefaultPresets() {
             .setOnionPikmin(Leaf,   Blue,   16)
             .setOnionPikmin(Flower, Red,     3)
             .setOnionPikmin(Flower, Purple,  2)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags))
-            .addCutsceneFlags(hob_cflags, ARRLEN(hob_cflags))
-            .addCutsceneFlags(wfg_cflags, ARRLEN(wfg_cflags))
-            .addCutsceneFlags(sh_cflags, ARRLEN(sh_cflags)),
+            .addCutsceneFlags(sh_cflags)
+            .addUpgrades(bk_upgrades),
         // PoD Enter BK (+5W +2B)
         Preset().setMsgId('3212_00')
             .setPikmin(     Flower, Red,    21)
@@ -170,10 +171,8 @@ gzCollections::Vec<Preset> getDefaultPresets() {
             .setOnionPikmin(Leaf,   Blue,   18)
             .setOnionPikmin(Flower, Red,     3)
             .setOnionPikmin(Flower, Purple,  2)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags))
-            .addCutsceneFlags(hob_cflags, ARRLEN(hob_cflags))
-            .addCutsceneFlags(wfg_cflags, ARRLEN(wfg_cflags))
-            .addCutsceneFlags(sh_cflags, ARRLEN(sh_cflags)),
+            .addCutsceneFlags(sh_cflags)
+            .addUpgrades(bk_upgrades),
         // PoD BK1-BK7
         Preset().setMsgId('3213_00')
             .setPikmin(     Flower, Red,    26)
@@ -184,11 +183,8 @@ gzCollections::Vec<Preset> getDefaultPresets() {
             .setOnionPikmin(Leaf,   Blue,   24)
             .setOnionPikmin(Flower, Red,     3)
             .setOnionPikmin(Flower, Purple,  2)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags))
-            .addCutsceneFlags(hob_cflags, ARRLEN(hob_cflags))
-            .addCutsceneFlags(wfg_cflags, ARRLEN(wfg_cflags))
-            .addCutsceneFlags(sh_cflags, ARRLEN(sh_cflags))
-            .addCutsceneFlags(bk_cflags, ARRLEN(bk_cflags)),
+            .addCutsceneFlags(bk_cflags)
+            .addUpgrades(bk_upgrades),
         // PoD BK1-BK7 (+5W)
         Preset().setMsgId('3214_00')
             .setPikmin(     Flower, Red,    21)
@@ -199,11 +195,8 @@ gzCollections::Vec<Preset> getDefaultPresets() {
             .setOnionPikmin(Leaf,   Blue,   24)
             .setOnionPikmin(Flower, Red,     3)
             .setOnionPikmin(Flower, Purple,  2)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags))
-            .addCutsceneFlags(hob_cflags, ARRLEN(hob_cflags))
-            .addCutsceneFlags(wfg_cflags, ARRLEN(wfg_cflags))
-            .addCutsceneFlags(sh_cflags, ARRLEN(sh_cflags))
-            .addCutsceneFlags(bk_cflags, ARRLEN(bk_cflags)),
+            .addCutsceneFlags(bk_cflags)
+            .addUpgrades(bk_upgrades),
         // PoD Enter SCx (Day 6)
         Preset().setMsgId('3215_00')
             .setOnionPikmin(Leaf,   Blue,   65)
@@ -211,11 +204,8 @@ gzCollections::Vec<Preset> getDefaultPresets() {
             .setOnionPikmin(Flower, Purple, 20)
             .setOnionPikmin(Flower, White,  15)
             .setOnionPikmin(Leaf,   White,  10)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags))
-            .addCutsceneFlags(hob_cflags, ARRLEN(hob_cflags))
-            .addCutsceneFlags(wfg_cflags, ARRLEN(wfg_cflags))
-            .addCutsceneFlags(sh_cflags, ARRLEN(sh_cflags))
-            .addCutsceneFlags(bk_cflags, ARRLEN(bk_cflags)),
+            .addCutsceneFlags(bk_cflags)
+            .addUpgrades(vor2_upgrades),
         // PoD Enter SCx (Day 7)
         Preset().setMsgId('3216_00')
             .setOnionPikmin(Flower, Blue,   65)
@@ -223,12 +213,8 @@ gzCollections::Vec<Preset> getDefaultPresets() {
             .setOnionPikmin(Flower, Purple, 20)
             .setOnionPikmin(Flower, White,  15)
             .setOnionPikmin(Leaf,   White,  10)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags))
-            .addCutsceneFlags(hob_cflags, ARRLEN(hob_cflags))
-            .addCutsceneFlags(wfg_cflags, ARRLEN(wfg_cflags))
-            .addCutsceneFlags(sh_cflags, ARRLEN(sh_cflags))
-            .addCutsceneFlags(bk_cflags, ARRLEN(bk_cflags))
-            .addCutsceneFlags(vor2_cflags, ARRLEN(vor2_cflags)),
+            .addCutsceneFlags(vor2_cflags)
+            .addUpgrades(vor2_upgrades),
         // PoD SCx1-4
         Preset().setMsgId('3217_00')
             .setPikmin(     Flower, Purple, 20)
@@ -236,12 +222,8 @@ gzCollections::Vec<Preset> getDefaultPresets() {
             .setPikmin(     Leaf,   White,  5)
             .setPikmin(     Flower, Blue,   60)
             .setOnionPikmin(Flower, Red,    29)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags))
-            .addCutsceneFlags(hob_cflags, ARRLEN(hob_cflags))
-            .addCutsceneFlags(wfg_cflags, ARRLEN(wfg_cflags))
-            .addCutsceneFlags(sh_cflags, ARRLEN(sh_cflags))
-            .addCutsceneFlags(bk_cflags, ARRLEN(bk_cflags))
-            .addCutsceneFlags(vor2_cflags, ARRLEN(vor2_cflags)),
+            .addCutsceneFlags(vor2_cflags)
+            .addUpgrades(vor2_upgrades),
         // PoD SCx1-4 (+5W)
         Preset().setMsgId('3218_00')
             .setPikmin(     Flower, Purple, 20)
@@ -250,24 +232,16 @@ gzCollections::Vec<Preset> getDefaultPresets() {
             .setPikmin(     Flower, Blue,   55)
             .setOnionPikmin(Flower, Red,    24)
             .setOnionPikmin(Leaf,   Blue,    5)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags))
-            .addCutsceneFlags(hob_cflags, ARRLEN(hob_cflags))
-            .addCutsceneFlags(wfg_cflags, ARRLEN(wfg_cflags))
-            .addCutsceneFlags(sh_cflags, ARRLEN(sh_cflags))
-            .addCutsceneFlags(bk_cflags, ARRLEN(bk_cflags))
-            .addCutsceneFlags(vor2_cflags, ARRLEN(vor2_cflags)),
+            .addCutsceneFlags(vor2_cflags)
+            .addUpgrades(vor2_upgrades),
         // PoD SCx5-Enter FC
         Preset().setMsgId('3219_00')
             .setPikmin(     Flower, Purple, 20)
             .setPikmin(     Flower, White,  35)
             .setPikmin(     Flower, Blue,   45)
             .setOnionPikmin(Flower, Red,    29)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags))
-            .addCutsceneFlags(hob_cflags, ARRLEN(hob_cflags))
-            .addCutsceneFlags(wfg_cflags, ARRLEN(wfg_cflags))
-            .addCutsceneFlags(sh_cflags, ARRLEN(sh_cflags))
-            .addCutsceneFlags(bk_cflags, ARRLEN(bk_cflags))
-            .addCutsceneFlags(vor2_cflags, ARRLEN(vor2_cflags)),
+            .addCutsceneFlags(vor2_cflags)
+            .addUpgrades(vor2_upgrades),
         // PoD SCx5-Enter FC (40W)
         Preset().setMsgId('3220_00')
             .setPikmin(     Flower, Purple, 20)
@@ -275,26 +249,18 @@ gzCollections::Vec<Preset> getDefaultPresets() {
             .setPikmin(     Flower, Blue,   40)
             .setOnionPikmin(Flower, Red,    24)
             .setOnionPikmin(Leaf,   Blue,    5)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags))
-            .addCutsceneFlags(hob_cflags, ARRLEN(hob_cflags))
-            .addCutsceneFlags(wfg_cflags, ARRLEN(wfg_cflags))
-            .addCutsceneFlags(sh_cflags, ARRLEN(sh_cflags))
-            .addCutsceneFlags(bk_cflags, ARRLEN(bk_cflags))
-            .addCutsceneFlags(vor2_cflags, ARRLEN(vor2_cflags)),
-        // PoD FC1-FC7
+            .addCutsceneFlags(vor2_cflags)
+            .addUpgrades(vor2_upgrades),
+        // PoD FC1-FC5
         Preset().setMsgId('3221_00')
             .setPikmin(     Flower, Purple, 20)
             .setPikmin(     Flower, White,  35)
             .setPikmin(     Flower, Blue,   20)
             .setOnionPikmin(Flower, Red,    29)
             .setOnionPikmin(Flower, Blue,   25)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags))
-            .addCutsceneFlags(hob_cflags, ARRLEN(hob_cflags))
-            .addCutsceneFlags(wfg_cflags, ARRLEN(wfg_cflags))
-            .addCutsceneFlags(sh_cflags, ARRLEN(sh_cflags))
-            .addCutsceneFlags(bk_cflags, ARRLEN(bk_cflags))
-            .addCutsceneFlags(vor2_cflags, ARRLEN(vor2_cflags)),
-        // PoD FC1-FC7 (40W)
+            .addCutsceneFlags(vor2_cflags)
+            .addUpgrades(vor2_upgrades),
+        // PoD FC1-FC5 (40W)
         Preset().setMsgId('3222_00')
             .setPikmin(     Flower, Purple, 20)
             .setPikmin(     Flower, White,  40)
@@ -302,24 +268,35 @@ gzCollections::Vec<Preset> getDefaultPresets() {
             .setOnionPikmin(Flower, Red,    24)
             .setOnionPikmin(Flower, Blue,   25)
             .setOnionPikmin(Leaf,   Blue,    5)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags))
-            .addCutsceneFlags(hob_cflags, ARRLEN(hob_cflags))
-            .addCutsceneFlags(wfg_cflags, ARRLEN(wfg_cflags))
-            .addCutsceneFlags(sh_cflags, ARRLEN(sh_cflags))
-            .addCutsceneFlags(bk_cflags, ARRLEN(bk_cflags))
-            .addCutsceneFlags(vor2_cflags, ARRLEN(vor2_cflags)),
+            .addCutsceneFlags(vor2_cflags)
+            .addUpgrades(vor2_upgrades),
+        // PoD FC6-FC7
+        Preset().setMsgId('3228_00')
+            .setPikmin(     Flower, Purple, 20)
+            .setPikmin(     Flower, White,  35)
+            .setPikmin(     Flower, Blue,   20)
+            .setOnionPikmin(Flower, Red,    29)
+            .setOnionPikmin(Flower, Blue,   25)
+            .addCutsceneFlags(vor2_cflags)
+            .addUpgrades(pp_upgrades),
+        // PoD FC6-FC7 (40W)
+        Preset().setMsgId('3229_00')
+            .setPikmin(     Flower, Purple, 20)
+            .setPikmin(     Flower, White,  40)
+            .setPikmin(     Flower, Blue,   15)
+            .setOnionPikmin(Flower, Red,    24)
+            .setOnionPikmin(Flower, Blue,   25)
+            .setOnionPikmin(Leaf,   Blue,    5)
+            .addCutsceneFlags(vor2_cflags)
+            .addUpgrades(pp_upgrades),
         // PoD Enter CoS
         Preset().setMsgId('3223_00')
             .setOnionPikmin(Flower, Blue,   50)
             .setOnionPikmin(Flower, Red,    29)
             .setOnionPikmin(Flower, Purple, 20)
             .setOnionPikmin(Flower, White,  40)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags))
-            .addCutsceneFlags(hob_cflags, ARRLEN(hob_cflags))
-            .addCutsceneFlags(wfg_cflags, ARRLEN(wfg_cflags))
-            .addCutsceneFlags(sh_cflags, ARRLEN(sh_cflags))
-            .addCutsceneFlags(bk_cflags, ARRLEN(bk_cflags))
-            .addCutsceneFlags(vor2_cflags, ARRLEN(vor2_cflags)),
+            .addCutsceneFlags(vor2_cflags)
+            .addUpgrades(pp_upgrades),
         // PoD CoS1-GK6
         Preset().setMsgId('3224_00')
             .setPikmin(     Flower, Purple, 20)
@@ -327,13 +304,8 @@ gzCollections::Vec<Preset> getDefaultPresets() {
             .setPikmin(     Flower, Blue,   45)
             .setOnionPikmin(Flower, Red,    29)
             .setOnionPikmin(Flower, Blue,    5)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags))
-            .addCutsceneFlags(hob_cflags, ARRLEN(hob_cflags))
-            .addCutsceneFlags(wfg_cflags, ARRLEN(wfg_cflags))
-            .addCutsceneFlags(sh_cflags, ARRLEN(sh_cflags))
-            .addCutsceneFlags(bk_cflags, ARRLEN(bk_cflags))
-            .addCutsceneFlags(vor2_cflags, ARRLEN(vor2_cflags))
-            .addCutsceneFlags(pp_cflags, ARRLEN(pp_cflags)),
+            .addCutsceneFlags(pp_cflags)
+            .addUpgrades(pp_upgrades),
         // PoD CoS1-GK6 (+5W)
         Preset().setMsgId('3225_00')
             .setPikmin(     Flower, Purple, 20)
@@ -341,13 +313,8 @@ gzCollections::Vec<Preset> getDefaultPresets() {
             .setPikmin(     Flower, Blue,   40)
             .setOnionPikmin(Flower, Red,    29)
             .setOnionPikmin(Flower, Blue,   10)
-            .addCutsceneFlags(ec_cflags, ARRLEN(ec_cflags))
-            .addCutsceneFlags(hob_cflags, ARRLEN(hob_cflags))
-            .addCutsceneFlags(wfg_cflags, ARRLEN(wfg_cflags))
-            .addCutsceneFlags(sh_cflags, ARRLEN(sh_cflags))
-            .addCutsceneFlags(bk_cflags, ARRLEN(bk_cflags))
-            .addCutsceneFlags(vor2_cflags, ARRLEN(vor2_cflags))
-            .addCutsceneFlags(pp_cflags, ARRLEN(pp_cflags)),
+            .addCutsceneFlags(pp_cflags)
+            .addUpgrades(pp_upgrades),
         // Testing
         Preset().setMsgId('3299_00')
             .setPikmin(     Flower, Red,     20)
@@ -360,7 +327,8 @@ gzCollections::Vec<Preset> getDefaultPresets() {
             .setOnionPikmin(Flower, Blue,   999)
             .setOnionPikmin(Flower, Purple, 999)
             .setOnionPikmin(Flower, White,  999)
-            .setSprays(99, 99),
+            .setSprays(99, 99)
+            .addUpgrades(pp_upgrades),
     };
 
     size_t numPresets = sizeof(defaultPresets) / sizeof(Preset);

--- a/include/GlobalData.h
+++ b/include/GlobalData.h
@@ -13,15 +13,17 @@ struct Preset {
 	Preset& setPikmin(int happa, int color, int amount);
 	Preset& setOnionPikmin(int happa, int color, int amount);
 	Preset& setSprays(int spicies, int bitters);
-	Preset& addCutsceneFlags(u16 flags[], size_t numFlags);
+	Preset& addCutsceneFlags(gzCollections::IndexBitflag<u64> flags);
+	Preset& addUpgrades(gzCollections::IndexBitflag<u32> flags);
 
 	s64 mMsgId;
 	Game::PikiContainer mSquad;
 	Game::PikiContainer mOnionPikis;
 	u16 mNumBitters;
 	u16 mNumSpicies;
-	gzCollections::Vec<u16> mCutsceneFlags;
-	// TODO: upgrades
+	gzCollections::IndexBitflag<u64> mCutsceneFlags;
+	gzCollections::IndexBitflag<u32> mUpgrades;
+	// TODO: area flags, area unlocked flags?
 };
 
 struct SegmentRecord {

--- a/include/gzCollections.h
+++ b/include/gzCollections.h
@@ -127,6 +127,59 @@ private:
     T* mBuf;
 };
 
+template<typename T>
+struct IndexBitflag {
+    IndexBitflag() {
+        mFlags = 0;
+    }
+
+    IndexBitflag(const IndexBitflag<T>& other) {
+        mFlags = other.mFlags;
+    }
+
+    IndexBitflag<T>& set(T index) {
+        mFlags |= 1 << index;
+        return *this;
+    }
+
+    IndexBitflag<T>& setAll(IndexBitflag<T> other) {
+        mFlags |= other.mFlags;
+        return *this;
+    }
+
+    struct Iter {
+        Iter(T flags) {
+            mFlags = flags;
+            mIdx = 0;
+        }
+
+        s32 next() {
+            s32 ret = -1;
+            while (ret == -1 && mIdx < sizeof(T) * 8) {
+                if (mFlags & 1 << mIdx) {
+                    ret = mIdx;
+                }
+                mIdx++;
+            }
+            return ret;
+        }
+
+    private:
+        T mFlags;
+        s32 mIdx;
+    };
+
+    Iter iter() {
+        return Iter(mFlags);
+    }
+
+    bool isSet(T index) {
+        return mFlags & 1 << index;
+    }
+
+    T mFlags;
+};
+
 } // namespace gzCollections
 
 #endif

--- a/src/p2gz/globalData.cpp
+++ b/src/p2gz/globalData.cpp
@@ -251,7 +251,8 @@ s64 P2GZ::getDefaultPresetId(int area, int destination, int sublevel) {
             if (sublevel < 5) return '3217_00';
             else return '3219_00';
         case 3: // FC
-            return '3221_00';
+            if (sublevel < 6) return '3221_00';
+            else return '3228_00';
         }
     case 1: // AW
         switch (destination) {
@@ -262,7 +263,7 @@ s64 P2GZ::getDefaultPresetId(int area, int destination, int sublevel) {
             else if (sublevel < 5) return '3203_00';
             else return '3204_00';
         case 2: // WFG
-            if (sublevel < 4) return '3204_00';
+            if (sublevel < 4) return '3226_00';
             else return '3205_00';
         case 3: // BK
             return '3213_00';
@@ -303,8 +304,19 @@ void P2GZ::applyPreset(Preset& preset) {
     }
 
     // Set cutscene flags
-    for (size_t i = 0; i < preset.mCutsceneFlags.len(); i++) {
-        playData->mDemoFlags.setFlag(preset.mCutsceneFlags[i]);
+    gzCollections::IndexBitflag<u64>::Iter iter1 = preset.mCutsceneFlags.iter();
+    while (true) {
+        s32 flag = iter1.next();
+        if (flag == -1) break;
+        playData->mDemoFlags.setFlag(flag);
+    }
+
+    // Set upgrades
+    gzCollections::IndexBitflag<u32>::Iter iter2 = preset.mUpgrades.iter();
+    while (true) {
+        s32 flag = iter2.next();
+        if (flag == -1) break;
+        playData->mOlimarData->getItem(flag);
     }
 }
 
@@ -334,10 +346,12 @@ Preset& Preset::setSprays(int spicies, int bitters) {
     return *this;
 }
 
-Preset& Preset::addCutsceneFlags(u16 flags[], size_t numFlags) {
-    mCutsceneFlags.expandCapacityTo(mCutsceneFlags.len() + numFlags);
-    for (size_t i = 0; i < numFlags; i++) {
-        mCutsceneFlags.push(flags[i]);
-    }
+Preset& Preset::addCutsceneFlags(gzCollections::IndexBitflag<u64> flags) {
+    mCutsceneFlags.setAll(flags);
+    return *this;
+}
+
+Preset& Preset::addUpgrades(gzCollections::IndexBitflag<u32> flags) {
+    mUpgrades.setAll(flags);
     return *this;
 }


### PR DESCRIPTION
Adds Exploration Kit upgrades to warping presets, plus uses a more space efficient data structure for storing lists of flags.