### PR TITLE
fix: pause world map when opening p2gz

### DIFF
--- a/src/p2gz/warp.cpp
+++ b/src/p2gz/warp.cpp
@@ -206,9 +206,9 @@ void Warp::do_warp()
 
 	if (preset) {
 		preset->apply();
-		preset_status          = PS_Stale;
+		preset_status                      = PS_Stale;
 		p2gz->preset_mgr->last_used_preset = preset;
-		needs_post_load_action = true;
+		needs_post_load_action             = true;
 	}
 
 	if (particle2dMgr) {
@@ -300,8 +300,7 @@ void Warp::warp_to_cave(Game::SingleGameSection* game)
 	Game::playData->mCaveSaveData.mCurrentCaveID = caveID;
 
 	// Save changes to world state if we're above-ground currently
-	// TODO: do we want to do this? Should it be a setting?
-	if (!Game::gameSystem->mIsInCave) {
+	if (in_above_ground_play()) {
 		game->saveToGeneratorCache(game->mCurrentCourseInfo);
 	}
 
@@ -355,8 +354,7 @@ void Warp::warp_to_area(Game::SingleGameSection* game)
 	}
 
 	// Save changes to world state if we're above-ground currently
-	// TODO: do we want to do this? Should it be a setting?
-	if (!Game::gameSystem->mIsInCave) {
+	if (in_above_ground_play()) {
 		game->saveToGeneratorCache(game->mCurrentCourseInfo);
 	}
 

--- a/src/plugProjectKandoU/singleGS_WorldMap.cpp
+++ b/src/plugProjectKandoU/singleGS_WorldMap.cpp
@@ -52,6 +52,11 @@ void SelectState::init(SingleGameSection*, StateArg*)
 	playData->mDeadNaviID = 0;
 	naviMgr->clearDeadCount();
 	mNewLevelOpen = false;
+
+	// @P2GZ p2gz-pause-fixes: set correct args to be able to warp out of world map
+	if (p2gz) {
+		p2gz->warp->warping_from_menu = true;
+	}
 }
 
 /**


### PR DESCRIPTION
Pauses world map when opening p2gz now, so you can warp from world map. Fixes #88 