### PR TITLE
fix: draw collision viewer earlier in frame

### DIFF
--- a/src/p2gz/p2gz.cpp
+++ b/src/p2gz/p2gz.cpp
@@ -117,7 +117,6 @@ void P2GZ::draw()
 		return;
 	}
 
-	collision_viewer->draw();
 	freecam->draw();
 	enemy_debug_info->draw();
 	dismiss_positions->draw();

--- a/src/plugProjectKandoU/baseGameSectionDraw.cpp
+++ b/src/plugProjectKandoU/baseGameSectionDraw.cpp
@@ -39,6 +39,10 @@ void BaseGameSection::newdraw_draw3D_all(Graphics& gfx)
 		particleMgr->setXfb(mXfbImage->mTexInfo);
 	}
 
+	// @P2GZ: collision viewer
+	// draw first in the frame so other graphics are drawn on top
+	p2gz->collision_viewer->draw();
+
 	// Draw particles for both viewports
 	sys->mTimers->_start("part-draw", true);
 	drawParticle(gfx, PLAYER1_VIEWPORT);


### PR DESCRIPTION
Collision viewer is a special case that needs to be drawn earlier in the frame than `p2gz->draw()` to prevent collision triangles from drawing on top of things like carry info, particles, etc.

Closes https://github.com/p2gz/p2gz/issues/118.