### PR TITLE
Add gate debug info + sync gate settings on menu open

### DIFF
--- a/include/Game/Entities/ItemGate.h
+++ b/include/Game/Entities/ItemGate.h
@@ -133,7 +133,10 @@ struct ItemGate : public WorkItem<ItemGate, GateFSM, GateState> {
 	void initMotion();
 	void initPlanes();
 
-	inline f32 getGateHealth();
+	// @P2GZ: gate debug info
+	// bring this in from itemGate.cpp so we can use it elsewhere
+	// inline f32 getGateHealth();
+	f32 getGateHealth() { return (mMaxSegments - mSegmentsDown - 1) * mMaxSegmentHealth + mCurrentSegmentHealth; }
 
 	// unused/inlined:
 	void startDamageMotion();

--- a/include/p2gz/StructureEditor.h
+++ b/include/p2gz/StructureEditor.h
@@ -36,19 +36,30 @@ struct StructureEditor {
 	};
 
 public:
-	StructureEditor() { }
+	StructureEditor()
+	    : gate_menu(nullptr)
+	    , gate_debug_enabled(false)
+	{
+	}
 
 	void init();
+	void draw();
 
 	void add_gate(Game::ItemGate* gate);
 	void set_gate_stages_left(const char* name, int stages_left);
 	void clear_gates();
+	void sync_gates();
+
+	void set_enabled_gate_debug(bool set) { gate_debug_enabled = set; }
+	bool is_gate_debug_enabled() { return gate_debug_enabled; }
+	void draw_gate_debug(Game::ItemGate* gate, const char* name, Graphics* gfx);
 
 private:
 	const char* get_gate_name(f32 x, f32 z);
 
 	Vec<GateWrapper*> gates;
 	ListMenu* gate_menu;
+	bool gate_debug_enabled;
 };
 
 }; // namespace gz

