### PR TITLE
Bug fix: remove crash on re-entering area

### DIFF
--- a/include/p2gz/StructureEditor.h
+++ b/include/p2gz/StructureEditor.h
@@ -39,7 +39,7 @@ public:
 private:
 	const char* get_gate_name(f32 x, f32 z);
 
-	Vec<GateWrapper> gates;
+	Vec<GateWrapper*> gates;
 	ListMenu* gate_menu;
 };
 

--- a/include/p2gz/gzCollections.h
+++ b/include/p2gz/gzCollections.h
@@ -116,12 +116,7 @@ struct Vec {
 		}
 	}
 
-	void clear()
-	{
-		delete[] mBuf;
-		mBuf = new T[mCapacity];
-		mLen = 0;
-	}
+	void clear() { mLen = 0; }
 
 private:
 	void _grow(size_t newCapacity)

--- a/src/p2gz/structureEditor.cpp
+++ b/src/p2gz/structureEditor.cpp
@@ -41,15 +41,15 @@ void StructureEditor::init()
 
 void StructureEditor::add_gate(Game::ItemGate* gate)
 {
-	GateWrapper gate_wrapper;
-	gate_wrapper.gate = gate;
+	GateWrapper* gate_wrapper = new GateWrapper();
+	gate_wrapper->gate        = gate;
 	gates.push(gate_wrapper);
 	const char* gate_name = get_gate_name(gate->mPosition.x, gate->mPosition.z);
 
 	// clang-format off
 	gate_menu->push(new OpenSubMenuOption(gate_name, (new ListMenu())
-	    ->push(new RangeMenuOption("segments remaining", 0, 3, 3 - gate->mSegmentsDown, RangeMenuOption::CAP, new Delegate1<GateWrapper, s32>(&gates[gates.len()-1], &GateWrapper::set_gate_segments)))
-		->push(new FloatRangeMenuOption("segment health", 0.0f, gate->mMaxSegmentHealth, gate->mCurrentSegmentHealth, new Delegate1<GateWrapper, f32>(&gates[gates.len()-1], &GateWrapper::set_gate_segment_health)))
+	    ->push(new RangeMenuOption("segments remaining", 0, 3, 3 - gate->mSegmentsDown, RangeMenuOption::CAP, new Delegate1<GateWrapper, s32>(gates[gates.len()-1], &GateWrapper::set_gate_segments)))
+		->push(new FloatRangeMenuOption("segment health", 0.0f, gate->mMaxSegmentHealth, gate->mCurrentSegmentHealth, new Delegate1<GateWrapper, f32>(gates[gates.len()-1], &GateWrapper::set_gate_segment_health)))
     ));
 	// clang-format on
 }


### PR DESCRIPTION
Fixes #71 by adjusting how the Vec implementation clears its members, especially those with non-trivial destructors, and forcing dynamic menu clearing on load to use the Vec method to avoid an infinite loop.