### PR TITLE
Fix IK system calculation issue for spider bosses

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1399,7 +1399,7 @@ config.libs = [
         "progress_category" : "game",
         "host": True,
         "objects": [
-            Object(Equivalent, "plugProjectNishimuraU/nslibmath.cpp"),
+            Object(NonMatching, "plugProjectNishimuraU/nslibmath.cpp"),
             Object(Matching, "plugProjectNishimuraU/ShadowCylinder.cpp"),
             Object(Equivalent, "plugProjectNishimuraU/playCamera.cpp"),
             Object(Matching, "plugProjectNishimuraU/shadowMgr.cpp"),


### PR DESCRIPTION
Update configure.py to change a matching file into nonmatching so IKS stuff for BLL and co. doesn't break