### PR TITLE
fixed main menu crash

### DIFF
--- a/include/p2gz/gzmenu.h
+++ b/include/p2gz/gzmenu.h
@@ -257,6 +257,8 @@ struct GridMenu : public MenuLayer {
 public:
 	GridMenu(f32 column_width_)
 	    : column_width(column_width_)
+	    , selected_row(0)
+	    , selected_col(0)
 	{
 		options.push(new Vec<MenuOption*>);
 	}

--- a/src/plugProjectKandoU/singleGS_Load.cpp
+++ b/src/plugProjectKandoU/singleGS_Load.cpp
@@ -7,6 +7,7 @@
 #include "Screen/Game2DMgr.h"
 #include "Game/GameSystem.h"
 #include "Radar.h"
+#include <p2gz/p2gz.h>
 
 namespace Game {
 namespace SingleGame {


### PR DESCRIPTION
Fixes crash when you enter story mode/ch mode, do some p2gz stuff, go back to the main title menu, then re-enter story/ch mode. Also includes missing include in `singleGS_Load.cpp` so this can build properly.