### PR TITLE
Move treasures back to their original positions when retrying AGs

### DIFF
--- a/include/p2gz/Preset.h
+++ b/include/p2gz/Preset.h
@@ -18,7 +18,7 @@ enum PresetCategory { PoD, AT, General, Generated };
 
 enum EnterAreaKind { PEK_FromCave = 0, PEK_FromMap = 1, PEK_FirstEnter = 2 };
 
-enum GenSpawnOverride { PSO_Ignore, PSO_DontSpawn, PSO_Spawn };
+enum GenSpawnOverride { PSO_Ignore = 0, PSO_DontSpawn = 1, PSO_Spawn = 2, PSO_SpawnAndMove = 3 };
 
 enum CourseIndex { COURSE_VoR, COURSE_AW, COURSE_PP, COURSE_WW };
 
@@ -47,11 +47,14 @@ struct Preset {
 		{
 			id             = 255;
 			spawn_override = PSO_Ignore;
+			position_override = Vector3f::zero;
 		}
 		TreasureGenSpawnOverride(u8 id_, GenSpawnOverride spawn_override_);
+		TreasureGenSpawnOverride(u8 id_, GenSpawnOverride spawn_override_, Vector3f position_override_);
 
 		u8 id;
 		GenSpawnOverride spawn_override;
+		Vector3f position_override; // only used if spawn_override is PSO_SpawnAndMove
 	};
 
 public:

--- a/src/p2gz/preset.cpp
+++ b/src/p2gz/preset.cpp
@@ -129,6 +129,14 @@ Preset::TreasureGenSpawnOverride::TreasureGenSpawnOverride(u8 id_, GenSpawnOverr
 	spawn_override = spawn_override_;
 }
 
+Preset::TreasureGenSpawnOverride::TreasureGenSpawnOverride(u8 id_, GenSpawnOverride spawn_override_, Vector3f position_override_)
+{
+	GZASSERTLINE(spawn_override_ == PSO_SpawnAndMove); // Doesn't make sense to use this ctor otherwise
+	id                = id_;
+	spawn_override    = spawn_override_;
+	position_override = position_override_;
+}
+
 GenSpawnOverride Preset::get_enemy_gen_override(Game::Generator* gen)
 {
 	if (gen->mObject->mTypeID == 'teki') {
@@ -416,8 +424,16 @@ void Preset::apply_post_load()
 			for (size_t i = 0; i < treasure_spawn_overrides.len(); i++) {
 				TreasureGenSpawnOverride& oride = treasure_spawn_overrides[i];
 				if (oride.id == treasure_id) {
-					if (oride.spawn_override == PSO_Spawn && gen->mCreature == nullptr) {
-						gen->generate();
+					if (oride.spawn_override >= PSO_Spawn) {
+						if (!gen->mCreature) {
+							gen->generate();
+						}
+						GZASSERTLINE(gen->mCreature);
+						if (oride.spawn_override == PSO_SpawnAndMove) {
+							gen->mCreature->setPosition(oride.position_override, false);
+						} else {
+							gen->mCreature->setPosition(gen->mPosition, false);
+						}
 					} else if (oride.spawn_override == PSO_DontSpawn && gen->mCreature) {
 						Game::PelletKillArg arg;
 						gen->mCreature->kill(&arg);

--- a/src/plugProjectKandoU/gameGenerator.cpp
+++ b/src/plugProjectKandoU/gameGenerator.cpp
@@ -312,7 +312,7 @@ void Generator::generate()
 		gz::GenSpawnOverride spawn_override = preset->get_enemy_gen_override(this);
 		if (spawn_override == gz::PSO_DontSpawn) {
 			return;
-		} else if (spawn_override == gz::PSO_Spawn) {
+		} else if (spawn_override >= gz::PSO_Spawn) {
 			mDayNum     = gameSystem->mTimeMgr->mDayCount;
 			mDeathCount = 0;
 			mCreature   = mObject->generate(this);


### PR DESCRIPTION
Previously when warping to an AG segment while some of its force-spawned treasures are alive, they would be left in the same position they were in when warping instead of respawned like they should be.

Also adds support for position overrides for treasure spawns. It's not used yet since we don't have a way to get good coordinates in-game, but it will be useful for AT splits and Enter FC.