### PR TITLE
fix: set freecam angle to CAMANGLE_Behind

### DIFF
--- a/include/p2gz/FreeCam.h
+++ b/include/p2gz/FreeCam.h
@@ -36,7 +36,11 @@ private:
 	Game::PlayCamera* camera;
 	Game::Navi* navi;
 	bool enabled;
+	int originalAngle;
+	int originalZoom;
+	int minZoom;
 	int zoom;
+	int maxZoom;
 	f32 animation_coefficient;
 	bool is_coefficient_positive;
 };

--- a/src/p2gz/freecam.cpp
+++ b/src/p2gz/freecam.cpp
@@ -9,9 +9,8 @@
 
 using namespace gz;
 
-const int MIN_FREECAM_ZOOM       = 0;
-const int DEFAULT_FREECAM_ZOOM   = 768;
-const int MAX_FREECAM_ZOOM       = 1700;
+const int INITIAL_ZOOM_OFFSET    = 100;
+const int MAX_ZOOM_OFFSET        = 1000;
 const int OUT_OF_BOUNDS_MIN_Y    = -1000;
 const f32 C_STICK_X_AXIS_SCALING = 0.05f;
 const f32 C_STICK_Y_AXIS_SCALING = 25.0f;
@@ -33,9 +32,16 @@ void FreeCam::enable()
 	camera = Game::cameraMgr->mCameraObjList[navi->getNaviID()];
 	Game::gameSystem->setPause(true, FREECAM_PAUSE_IDENTIFIER, 3);
 
-	zoom = DEFAULT_FREECAM_ZOOM;
-	camera->mGoalPosition += Vector3f(0, zoom, 0);
+	originalAngle = camera->mCameraSelAngle;
+	originalZoom  = camera->mCameraZoomLevel;
+
+	minZoom = navi->mPosition.y;
+	zoom    = minZoom + INITIAL_ZOOM_OFFSET;
+	maxZoom = zoom + MAX_ZOOM_OFFSET;
+
+	camera->mGoalPosition.y    = zoom;
 	camera->mGoalVerticalAngle = PI / 2;
+	camera->mCameraSelAngle    = Game::CAMANGLE_Behind;
 
 	og::ogSound->setOpen();
 }
@@ -52,6 +58,10 @@ void FreeCam::disable()
 	camera->mGoalPosition -= Vector3f(0, zoom, 0);
 	camera->mGoalVerticalAngle                       = PI / 8;
 	camera->mCameraParms->mSettingChangeSpeed.mValue = 0.1f;
+
+	camera->mCameraSelAngle  = originalAngle;
+	camera->mCameraZoomLevel = originalZoom;
+	camera->setTargetParms();
 
 	navi   = nullptr;
 	camera = nullptr;
@@ -214,7 +224,7 @@ void FreeCam::update_zoom()
 	f32 cStickY = navi->mController1->getSubStickY() * C_STICK_Y_AXIS_SCALING;
 
 	camera->mCameraAngleTarget -= cStickX;
-	if (zoom > MIN_FREECAM_ZOOM && zoom - cStickY > MIN_FREECAM_ZOOM && zoom < MAX_FREECAM_ZOOM && zoom - cStickY < MAX_FREECAM_ZOOM) {
+	if (zoom > minZoom && zoom - cStickY > minZoom && zoom < maxZoom && zoom - cStickY < maxZoom) {
 		zoom -= cStickY;
 		camera->mGoalPosition -= Vector3f(0, cStickY, 0);
 		if (cStickY > 0) {


### PR DESCRIPTION
For some reason, if freecam was enabled with the top-down camera, the control stick Y-axis controls would be inverted. It was way easier to override `mCameraSelAngle` to `CAMANGLE_Behind` than to debug why that was happening. Closes https://github.com/p2gz/p2gz/issues/62.

Two other small things:
- The min and max zoom range are now dynamically set based on the y-coordinate the camera is opened at, rather than fixed values.
- The original camera parameters are restored after exiting freecam.
