### PR TITLE
fix graphics breaking text

### DIFF
--- a/include/p2gz/gzmenu.h
+++ b/include/p2gz/gzmenu.h
@@ -259,6 +259,11 @@ public:
 	void open();
 	void close();
 	bool is_open() { return enabled; }
+	bool is_lock() { return lock; }
+
+	// Called when navigating to a new page to disable inputs for 1 frame to prevent accidentally activating other stuff in submenus
+	// immediately
+	void set_lock() { lock = true; }
 
 	/// Returns a reference to the option, or creates it if
 	/// it doesn't exist. Use slashes to indicate heirarchy,

--- a/src/p2gz/gzmenu.cpp
+++ b/src/p2gz/gzmenu.cpp
@@ -104,6 +104,12 @@ void GZMenu::update()
 			else
 				open();
 		}
+
+		// If A or B button was pressed, set the lock for one frame (disable accidental inputs for other submenus as we navigate between
+		// menus)
+		if (enabled && ((controller->getButton() & Controller::PRESS_A) || (controller->getButton() & Controller::PRESS_B))) {
+			set_lock();
+		}
 	}
 
 	if (enabled && layer && controller) {
@@ -214,6 +220,7 @@ void GZMenu::navigate_to(const char* path)
 {
 	close();
 	open();
+	set_lock();
 	root_layer->navigate_to(path);
 }
 

--- a/src/p2gz/p2gz.cpp
+++ b/src/p2gz/p2gz.cpp
@@ -37,13 +37,11 @@ void P2GZ::init()
 
 void P2GZ::update()
 {
-	collision_viewer->update();
-	freecam->update();
-	waypoint_viewer->update();
 	day_editor->update();
 
 	// Menu must update last so button presses for menu interactions don't
 	// inadvertantly do things in other systems on the same frame they're pressed.
+	// NEW - we use the menu lock to prevent this issue for update calls outside of this function (such as graphical updates)
 	menu->update();
 }
 

--- a/src/plugProjectKandoU/baseGameSectionDraw.cpp
+++ b/src/plugProjectKandoU/baseGameSectionDraw.cpp
@@ -14,6 +14,9 @@
 #include "Light.h"
 #include "nans.h"
 
+// @P2GZ
+#include <p2gz/p2gz.h>
+
 const char* message = "drct-post";
 
 namespace Game {
@@ -58,6 +61,19 @@ void BaseGameSection::newdraw_draw3D_all(Graphics& gfx)
 		gfx.mCurrentViewport = vp;
 		directDrawPost(gfx, vp);
 	}
+
+	// @P2GZ fix-graphics-text-corruption: CALL ANY P2GZ UPDATES INVOLVING GRAPHICS HERE
+	// Any p2gz menu that performs graphics stuff must be called here, as running it earlier in the frame before other graphics stuff gets
+	// drawn causes corruption issues with JD2Print for unknown reasons
+
+	p2gz->collision_viewer->update();
+	// When we initially enter freecam menu, the input from P2GZ menu is still active since it's still the same frame (just called way
+	// later). Check the lock here so we don't process that same input for freecam (otherwise we will warp frame 1 and instantly close the
+	// menu).
+	if (!p2gz->menu->is_lock()) {
+		p2gz->freecam->update();
+	}
+	p2gz->waypoint_viewer->update();
 
 	sys->mTimers->_stop("drct-post");
 }


### PR DESCRIPTION
Moves some of the menu updates to run in `baseGameSectionDraw::newdraw_draw3D_all()` in order to fix an issue where graphic drawing corrupts text drawing. Now any P2GZ option that renders something graphically needs to be called in the aforementioned function for now on.