--- a/src/p2gz/gzmenu.cpp
+++ b/src/p2gz/gzmenu.cpp
@@ -99,7 +99,9 @@ void GZMenu::init_menu()
         ))
 		->push(new OpenSubMenuOption("map", (new ListMenu())
 			->push(new OpenSubMenuOption("structures", (new ListMenu())
-				->push(new OpenSubMenuOption("gates", (new ListMenu()))) // Will be populated dynamically by StructureEditor
+				->push(new OpenSubMenuOption("gates", (new ListMenu(new Delegate<StructureEditor>(p2gz->structure_editor, &StructureEditor::sync_gates))))) // Will be populated dynamically by StructureEditor
+				->push(new ToggleMenuOption("show gate debug info", false,
+	                         new Delegate1<StructureEditor, bool>(p2gz->structure_editor, &StructureEditor::set_enabled_gate_debug)))
 			))
 			->push(new ToggleMenuOption("collision viewer", false, new Delegate1<CollisionViewer, bool>(p2gz->collision_viewer, &CollisionViewer::toggle)))
 			->push(new ToggleMenuOption("waypoint viewer", false, new Delegate1<WaypointViewer, bool>(p2gz->waypoint_viewer, &WaypointViewer::toggle)))

--- a/src/p2gz/p2gz.cpp
+++ b/src/p2gz/p2gz.cpp
@@ -120,6 +120,7 @@ void P2GZ::draw()
 
 	freecam->draw();
 	enemy_debug_info->draw();
+	structure_editor->draw();
 	dismiss_positions->draw();
 }
 

--- a/src/p2gz/structureEditor.cpp
+++ b/src/p2gz/structureEditor.cpp
@@ -2,11 +2,13 @@
 #include <p2gz/gzmenu.h>
 #include <p2gz/p2gz.h>
 #include <Game/Entities/ItemGate.h>
+#include <P2JME/P2JME.h>
 #include <types.h>
 
 using namespace gz;
 
-#define GATE_SEARCH_RADIUS (5.0f)
+#define GATE_SEARCH_RADIUS     (5.0f)
+#define GATE_DEBUG_RENDER_DIST (512.0f)
 
 static const size_t NUM_GATE_NAMES                                            = 20;
 static const StructureEditor::NameCoordinateMap COORD_TO_NAME[NUM_GATE_NAMES] = {
@@ -108,4 +110,88 @@ void StructureEditor::GateWrapper::set_gate_segments(s32 segments)
 void StructureEditor::GateWrapper::set_gate_segment_health(f32 health)
 {
 	gate->mCurrentSegmentHealth = health;
+}
+
+void StructureEditor::sync_gates()
+{
+	for (size_t i = 0; i < gates.len(); i++) {
+		// sanity check to only update gates we have actual info for
+		if (!gates[i] || !gates[i]->name || !gates[i]->gate) {
+			continue;
+		}
+
+		ListMenu* gate_submenu = static_cast<ListMenu*>(gate_menu->get_option(gates[i]->name)->get_sub_menu());
+		if (gate_submenu) {
+			static_cast<RangeMenuOption*>(gate_submenu->get_option("segments remaining"))->set_selection(3 - gates[i]->gate->mSegmentsDown);
+			static_cast<FloatRangeMenuOption*>(gate_submenu->get_option("segment health"))
+			    ->set_selection(gates[i]->gate->mCurrentSegmentHealth);
+		}
+	}
+}
+
+void StructureEditor::draw()
+{
+	if (!gate_debug_enabled) {
+		return;
+	}
+
+	if (!Game::itemGateMgr) {
+		return;
+	}
+
+	Graphics* gfx = sys->mGfx;
+	if (!gfx || !gfx->mCurrentViewport || !Game::naviMgr || !Game::naviMgr->getActiveNavi()) {
+		return;
+	}
+	gfx->initPerspPrintf(gfx->mCurrentViewport);
+
+	for (size_t i = 0; i < gates.len(); i++) {
+		if (!gates[i]) {
+			continue;
+		}
+		Game::ItemGate* gate = gates[i]->gate;
+		const char* name     = gates[i]->name;
+		if (gate && name) {
+			draw_gate_debug(gate, name, gfx);
+		}
+	}
+}
+
+void StructureEditor::draw_gate_debug(Game::ItemGate* gate, const char* name, Graphics* gfx)
+{
+	if (!gate || !name) {
+		return;
+	}
+
+	if (gate->getGateHealth() <= 0.0f || !gate->mLod.isFlag(AILOD_IsVisible)) {
+		return;
+	}
+
+	Vector3f naviPos = Game::naviMgr->getActiveNavi()->getPosition();
+	Vector3f gatePos = gate->mPosition;
+	if (sqrDistanceXZ(naviPos, gatePos) > SQUARE(GATE_DEBUG_RENDER_DIST)) {
+		return;
+	}
+
+	Color4 color(255, 255, 255, 255);
+
+	PerspPrintfInfo info;
+	info.mFont   = gP2JMEMgr->mFont;
+	info.mScale  = 0.5f;
+	info.mColorA = color;
+	info.mColorB = color;
+	Vector3f pos = gatePos + Vector3f(0, 120.0f + 40.0f, 0);
+
+	int line_height = 22;
+	// draw name
+	gfx->perspPrintf(info, pos, "%s", name);
+	info.mPerspectiveOffsetY += line_height;
+
+	// draw current health
+	gfx->perspPrintf(info, pos, "health remaining: %.0f", gate->getGateHealth());
+	info.mPerspectiveOffsetY += line_height;
+
+	// draw total health
+	gfx->perspPrintf(info, pos, "max health: %.0f", gate->mMaxSegmentHealth * gate->mMaxSegments);
+	info.mPerspectiveOffsetY += line_height;
 }

--- a/src/plugProjectKandoU/itemGate.cpp
+++ b/src/plugProjectKandoU/itemGate.cpp
@@ -11,6 +11,7 @@
 #include "Game/gamePlayData.h"
 #include "Game/MoviePlayer.h"
 #include "PSSystem/PSSystemIF.h"
+#include "LifeGaugeMgr.h"
 #include "nans.h"
 #include <p2gz/p2gz.h>
 
@@ -51,6 +52,12 @@ ItemGate::ItemGate()
 	mIsElectric             = false;
 	mEgateEfxA              = nullptr;
 	mEgateEfxBC             = nullptr;
+
+	// @P2GZ: gate debug info
+	// setup life gauge information so we can draw it later
+	if (lifeGaugeMgr) {
+		lifeGaugeMgr->createLifeGauge(this);
+	}
 }
 
 /**
@@ -93,6 +100,12 @@ void ItemGate::onInit(CreatureInitArg* arg)
 	} else {
 		mMatAnimator = new Sys::MatLoopAnimator;
 		mMatAnimator->start(&itemGateMgr->mMatTevRegAnim);
+	}
+
+	// @P2GZ: gate debug info
+	// make life gauge visible and actively updated
+	if (lifeGaugeMgr) {
+		lifeGaugeMgr->activeLifeGauge(this, 1.0f);
 	}
 }
 
@@ -733,10 +746,12 @@ void ItemGate::changeMaterial()
 	}
 }
 
-inline f32 ItemGate::getGateHealth()
-{
-	return (mMaxSegments - mSegmentsDown - 1) * mMaxSegmentHealth + mCurrentSegmentHealth;
-}
+// @P2GZ: gate debug info
+// move this to ItemGate.h so we can use it elsewhere
+// inline f32 ItemGate::getGateHealth()
+// {
+// 	return (mMaxSegments - mSegmentsDown - 1) * mMaxSegmentHealth + mCurrentSegmentHealth;
+// }
 
 /**
  * @note Address: 0x801C88D8
@@ -749,7 +764,11 @@ void ItemGate::getLifeGaugeParam(Game::LifeGaugeParam& param)
 	param.mPosition.y += 120.0f;
 	param.mRadius          = 10.0f;
 	param.mCurrHealthRatio = getGateHealth() / (mMaxSegmentHealth * mMaxSegments);
-	param.mIsGaugeShown    = mLod.isFlag(AILOD_IsVisible);
+	// @P2GZ: gate debug info
+	// hide life gauge when gate is at zero health
+	// (we could do this with inactiveLifeGauge I think, but not from in here)
+	// param.mIsGaugeShown    = mLod.isFlag(AILOD_IsVisible);
+	param.mIsGaugeShown = mLod.isFlag(AILOD_IsVisible) && (getGateHealth() > 0.0f);
 }
 
 /**


### PR DESCRIPTION
Adds a gate debug info drawing option to the structure menu, along with code that prints the gate name (as per our internal names + what name is used in the menu), current health, and max health. This also re-enables the unused gate health gauge code to display that as well when we have the debug info active.

This also fixes #127 by adding a sync callback to the gates menu to update values on gate menu open.

Open to suggestions on how else to format the debug info/anything else to add, or whether that's out of scope. Could also refactor the gate debug info code into a generic structure debug info object for use with bridges/plugs/etc in the future - open to ideas or help.

<img width="1372" height="1010" alt="image" src="https://github.com/user-attachments/assets/33f92866-de04-4679-845f-6b704fab0154" />
