### PR TITLE
auto skip all movie cutscenes

### DIFF
--- a/src/plugProjectKandoU/singleGS_Ending.cpp
+++ b/src/plugProjectKandoU/singleGS_Ending.cpp
@@ -166,8 +166,8 @@ void EndingState::exec(SingleGameSection* game)
 					mTHPPlayer->play();
 				}
 			} else {
-				// @p2gz: auto-ski-thp
-				// just auto end any movie files now that they are all black screens (pretend like we're never loading them :P)
+				// @p2gz: auto-skip-thp
+				// Automatically end the movie since its files have been removed
 				mTHPPlayer->stop();
 				mStatus   = EndingStatus_PlayMovieCredits;
 				mThpState = 1;
@@ -182,8 +182,8 @@ void EndingState::exec(SingleGameSection* game)
 					mTHPPlayer->play();
 				}
 			} else {
-				// @p2gz: auto-ski-thp
-				// just auto end any movie files now that they are all black screens (pretend like we're never loading them :P)
+				// @p2gz: auto-skip-thp
+				// Automatically end the movie since its files have been removed
 				mTHPPlayer->stop();
 				mStatus = EndingStatus_ShowFinalResultsDebt;
 				kh::Screen::DispFinalResult disp(mResultData, kh::Screen::DispFinalResult::PostDebt, mMainHeap);
@@ -234,8 +234,8 @@ void EndingState::exec(SingleGameSection* game)
 					mTHPPlayer->play();
 				}
 			} else {
-				// @p2gz: auto-ski-thp
-				// just auto end any movie files now that they are all black screens (pretend like we're never loading them :P)
+				// @p2gz: auto-skip-thp
+				// Automatically end the movie since its files have been removed
 				mTHPPlayer->stop();
 				transit(game, SGS_Select, nullptr);
 			}
@@ -248,8 +248,8 @@ void EndingState::exec(SingleGameSection* game)
 					mTHPPlayer->play();
 				}
 			} else {
-				// @p2gz: auto-ski-thp
-				// just auto end any movie files now that they are all black screens (pretend like we're never loading them :P)
+				// @p2gz: auto-skip-thp
+				// Automatically end the movie since its files have been removed
 				mTHPPlayer->stop();
 				kh::Screen::DispFinalResult disp(mResultData, kh::Screen::DispFinalResult::Complete, mMainHeap);
 				Screen::gGame2DMgr->setGamePad(mController);

--- a/src/plugProjectKandoU/singleGS_Movie.cpp
+++ b/src/plugProjectKandoU/singleGS_Movie.cpp
@@ -124,8 +124,8 @@ void MovieState::exec(SingleGameSection* gs)
 			}
 			break;
 		case true:
-			// @p2gz: auto-ski-thp
-			// just auto end any movie files now that they are all black screens (pretend like we're never loading them :P)
+			// @p2gz: auto-skip-thp
+			// Automatically end the movie since its files have been removed
 			{
 				gs->mDisplayWiper = gs->mWipeInFader;
 				gs->mWipeInFader->start(4.0f);

--- a/src/sysGCU/demoSection.cpp
+++ b/src/sysGCU/demoSection.cpp
@@ -109,8 +109,8 @@ bool Section::doUpdate()
 
 	BaseHIOSection::doUpdate();
 
-	// @p2gz: auto-ski-thp
-	// just auto end any movie files now that they are all black screens (pretend like we're never loading them :P)
+	// @p2gz: auto-skip-thp
+	// Automatically end the movie since its files have been removed
 	PSSystem::spSysIF->playSystemSe(PSSE_SY_MENU_CANCEL, 0);
 	mIsMainActive = false;
 

--- a/src/sysGCU/titleSection.cpp
+++ b/src/sysGCU/titleSection.cpp
@@ -433,8 +433,8 @@ void Section::doUpdateOmake()
 		}
 		mThpPlayer->update();
 		if (mThpPlayer->isFinishLoading()) {
-			// @p2gz: auto-ski-thp
-			// just auto end any movie files now that they are all black screens (pretend like we're never loading them :P)
+			// @p2gz: auto-skip-thp
+			// Automatically end the movie since its files have been removed
 			PSSystem::spSysIF->playSystemSe(PSSE_SY_MENU_CANCEL, 0);
 			mThpPlayer->pause();
 			mThpPlayer->stop();


### PR DESCRIPTION
Removes the awkward black screens whenever a THP movie cutscene would normally play by causing the game to automatically skip it.