### PR TITLE
Replace Nintendo text on title with P2GZ version

### DIFF
--- a/include/p2gz/p2gz.h
+++ b/include/p2gz/p2gz.h
@@ -21,6 +21,9 @@
 #include <p2gz/EnemyDebugInfo.h>
 #include <p2gz/Preset.h>
 
+/*!!! VERSION NUMBER - TO BE UPDATED EACH RELEASE !!!*/
+#define P2GZ_VERSION "alpha1"
+
 struct P2GZ {
 public:
 	P2GZ();
@@ -30,7 +33,8 @@ public:
 	void update();
 	void draw_2d();
 	void draw();
-	void draw_images();
+
+	static void draw_version();
 
 	// our own persistent controller so we don't crash the game on new file starting (don't ask)
 	Controller* controller;

--- a/src/p2gz/p2gz.cpp
+++ b/src/p2gz/p2gz.cpp
@@ -10,6 +10,7 @@
 #include <p2gz/EnemyDebugInfo.h>
 #include <p2gz/SquadEditor.h>
 #include <Game/Navi.h>
+#include <P2JME/P2JME.h>
 #include <IDelegate.h>
 
 using namespace gz;
@@ -79,4 +80,21 @@ void P2GZ::draw()
 	collision_viewer->draw();
 	freecam->draw();
 	enemy_debug_info->draw();
+}
+
+// Code to draw the version number on the title screen
+void P2GZ::draw_version()
+{
+	J2DPrint j2d(gP2JMEMgr->mFont, 0.0f);
+	j2d.initiate();
+
+	j2d.mGlyphWidth  = 20.0f;
+	j2d.mGlyphHeight = 20.0f;
+
+	JUtility::TColor color = JUtility::TColor(255, 255, 255, 255);
+	j2d.mCharColor.set(color);
+	j2d.mGradientColor.set(color);
+
+	// coordinates determined experimentally - will need to re-adjust based on text length
+	j2d.print(250.0f, 424.0f, "v.%s", P2GZ_VERSION);
 }

--- a/src/plugProjectEbisawaU/ebiScreenTMBack.cpp
+++ b/src/plugProjectEbisawaU/ebiScreenTMBack.cpp
@@ -3,6 +3,7 @@
 #include "ebi/Screen/TNintendoLogo.h"
 #include "Graphics.h"
 #include "System.h"
+#include <p2gz/p2gz.h>
 
 namespace ebi {
 namespace Screen {
@@ -158,7 +159,9 @@ void TNintendoLogo::doDraw()
 	J2DPerspGraph* context = &gfx->mPerspGraph;
 	context->setPort();
 
-	mScreenObj->draw(*gfx, *context);
+	// @P2GZ: remove (C) 2004 Nintendo and draw P2GZ version instead
+	// mScreenObj->draw(*gfx, *context);
+	P2GZ::draw_version();
 }
 } // namespace Screen
 } // namespace ebi


### PR DESCRIPTION
Hides the "2004 Nintendo" text from the title screen, and prints the P2GZ version number instead. Currently, version is stored as a define in `p2gz.h` - whether this should be somehow pulled in from the build script instead is probably a question for a future PR. Tried to get automatic text centering working regardless of version string length, but the screen size and/or font size seem weird, so at the moment it's manually set to a position that seems good (enough).

<img width="1377" height="1012" alt="image" src="https://github.com/user-attachments/assets/e65d151f-378b-47f6-9539-5416e74bebd2" />
