### PR TITLE
Make all "first area enter" cutscenes skippable

### DIFF
--- a/include/p2gz/timer.h
+++ b/include/p2gz/timer.h
@@ -30,6 +30,9 @@ struct ListMenu;
 /// for intro/crash landing cutscene
 #define MAX_CRASH_LANDING_CUTSCENE_TIME (37.5f)
 
+/// for all other "first time enter" cutscenes
+#define MAX_FIRST_ENTER_CUTSCENE_TIME (13.0f)
+
 struct Timer {
 public:
 	Timer();

--- a/src/p2gz/skippableCS.cpp
+++ b/src/p2gz/skippableCS.cpp
@@ -44,8 +44,9 @@ void SkippableCutscenes::prime_skip(Creature* cutscene_target, MovieConfig* conf
 		return;
 	}
 
-	// toggle intro crash landing cutscene skippable
-	if (config->is("x01_gamestart")) {
+	// toggle intro crash landing/first area enter cutscenes skippable
+	if (config->is("x01_gamestart") || config->is("x01_coursein_forest") || config->is("x01_coursein_yakushima")
+	    || config->is("x01_coursein_last")) {
 		if (enabled) {
 			config->enableSkippable();
 

--- a/src/p2gz/timer.cpp
+++ b/src/p2gz/timer.cpp
@@ -212,6 +212,9 @@ void Timer::stop_skip_timer(Game::MovieConfig* config)
 	if (config->is("x01_gamestart")) {
 		// intro crash landing cutscene
 		max_cutscene_time = MAX_CRASH_LANDING_CUTSCENE_TIME;
+	} else if (config->is("x01_coursein_forest") || config->is("x01_coursein_yakushima") || config->is("x01_coursein_last")) {
+		// first area enter cutscene (all three others are the same length)
+		max_cutscene_time = MAX_FIRST_ENTER_CUTSCENE_TIME;
 	} else if (config->is("s22_cv_suck_treasure") || config->is("s10_suck_treasure")) {
 		// treasure cutscene
 		max_cutscene_time = MAX_TREASURE_CUTSCENE_TIME;


### PR DESCRIPTION
All "first area enter" fly-in cutscenes are skippable, with an appropriate timer offset based on when they're skipped, all controlled by the same "skippable cutscenes" menu option as the rest. 

Exact timer offset may need tweaking with some playtesting, but should be very easy to update based on feedback. As far as I can tell, all three enters aside from VoR are the same length (approx. 13s from beginning of fly-in after area text to beginning of fade-out at end of cutscene).

Fixes #189.