### PR TITLE
fix: wild bulbmin no longer show up in generated presets

### DIFF
--- a/include/Game/FakePiki.h
+++ b/include/Game/FakePiki.h
@@ -179,6 +179,10 @@ struct FakePiki : public Creature, public SysShape::MotionListener {
 		}
 	}
 	virtual bool wasZikatu() { return isFPFlag(FPFLAGS_WasZikatu); } // _1FC (weak)
+
+	// @P2GZ - add helper for checking if a pikmin is wild bulbmin
+	bool isWildBulbmin() { return isFPFlag(FPFLAGS_IsWildBulbmin); }
+
 	virtual void inWaterCallback(WaterBox* wb) { }                   // _84 (weak)
 	virtual void outWaterCallback() { }                              // _88 (weak)
 	virtual f32 getMapCollisionRadius() { return 8.5f; }             // _200 (weak)

--- a/src/p2gz/preset.cpp
+++ b/src/p2gz/preset.cpp
@@ -260,10 +260,9 @@ void PresetMenuOption::select_current_preset(ListMenu* menu)
 	menu->selected = idx_in_category;
 }
 
-static const char* PIKI_IMG_NAMES[15] = {
-	"blue_leaf",     "blue_bud",    "blue_flower", "red_leaf",      "red_bud",    "red_flower", "yellow_leaf",  "yellow_bud",
-	"yellow_flower", "purple_leaf", "purple_bud",  "purple_flower", "white_leaf", "white_bud",  "white_flower",
-};
+static const char* PIKI_IMG_NAMES[18] = { "blue_leaf",   "blue_bud",   "blue_flower",   "red_leaf",     "red_bud",     "red_flower",
+	                                      "yellow_leaf", "yellow_bud", "yellow_flower", "purple_leaf",  "purple_bud",  "purple_flower",
+	                                      "white_leaf",  "white_bud",  "white_flower",  "bulbmin_leaf", "bulbmin_bud", "bulbmin_flower" };
 
 static const char* ONION_IMG_NAMES[5] = {
 	"onion_blue", "onion_red", "onion_yellow", "ship_purple", "ship_white",

--- a/src/p2gz/presetMgr.cpp
+++ b/src/p2gz/presetMgr.cpp
@@ -560,7 +560,7 @@ Preset* PresetMgr::create()
 	CI_LOOP(iterator)
 	{
 		Piki* piki = *iterator;
-		if (piki->isAlive() && !piki->isZikatu()) {
+		if (piki->isAlive() && !piki->isZikatu() && !piki->isWildBulbmin()) {
 			preset->squad(piki)++;
 		}
 	}


### PR DESCRIPTION
Closes https://github.com/p2gz/p2gz/issues/130

Also adds bulbmin images to the preset rendering code so they'll show up properly when they're actually supposed to be there.