### PR TITLE
Fix controller-related new game crash

### DIFF
--- a/include/p2gz/DoublePress.h
+++ b/include/p2gz/DoublePress.h
@@ -1,7 +1,7 @@
 #ifndef _DOUBLEPRESS_H
 #define _DOUBLEPRESS_H
 
-#include <JSystem/JUtility/JUTGamePad.h>
+#include <Controller.h>
 
 namespace gz {
 
@@ -14,7 +14,7 @@ public:
 	{
 	}
 
-	bool check(JUTGamePad* controller)
+	bool check(Controller* controller)
 	{
 		if (frames_left > 0) {
 			frames_left -= 1;

--- a/include/p2gz/gzmenu.h
+++ b/include/p2gz/gzmenu.h
@@ -5,7 +5,6 @@
 #include <p2gz/gzCollections.h>
 #include <p2gz/DoublePress.h>
 #include <JSystem/JUtility/TColor.h>
-#include <JSystem/JUtility/JUTGamePad.h>
 #include <JSystem/J2D/J2DPrint.h>
 #include <Dolphin/os.h>
 #include <IDelegate.h>
@@ -118,7 +117,7 @@ struct MenuLayer {
 public:
 	MenuLayer() { }
 
-	virtual void update(JUTGamePad* controller)    = 0;
+	virtual void update(Controller* controller)    = 0;
 	virtual void draw(J2DPrint& j2d, f32 x, f32 z) = 0;
 	virtual MenuOption* get_option(const char* path) { return nullptr; }
 	virtual void navigate_to(const char* path) { }
@@ -131,7 +130,7 @@ struct ListMenu : public MenuLayer {
 public:
 	ListMenu() { }
 
-	virtual void update(JUTGamePad* controller);
+	virtual void update(Controller* controller);
 	virtual void draw(J2DPrint& j2d, f32 x, f32 z);
 	virtual MenuOption* get_option(const char* path);
 	virtual void navigate_to(const char* path);

--- a/include/p2gz/p2gz.h
+++ b/include/p2gz/p2gz.h
@@ -16,6 +16,10 @@ public:
 	void update();
 	void draw();
 
+	// our own persistent controller so we don't crash the game on new file starting (don't ask)
+	Controller* controller;
+
+	// gz specifics
 	gz::GZMenu* menu;
 	gz::FreeCam* freecam;
 	gz::NaviTools* navi_tools;

--- a/src/p2gz/gzmenu.cpp
+++ b/src/p2gz/gzmenu.cpp
@@ -71,7 +71,7 @@ void GZMenu::update()
 		return;
 	}
 
-	JUTGamePad* controller = JUTGamePad::getGamePad(0);
+	Controller* controller = p2gz->controller;
 
 	if (controller) {
 		// If we ever press A the double press to open/close the menu should be ignored
@@ -255,7 +255,7 @@ void ListMenu::navigate_to(const char* path)
 	}
 }
 
-void ListMenu::update(JUTGamePad* controller)
+void ListMenu::update(Controller* controller)
 {
 	// Menu navigation
 	u32 btn = controller->getButtonDown();

--- a/src/p2gz/p2gz.cpp
+++ b/src/p2gz/p2gz.cpp
@@ -12,11 +12,12 @@ P2GZ* p2gz;
 
 P2GZ::P2GZ()
 {
+	controller      = new Controller(JUTGamePad::PORT_0);
 	menu            = new GZMenu();
 	freecam         = new FreeCam();
 	navi_tools      = new NaviTools();
 	waypoint_viewer = new WaypointViewer();
-  timer           = new Timer();
+	timer           = new Timer();
 }
 
 void P2GZ::update()


### PR DESCRIPTION
Currently the game crashes on trying to start the Crash Landing in-engine cutscene. This fixes that crash (somehow) by creating a persistent `Controller` pointer for the global p2gz object, rather than getting a `JUTGamePad` pointer every frame. Also updates any gz-related arguments from `JUTGamePad*` to `Controller*` for clarity.

Any input handling should probably just go through the `p2gz->controller` pointer in future. 