### PR TITLE
build: dynamically find p2gz files

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -13,6 +13,8 @@
 ###
 
 import argparse
+import glob
+import os
 import sys
 from pathlib import Path
 from typing import Any, Dict, List
@@ -2087,25 +2089,8 @@ config.libs = [
         "cflags": [*cflags_pikmin],
         "mw_version": "GC/2.6",
         "host": True,
-        "objects": [
-            # p2gz: add new files here...
-            Object(Matching, "p2gz/p2gz.cpp"),
-            Object(Matching, "p2gz/gzmenu.cpp"),
-            Object(Matching, "p2gz/freecam.cpp"),
-            Object(Matching, "p2gz/navitools.cpp"),
-            Object(Matching, "p2gz/timer.cpp"),
-            Object(Matching, "p2gz/waypointViewer.cpp"),
-            Object(Matching, "p2gz/collisionViewer.cpp"),
-            Object(Matching, "p2gz/warp.cpp"),
-            Object(Matching, "p2gz/skippableCS.cpp"),
-            Object(Matching, "p2gz/dayEditor.cpp"),
-            Object(Matching, "p2gz/images.cpp"),
-            Object(Matching, "p2gz/structureEditor.cpp"),
-            Object(Matching, "p2gz/sprayEditor.cpp"),
-            Object(Matching, "p2gz/segmentHistory.cpp"),
-            Object(Matching, "p2gz/enemyDebugInfo.cpp"),
-            Object(Matching, "p2gz/squadEditor.cpp"),
-        ],
+        "objects": [Object(Matching, os.path.relpath(file, "src"))
+                    for file in glob.glob(os.path.join("src", "p2gz", "*.cpp"))],
     },
 ]
 
@@ -2119,25 +2104,8 @@ def link_order_callback(module_id: int, objects: List[str]) -> List[str]:
     if not config.non_matching:
         return objects
     if module_id == 0:  # DOL
-        return objects + [
-            # p2gz: ... and here
-            "p2gz/p2gz.cpp",
-            "p2gz/gzmenu.cpp",
-            "p2gz/freecam.cpp",
-            "p2gz/navitools.cpp",
-            "p2gz/timer.cpp",
-            "p2gz/waypointViewer.cpp",
-            "p2gz/collisionViewer.cpp",
-            "p2gz/warp.cpp",
-            "p2gz/skippableCS.cpp",
-            "p2gz/dayEditor.cpp",
-            "p2gz/images.cpp",
-            "p2gz/structureEditor.cpp",
-            "p2gz/sprayEditor.cpp",
-            "p2gz/segmentHistory.cpp",
-            "p2gz/enemyDebugInfo.cpp",
-            "p2gz/squadEditor.cpp",
-            ]
+        return objects + [os.path.relpath(file, "src")  
+                          for file in glob.glob(os.path.join("src", "p2gz", "*.cpp"))]
     return objects
 
 # Uncomment to enable the link order callback.


### PR DESCRIPTION
```
PS D:\p2gz> python3 build.py --clean
Cleaning... ninja: error: remove(build/compilers): The directory is not empty.

ninja: error: remove(build/binutils): The directory is not empty.

1173 files.
Extracting D:\p2gz\GPVE01 Pikmin 2.iso
[18.8179 INFO nod] Success!
Copying D:\p2gz\assets\files\memoryCard\memoryCardHeader.szs to D:\p2gz\root\files\memoryCard\memoryCardHeader.szs
Copying D:\p2gz\assets\sys\boot.bin to D:\p2gz\root\sys\boot.bin
[1/3] TOOL build\tools\dtk.exe
[2/3] SPLIT config\GPVE01\config.yml
 INFO Loading config\GPVE01\config.yml
 INFO Loading and analyzing 1 module (using 1 thread)
 INFO Rebuilding relocations and splitting
 INFO Splitting completed in 2.200s (wrote 1153 objects)
[3/3] RUN configure.py
[1172/1172] DOL build\GPVE01\main.dol
Done! Build took 83.38s
```