### PR TITLE
Show the current test on screen

### DIFF
--- a/include/p2gz/Test.h
+++ b/include/p2gz/Test.h
@@ -158,6 +158,8 @@ public:
 		return this;
 	}
 
+	inline const char* get_name() { return name; }
+
 private:
 	const char* name;
 	size_t cur_op;
@@ -171,6 +173,7 @@ public:
 
 	void init();
 	void update();
+	void draw_2d();
 
 	JUTGamePadRecordFixed* gamepad;
 

--- a/src/p2gz/p2gz.cpp
+++ b/src/p2gz/p2gz.cpp
@@ -134,6 +134,10 @@ void P2GZ::draw_2d()
 		return;
 	}
 
+#ifdef GZ_TEST
+	test_runner->draw_2d();
+#endif
+
 	menu->draw();
 	timer->draw();
 	segment_history->draw_2d();

--- a/src/p2gz/test/test.cpp
+++ b/src/p2gz/test/test.cpp
@@ -2,6 +2,7 @@
 #include <p2gz/Test.h>
 #include <JSystem/JUtility/JUTGamePad.h>
 #include <Dolphin/pad.h>
+#include <P2JME/P2JME.h>
 
 using namespace gz;
 using namespace gz::test;
@@ -48,6 +49,25 @@ void TestRunner::update()
 	if (cur_test >= tests.len()) {
 		OSReport("GZTest: Done with all tests\n");
 	}
+}
+
+void TestRunner::draw_2d()
+{
+	if (!inited || cur_test >= tests.len()) {
+		return;
+	}
+
+	Test* test = tests[cur_test];
+
+	J2DPrint j2d(gP2JMEMgr->mFont, 0.0f);
+	j2d.initiate();
+	j2d.mGlyphWidth  = 28.0f;
+	j2d.mGlyphHeight = 28.0f;
+	const JUtility::TColor color(200, 255, 200, 255);
+	j2d.mCharColor.set(color);
+	j2d.mGradientColor.set(color);
+
+	j2d.print(96.0f, 128.0f, "Running test:\n-> %s", test->get_name());
 }
 
 Test::Test(const char* name_)


### PR DESCRIPTION
Prints the current test name in large font on the screen when running tests. This makes it easier to keep track of what test is running.
<img width="1483" height="1091" alt="image" src="https://github.com/user-attachments/assets/e9040531-45a5-4db6-9ee9-0894351b1a2e" />
