### PR TITLE
fix: keep sprays unlocked in caves when counts are zero

### DIFF
--- a/src/p2gz/sprayEditor.cpp
+++ b/src/p2gz/sprayEditor.cpp
@@ -52,14 +52,14 @@ void SprayEditor::toggle_bitters(bool unlocked)
 	if (unlocked) {
 		Game::playData->setDemoFlag(Game::DEMO_First_Bitter_Berry);
 		Game::playData->setDemoFlag(Game::DEMO_First_Bitter_Spray_Made);
-		// don't set DEMO_BITTER_ENABLED here, SingleGameSection will do it automatically
-		// (and then show counter)
+		if (Game::gameSystem->mIsInCave) {
+			Game::playData->setDemoFlag(Game::DEMO_BITTER_ENABLED);
+		}
 	} else {
 		Game::playData->mSprayCount[1] = 0;
 		static_cast<RangeMenuOption*>(spray_menu->get_option("bitters"))->set_selection(0);
 		Game::playData->mDemoFlags.resetFlag(Game::DEMO_First_Bitter_Berry);
 		Game::playData->mDemoFlags.resetFlag(Game::DEMO_First_Bitter_Spray_Made);
-		// unset flag so ogObjGround can hide display correctly, though
 		Game::playData->mDemoFlags.resetFlag(Game::DEMO_BITTER_ENABLED);
 	}
 }
@@ -69,14 +69,14 @@ void SprayEditor::toggle_spicies(bool unlocked)
 	if (unlocked) {
 		Game::playData->setDemoFlag(Game::DEMO_First_Spicy_Berry);
 		Game::playData->setDemoFlag(Game::DEMO_First_Spicy_Spray_Made);
-		// don't set DEMO_SPICY_ENABLED here, SingleGameSection will do it automatically
-		// (and then show counter)
+		if (Game::gameSystem->mIsInCave) {
+			Game::playData->setDemoFlag(Game::DEMO_SPICY_ENABLED);
+		}
 	} else {
 		Game::playData->mSprayCount[0] = 0;
 		static_cast<RangeMenuOption*>(spray_menu->get_option("spicies"))->set_selection(0);
 		Game::playData->mDemoFlags.resetFlag(Game::DEMO_First_Spicy_Berry);
 		Game::playData->mDemoFlags.resetFlag(Game::DEMO_First_Spicy_Spray_Made);
-		// unset flag so ogObjGround can hide display correctly, though
 		Game::playData->mDemoFlags.resetFlag(Game::DEMO_SPICY_ENABLED);
 	}
 }


### PR DESCRIPTION
I don't know.

Resolves https://github.com/p2gz/p2gz/issues/129.