### PR TITLE
Fix: Collision viewer no longer draws 50k triangles per frame

### DIFF
--- a/src/p2gz/collisionViewer.cpp
+++ b/src/p2gz/collisionViewer.cpp
@@ -9,7 +9,7 @@
 #include <Game/mapParts.h>
 #include <p2gz/p2gz.h>
 
-const int RENDER_DISTANCE = 16;
+const f32 RENDER_RADIUS = 1024.0f;
 
 namespace gz {
 bool CollisionViewer::is_navi_on_triangle(Sys::Triangle* tri, Sys::VertexTable* vertTable)
@@ -55,30 +55,32 @@ void CollisionViewer::draw_triangles(Sys::Sphere& sphere)
 		return;
 	}
 
-	for (int i = 0; i < triLists->mCount; i++) {
-		Sys::Triangle* tri = triTable->getTriangle(triLists->mObjects[i]);
-		Color4 color       = Color4(200, 200, 200, 128);
-		if (!is_navi_on_triangle(tri, vertTable)) {
-			switch (tri->mCode.getSlipCode()) {
-			case MapCode::Code::SlipCode_NoSlip:
-				color = Color4(0, 50 + 150 * fabs(tri->mTrianglePlane.mNormal.y), 0, 128);
-				break;
-			case MapCode::Code::SlipCode_Gradual:
-				color = Color4(0, 0, 50 + 150 * fabs(tri->mTrianglePlane.mNormal.y), 128);
-				break;
-			case MapCode::Code::SlipCode_Steep:
-				color = Color4(50 + 150 * fabs(tri->mTrianglePlane.mNormal.y), 0, 0, 128);
-				break;
+	for (triLists; triLists; triLists = static_cast<Sys::TriIndexList*>(triLists->mNext)) {
+		for (int i = 0; i < triLists->getNum(); i++) {
+			Sys::Triangle* tri = triTable->getTriangle(triLists->mObjects[i]);
+			Color4 color       = Color4(200, 200, 200, 128);
+			if (!is_navi_on_triangle(tri, vertTable)) {
+				switch (tri->mCode.getSlipCode()) {
+				case MapCode::Code::SlipCode_NoSlip:
+					color = Color4(0, 50 + 150 * fabs(tri->mTrianglePlane.mNormal.y), 0, 128);
+					break;
+				case MapCode::Code::SlipCode_Gradual:
+					color = Color4(0, 0, 50 + 150 * fabs(tri->mTrianglePlane.mNormal.y), 128);
+					break;
+				case MapCode::Code::SlipCode_Steep:
+					color = Color4(50 + 150 * fabs(tri->mTrianglePlane.mNormal.y), 0, 0, 128);
+					break;
+				}
 			}
-		}
 
-		GXBegin(GX_TRIANGLES, GX_VTXFMT0, 3);
-		for (int i = 0; i < 3; i++) {
-			Vector3f vertex = *vertTable->getVertex(tri->mVertices[i]);
-			GXPosition3f32(vertex.x, vertex.y, vertex.z);
-			GXColor4u8(color.r, color.g, color.b, color.a);
+			GXBegin(GX_TRIANGLES, GX_VTXFMT0, 3);
+			for (int i = 0; i < 3; i++) {
+				Vector3f vertex = *vertTable->getVertex(tri->mVertices[i]);
+				GXPosition3f32(vertex.x, vertex.y, vertex.z);
+				GXColor4u8(color.r, color.g, color.b, color.a);
+			}
+			GXEnd();
 		}
-		GXEnd();
 	}
 }
 
@@ -112,13 +114,8 @@ void CollisionViewer::draw()
 	gfx->initPrimDraw(nullptr);
 
 	Vector3f naviPos = navi->getPosition();
-	for (int i = -RENDER_DISTANCE; i <= RENDER_DISTANCE; i++) {
-		for (int j = -RENDER_DISTANCE; j <= RENDER_DISTANCE; j++) {
-			Vector3f scoutPos = naviPos + Vector3f(32 * i, 0, 32 * j);
-			Sys::Sphere scout(scoutPos, 0.0f);
-			draw_triangles(scout);
-		}
-	}
+	Sys::Sphere renderSphere(naviPos, RENDER_RADIUS);
+	draw_triangles(renderSphere);
 }
 } // namespace gz
 


### PR DESCRIPTION
Properly iterates over TriIndexLists to fix the collision viewer drawing. Now draws about 6k triangles per frame with double the render distance, rather than 50k previously. Hopefully increases performance on console, but unsure if it fixes any collision-viewer-associated crashes.

<img width="1372" height="1012" alt="image" src="https://github.com/user-attachments/assets/fc7e8d96-e0c1-4351-a19b-ade304e997f1" />
