### PR TITLE
dismiss circles now wrap around the ground

### DIFF
--- a/include/p2gz/HelperInlines.h
+++ b/include/p2gz/HelperInlines.h
@@ -3,6 +3,7 @@
 
 #include <Game/GameSystem.h>
 #include <Game/SingleGame.h>
+#include <Game/MapMgr.h>
 #include <GameFlow.h>
 
 namespace gz {
@@ -10,6 +11,18 @@ namespace gz {
 inline bool is_30_fps()
 {
 	return sys && (sys->mFrameRate == 2.0f);
+}
+
+inline f32 get_min_Y_clamped(Vector3f& pos, Vector3f& ref_pos, f32 max_height_diff, f32 offset_above_floor)
+{
+	// clamps pos's height toward the floor, but vertically no further than max_height_diff away from ref_pos
+	f32 minY = Game::mapMgr->getMinY(pos);
+	if (fabs(ref_pos.y - minY) > max_height_diff) {
+		minY = (ref_pos.y > minY) ? ref_pos.y - max_height_diff : ref_pos.y + max_height_diff;
+	}
+
+	// offset up a bit so we're not clipped into the floor
+	return minY + offset_above_floor;
 }
 
 inline bool in_boot_up()

--- a/src/p2gz/dismissPositions.cpp
+++ b/src/p2gz/dismissPositions.cpp
@@ -5,6 +5,7 @@
 #include <Game/PikiMgr.h>
 #include <Game/PikiState.h>
 #include <Game/MapMgr.h>
+#include <p2gz/HelperInlines.h>
 
 using namespace gz;
 
@@ -23,37 +24,18 @@ void DismissPositions::draw_circle(Vector3f position, f32 radius, Color4 color)
 
 	Vector3f vertices[3];
 	vertices[0] = position;
-	// Offset y position so the circle is not clipping into the ground and adjusts for slopes
-	// Also if the difference in height is too great, clamp the height of the circle to prevent jank-looking circles
-	f32 minY = Game::mapMgr->getMinY(vertices[0]);
-	if (fabs(position.y - minY) > MAX_DRAW_CIRCLE_HEIGHT) {
-		minY = position.y > minY ? position.y - MAX_DRAW_CIRCLE_HEIGHT : position.y + MAX_DRAW_CIRCLE_HEIGHT;
-	}
-	vertices[0].y = minY;
-	vertices[0].y += CIRCLE_VERTICAL_OFFSET;
+	// clamp toward floor, but no further than MAX_DRAW_CIRCLE_HEIGHT away from circle center
+	// (also add an offset so we're not *in* the floor)
+	vertices[0].y = get_min_Y_clamped(vertices[0], position, MAX_DRAW_CIRCLE_HEIGHT, CIRCLE_VERTICAL_OFFSET);
 
 	for (int i = 0; i < 32; i++) {
-		f32 theta   = -HALF_PI - (TAU * i / 32);
-		vertices[1] = Vector3f(radius * sinf(theta), 0.0f, radius * cosf(theta)) + position;
-		// Offset y position so the circle is not clipping into the ground and adjusts for slopes
-		// Also if the difference in height is too great, clamp the height of the circle to prevent jank-looking circles
-		minY = Game::mapMgr->getMinY(vertices[1]);
-		if (fabs(position.y - minY) > MAX_DRAW_CIRCLE_HEIGHT) {
-			minY = position.y > minY ? position.y - MAX_DRAW_CIRCLE_HEIGHT : position.y + MAX_DRAW_CIRCLE_HEIGHT;
-		}
-		vertices[1].y = minY;
-		vertices[1].y += CIRCLE_VERTICAL_OFFSET;
+		f32 theta     = -HALF_PI - (TAU * i / 32);
+		vertices[1]   = Vector3f(radius * sinf(theta), 0.0f, radius * cosf(theta)) + position;
+		vertices[1].y = get_min_Y_clamped(vertices[1], position, MAX_DRAW_CIRCLE_HEIGHT, CIRCLE_VERTICAL_OFFSET);
 
 		f32 nextTheta = -HALF_PI - (TAU * (i + 1) / 32);
 		vertices[2]   = Vector3f(radius * sinf(nextTheta), 0.0f, radius * cosf(nextTheta)) + position;
-		// Offset y position so the circle is not clipping into the ground and adjusts for slopes
-		// Also if the difference in height is too great, clamp the height of the circle to prevent jank-looking circles
-		minY = Game::mapMgr->getMinY(vertices[2]);
-		if (fabs(position.y - minY) > MAX_DRAW_CIRCLE_HEIGHT) {
-			minY = position.y > minY ? position.y - MAX_DRAW_CIRCLE_HEIGHT : position.y + MAX_DRAW_CIRCLE_HEIGHT;
-		}
-		vertices[2].y = minY;
-		vertices[2].y += CIRCLE_VERTICAL_OFFSET;
+		vertices[2].y = get_min_Y_clamped(vertices[2], position, MAX_DRAW_CIRCLE_HEIGHT, CIRCLE_VERTICAL_OFFSET);
 
 		GXBegin(GX_TRIANGLEFAN, GX_VTXFMT0, 3);
 		for (int j = 0; j < 3; j++) {
@@ -95,12 +77,7 @@ void DismissPositions::draw()
 		Vector3f pos2 = positions[i];
 		// Adjust y-endpoint so the line can point to circles that aren't on the same xz plane as the player (be sure to clamp on offsets
 		// that are too high!)
-		f32 minY = Game::mapMgr->getMinY(pos2);
-		if (fabs(pos2.y - minY) > MAX_DRAW_CIRCLE_HEIGHT) {
-			minY = pos2.y > minY ? pos2.y - MAX_DRAW_CIRCLE_HEIGHT : pos2.y + MAX_DRAW_CIRCLE_HEIGHT;
-		}
-		pos2.y = minY;
-		pos2.y += CIRCLE_VERTICAL_OFFSET;
+		pos2.y = get_min_Y_clamped(pos2, pos2, MAX_DRAW_CIRCLE_HEIGHT, CIRCLE_VERTICAL_OFFSET);
 		gfx->drawLine(pos1, pos2);
 		gfx->mDrawColor = Color4(0, 0, 0, 255);
 	}


### PR DESCRIPTION
"Dismiss positions" option now has the circles wrap along the ground. Note that circle positions can get a little iffy with dramatic slopes/walls/oob areas, want to get everyone's take on it. Playtesters (jpep) complained about the original circles being flat and clipping into the ground, so this helps to address that. Here are some images with the new circles (both good and bad).

<img width="975" height="528" alt="image" src="https://github.com/user-attachments/assets/3d08e5d8-5da3-4162-8494-ef05f48ad16d" />
<img width="975" height="528" alt="image" src="https://github.com/user-attachments/assets/201c732a-f527-46ac-8d96-4fbe3c9d5e22" />
<img width="975" height="528" alt="image" src="https://github.com/user-attachments/assets/42b2cccf-8f62-451d-b2a5-68f416ca8590" />
<img width="975" height="528" alt="image" src="https://github.com/user-attachments/assets/3357935d-5b75-4db1-b42f-65c07b2faa40" />
<img width="975" height="528" alt="image" src="https://github.com/user-attachments/assets/bfc3422f-c508-4b41-b730-51f47dca7203" />
<img width="975" height="528" alt="image" src="https://github.com/user-attachments/assets/138a1e94-e448-4316-b51a-4c03d0c8a679" />
<img width="975" height="528" alt="image" src="https://github.com/user-attachments/assets/13903f74-2a2a-4428-af9c-b77e67fdff09" />
<img width="975" height="528" alt="image" src="https://github.com/user-attachments/assets/686ab22c-eff9-4de8-b305-46cb00c29e3b" />
<img width="975" height="528" alt="image" src="https://github.com/user-attachments/assets/ffc67f78-bc50-4505-af50-1d2088a584f7" />
<img width="975" height="528" alt="image" src="https://github.com/user-attachments/assets/aa42589f-f802-47d9-ae77-fff435e01d20" />
<img width="975" height="528" alt="image" src="https://github.com/user-attachments/assets/09424cca-c473-49a6-81bf-5d833596ecae" />
