### PR TITLE
Fix: stop title screen demos attempting to play altogether

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2049,7 +2049,7 @@ config.libs = [
             Object(NonMatching, "sysGCU/pikmin2MemoryCardMgr.cpp"),
             Object(Matching, "sysGCU/commonSaveData.cpp"),
             Object(Equivalent, "sysGCU/bootSection.cpp"),
-            Object(NonMatching, "sysGCU/titleSection.cpp"),
+            Object(Equivalent, "sysGCU/titleSection.cpp"),
             Object(Matching, "sysGCU/loadResource.cpp"),
             Object(Matching, "sysGCU/rootMenuSection.cpp"),
             Object(Matching, "sysGCU/demoSection.cpp"),

--- a/include/GameFlow.h
+++ b/include/GameFlow.h
@@ -16,9 +16,14 @@ struct JKRHeap;
 struct SectionInfo {
 	char* mName; // _00
 
+	// @P2GZ: make titleSection.cpp equivalent
+	// union {
+	// 	u32 abcd;
+	// 	u8 mSectionId, b, c, d;
+	// } mId; // _04
 	union {
 		u32 abcd;
-		u8 mSectionId, b, c, d;
+		u8 mSectionId[4];
 	} mId; // _04
 };
 

--- a/src/sysGCU/gameflow.cpp
+++ b/src/sysGCU/gameflow.cpp
@@ -132,7 +132,9 @@ SectionInfo* GameFlow::getSectionInfo(int id)
 	P2ASSERTBOUNDSLINE(201, 0, id, SN_SECTION_COUNT);
 
 	for (u32 i = 0; i < SN_SECTION_COUNT; i++) {
-		if (id == sSectionInfo[i].mId.mSectionId) {
+		// @P2GZ: make titleSection.cpp equivalent
+		// if (id == sSectionInfo[i].mId.mSectionId) {
+		if (id == sSectionInfo[i].mId.mSectionId[0]) {
 			sectionInfo = &sSectionInfo[i];
 			break;
 		}

--- a/src/sysGCU/titleSection.cpp
+++ b/src/sysGCU/titleSection.cpp
@@ -130,24 +130,37 @@ void Section::init()
 	mMenu->addKeyEvent(Menu::KeyEvent::U6, Controller::PRESS_B, new Delegate1<Section, Menu&>(this, &menuCancel));
 	mMenu->addKeyEvent(Menu::KeyEvent::INVOKE_ACTION_ON_BUTTON_PRESS, Controller::PRESS_A,
 	                   new Delegate1<Section, Menu&>(this, &menuSelect));
+
+	// @P2GZ: make titleSection.cpp equivalent
+	// int sects = 0;
+	// for (int i = 0; i < GameFlow::SN_SECTION_COUNT; i++) {
+	int i     = 0;
 	int sects = 0;
-	for (int i = 0; i < GameFlow::SN_SECTION_COUNT; i++) {
+	for (i = 0; i < GameFlow::SN_SECTION_COUNT; i++) {
 		SectionInfo* data = GameFlow::getSectionInfo(i);
 
 		if (data) {
-			if ((!Game::gGameConfig.mParms.mMarioClubDevelop() || data->mId.c) && data->mId.b) {
+			// @P2GZ: make titleSection.cpp equivalent
+			// if ((!Game::gGameConfig.mParms.mMarioClubDevelop() || data->mId.c) && data->mId.b) {
+			if ((!Game::gGameConfig.mParms.mMarioClubDevelop() || data->mId.mSectionId[2]) && data->mId.mSectionId[1]) {
 				mMenu->addOption(i, data->mName, nullptr, true);
 				sects++;
 			}
 		} else {
-			char* name = "NO NAME";
-			mMenu->addOption(i, name, nullptr, true);
+			// @P2GZ: make titleSection.cpp equivalent
+			// char* name = "NO NAME";
+			// mMenu->addOption(i, name, nullptr, true);
+			mMenu->addOption(i, "NO NAME", nullptr, true);
 			sects++;
 		}
 	}
 
 	JUTFont* font = JFWSystem::systemFont;
-	mMenu->setPosition(300, sys->getRenderModeObj()->efbHeight - (sects * font->getHeight() + 60));
+	// @P2GZ: make titleSection.cpp equivalent
+	// mMenu->setPosition(300, sys->getRenderModeObj()->efbHeight - (sects * font->getHeight() + 60));
+	int x = 300;
+	int y = sys->getRenderModeObj()->efbHeight - (sects * font->getHeight() + 60);
+	mMenu->setPosition(x, y);
 
 	sys->heapStatusEnd("TitleSection::init");
 
@@ -231,9 +244,11 @@ void Section::drawShortCuts(Graphics& gfx)
  * @note Address: N/A
  * @note Size: 0x150
  */
-void Section::drawShortCut(Graphics&, int, int, int, char*)
+void Section::drawShortCut(Graphics&, int p2, int, int, char*)
 {
-	mTimeStep = randFloat(); // here for sdata2
+	// @P2GZ: make titleSection.cpp equivalent
+	// mTimeStep = randFloat(); // here for sdata2
+	mTimeStep = p2; // only here for sdata2
 
 	// UNUSED FUNCTION
 }
@@ -283,7 +298,9 @@ void Section::updateMenu()
  */
 void Section::doUpdateMainTitle()
 {
-	mGoToDemoTimer += sys->mDeltaTime;
+	// @P2GZ: stop transits to tutorial cutscenes
+	// mGoToDemoTimer += sys->mDeltaTime;
+	mGoToDemoTimer = 0.0f;
 	updateMenu();
 	mMainTitleMgr.update();
 	if (mController1->isButtonHeld(~JUTGamePad::False)) {
@@ -343,9 +360,13 @@ void Section::doUpdateMainTitle()
 				mgr->checkScene();
 				seq = PSSystem::getSeqData(mgr, BGM_HiScore);
 				seq->startSeq();
-				mIsMainActive = true;
-				break;
+				// @P2GZ: make titleSection.cpp equivalent
+				// 	mIsMainActive = true;
+				// 	break;
+				// }
 			}
+			mIsMainActive = true;
+			break;
 		case ebi::TMainTitleMgr::Select_Bonus:
 			mState = State_Bonus;
 			mOmakeMgr.start();
@@ -410,7 +431,7 @@ void Section::doUpdateOmake()
 		PSSystem::validateSceneMgr(mgr);
 		mgr->checkScene();
 		PSSystem::SeqBase* seq = PSSystem::getSeqData(mgr, BGM_Bonus);
-		f32 rate               = (ebi::TMainTitleMgr::kFadeOutTime / sys->mDeltaTime);
+		f32 rate               = (ebi::E2DFader::kFadeTime / sys->mDeltaTime);
 		rate                   = ROUND_F32_TO_U8(rate);
 		seq->stopSeq((int)rate);
 	}
@@ -515,8 +536,6 @@ void Section::run()
  */
 bool Section::doUpdate()
 {
-	PSSystem::SeqBase* seq;
-
 	sys->mCardMgr->update();
 	switch (mState) {
 	case State_Init:
@@ -583,7 +602,9 @@ bool Section::doLoading()
 		sys->dvdLoadUseCallBack(&mThreadCommand, mButtonCallback);
 		PSMGetSceneMgrCheck()->doStartMainSeq();
 	}
-	return u8(done == 0);
+	// @P2GZ: make titleSection.cpp equivalent
+	// return u8(done == 0);
+	return !done;
 }
 
 /**


### PR DESCRIPTION
Fixes the title screen "tutorial" cutscenes to make them not even attempt to play, rather than transiting to a black screen and back. Also makes titleSection.cpp equivalent, which should be helpful if we want to edit that further down the track.