### PR TITLE
Add option to build symbol map to build script

### DIFF
--- a/build.py
+++ b/build.py
@@ -5,6 +5,7 @@ import platform
 import shutil
 import subprocess
 import time
+import itertools
 
 # set paths
 ISO_ASSETS = os.path.join(os.getcwd(), 'root', 'files')
@@ -22,6 +23,7 @@ P2GZ_CUSTOM_ASSETS = [
 parser = argparse.ArgumentParser()
 parser.add_argument('--clean', '-c', action='store_true', help='Build from a clean working directory')
 parser.add_argument('--restart-dolphin', '-rd', action='store_true', help='Restart Dolphin with root/sys/main.dol after build')
+parser.add_argument('--map', '-m', action='store_true', help='Compile a map file for easier debugging')
 args = parser.parse_args()
 
 if args.restart_dolphin:
@@ -46,7 +48,7 @@ except IndexError:
 if not os.path.exists(os.path.join(os.getcwd(), 'root')):
     print(f'Extracting {iso}')
     subprocess.run(f'nodtool extract "{iso}" root', shell=True)
-    
+
     # add extracted dol to correct directory so dtk can find it
     shutil.copy2('root/sys/main.dol', 'orig/GPVE01/sys/main.dol')
 
@@ -69,21 +71,36 @@ for p2gz_path, dirs, _ in os.walk(P2GZ_ASSETS):
 
             print(f'Copying {patch_dir} to {iso_dir}')
             shutil.copytree(patch_dir, iso_dir, dirs_exist_ok=True)
-            
+
             subprocess.run(f'cube pack -d --arc-extension szs {iso_dir}', shell=True)
-        
+
         # adding custom asset
         elif patch_dir in P2GZ_CUSTOM_ASSETS:
             print(f'Copying {patch_dir} to {iso_dir}')
             shutil.copytree(patch_dir, iso_dir, dirs_exist_ok=True)
-            
+
             subprocess.run(f'cube pack -d --arc-extension szs {iso_dir}', shell=True)
-            
+
 
 # patch dol
-subprocess.run('python3 configure.py --non-matching', shell=True)
+config_cmd = 'python3 configure.py --non-matching'
+if args.map:
+    config_cmd += ' --map'
+
+subprocess.run(config_cmd, shell=True)
+
 subprocess.run('ninja', shell=True)
 shutil.copy2('build/GPVE01/main.dol', 'root/sys/main.dol')
+
+if args.map:
+    subprocess.run('rm root/files/pikmin2UP.map')
+    shutil.copy2('build/GPVE01/main.elf.MAP', 'root/files/pikmin2UP.map')
+    lines = []
+    with open('root/files/pikmin2UP.map', 'r') as f:
+        lines = itertools.dropwhile(lambda line: not line.startswith('.init section layout'), f.readlines())
+    with open('root/files/pikmin2UP.map', 'w') as f:
+        f.writelines(lines)
+
 
 print(f'Done! Build took {round(time.time() - start_time, 2)}s')
 


### PR DESCRIPTION
`python3 build.py --map`

Automatically strips out the first part of the file for faster in-game parsing