### PR TITLE
Fix "over-completing" caves

### DIFF
--- a/include/p2gz/SegmentHistory.h
+++ b/include/p2gz/SegmentHistory.h
@@ -30,6 +30,10 @@ public:
 	Segment* cur_segment();
 	void record_squad();
 
+	void retry_segment();
+	void retry_same_seed();
+	void retry_cave();
+
 	bool started_creating_map;
 	bool entering_next_segment;
 

--- a/include/p2gz/Test.h
+++ b/include/p2gz/Test.h
@@ -14,12 +14,13 @@ namespace test {
 #define TEST(name, ...) ((new Test(name))__VA_ARGS__ WAIT(30))
 #define __TEST_OP(op)   ->push(op)
 
-#define __COMPOUND(...)        (new CompoundOp()) __VA_ARGS__
-#define PRESS(btn)             __TEST_OP(new ButtonInput(btn)) __TEST_OP(new Wait(1))
-#define DBL_DPAD_L             PRESS(PAD_BUTTON_LEFT) PRESS(PAD_BUTTON_LEFT)
-#define MASH_TEXT              PRESS(PAD_BUTTON_A) PRESS(PAD_BUTTON_B)
-#define SKIP_CUTSCENE          __TEST_OP(new ActionOp(new FreeDelegate(&skip_movie)))
-#define SKIP_LOAD_CUTSCENES    DO_UNTIL(SKIP_CUTSCENE, in_gameplay)
+#define __COMPOUND(...)     (new CompoundOp()) __VA_ARGS__
+#define PRESS(btn)          __TEST_OP(new ButtonInput(btn)) __TEST_OP(new Wait(1))
+#define DBL_DPAD_L          PRESS(PAD_BUTTON_LEFT) PRESS(PAD_BUTTON_LEFT)
+#define MASH_TEXT           PRESS(PAD_BUTTON_A) PRESS(PAD_BUTTON_B)
+#define SKIP_CUTSCENE       __TEST_OP(new ActionOp(new FreeDelegate(&skip_movie)))
+#define SKIP_LOAD_CUTSCENES DO_UNTIL(SKIP_CUTSCENE, in_gameplay)
+#define RETRY_SEGMENT       __TEST_OP(new ActionOp(new Delegate<SegmentHistory>(p2gz->segment_history, &SegmentHistory::retry_segment)))
 
 #define DO_ACTION(delegate)    __TEST_OP(new ActionOp(delegate))
 #define DO_N(num, ...)         __TEST_OP(new DoN(__COMPOUND(__VA_ARGS__), num))

--- a/src/p2gz/segmentHistory.cpp
+++ b/src/p2gz/segmentHistory.cpp
@@ -44,38 +44,107 @@ Segment* SegmentHistory::cur_segment()
 	return nullptr;
 }
 
-void SegmentHistory::update()
+void SegmentHistory::retry_segment()
 {
 	const Segment* current_segment = cur_segment();
 	if (!current_segment) {
 		return;
 	}
-
 	WarpDestination current_dest = current_segment->dest;
-	const u32 btn                = p2gz->controller->getButtonDown();
 
+	current_dest.use_set_seed = false;
+	p2gz->warp->set_dest(current_dest);
+	p2gz->warp->set_preset(current_segment->preset, PS_Generated);
+	p2gz->warp->do_warp();
+
+	entering_next_segment = false;
+}
+
+void SegmentHistory::retry_same_seed()
+{
+	const Segment* current_segment = cur_segment();
+	if (!current_segment) {
+		return;
+	}
+	WarpDestination current_dest = current_segment->dest;
+
+	current_dest.use_set_seed = true;
+
+	p2gz->warp->set_dest(current_dest);
+	p2gz->warp->set_preset(current_segment->preset, PS_Generated);
+	p2gz->warp->do_warp();
+
+	entering_next_segment = false;
+}
+
+void SegmentHistory::retry_cave()
+{
+	const Segment* current_segment = cur_segment();
+	if (!current_segment) {
+		return;
+	}
+	WarpDestination current_dest = current_segment->dest;
+
+	if (segments.len() == 0) {
+		return;
+	}
+
+	// Find segment for the first floor of the cave
+	const Segment* floor0_segment = nullptr;
+	for (size_t i = 0; i < segments.len(); i++) {
+		const Segment* this_segment = segments.peekN(i);
+		if (!this_segment) {
+			break;
+		}
+
+		if (this_segment->dest.cave == current_dest.cave) {
+			if (this_segment->dest.area == current_dest.area && this_segment->dest.sublevel == 0) {
+				floor0_segment = this_segment;
+				break;
+			}
+		} else {
+			break;
+		}
+	}
+
+	if (!floor0_segment) {
+		floor0_segment = current_segment;
+	}
+
+	WarpDestination floor0_dest = floor0_segment->dest;
+	floor0_dest.use_set_seed    = false;
+	if (floor0_dest.sublevel != 0) {
+		floor0_dest.sublevel = 0;
+		// If we don't find history for floor 0 in this cave, get the recommended preset for it.
+		// TODO: currently assumes the PoD preset. Adjust to reflect AT in the future
+		PresetCategory cat = PoD;
+		if (floor0_segment->preset && floor0_segment->preset->category != Generated) {
+			cat = floor0_segment->preset->category;
+		}
+		p2gz->warp->set_dest(floor0_dest);
+		p2gz->warp->set_preset(p2gz->preset_mgr->suggested_preset(floor0_dest, cat), PS_Suggested);
+	} else {
+		p2gz->warp->set_dest(floor0_dest);
+		p2gz->warp->set_preset(floor0_segment->preset, PS_Generated);
+	}
+
+	p2gz->warp->do_warp();
+	entering_next_segment = false;
+}
+
+void SegmentHistory::update()
+{
+	const u32 btn = p2gz->controller->getButtonDown();
 	if (entering_next_segment || p2gz->menu->is_root_open()) {
 		// Retry same sublevel, random seed
 		if (btn & Controller::PRESS_X) {
-			current_dest.use_set_seed = false;
-
-			p2gz->warp->set_dest(current_dest);
-			p2gz->warp->set_preset(current_segment->preset, PS_Generated);
-			p2gz->warp->do_warp();
-
-			entering_next_segment = false;
+			retry_segment();
 			return;
 		}
 
 		// Retry same sublevel, same seed
 		if (btn & Controller::PRESS_Y && in_cave_play()) {
-			current_dest.use_set_seed = true;
-
-			p2gz->warp->set_dest(current_dest);
-			p2gz->warp->set_preset(current_segment->preset, PS_Generated);
-			p2gz->warp->do_warp();
-
-			entering_next_segment = false;
+			retry_same_seed();
 			return;
 		}
 	}
@@ -83,51 +152,7 @@ void SegmentHistory::update()
 	if (entering_next_segment && in_cave_play()) {
 		// Restart cave from the beginning
 		if (btn & Controller::PRESS_L) {
-			if (segments.len() == 0) {
-				return;
-			}
-
-			// Find segment for the first floor of the cave
-			const Segment* floor0_segment = nullptr;
-			for (size_t i = 0; i < segments.len(); i++) {
-				const Segment* this_segment = segments.peekN(i);
-				if (!this_segment) {
-					break;
-				}
-
-				if (this_segment->dest.cave == current_dest.cave) {
-					if (this_segment->dest.area == current_dest.area && this_segment->dest.sublevel == 0) {
-						floor0_segment = this_segment;
-						break;
-					}
-				} else {
-					break;
-				}
-			}
-
-			if (!floor0_segment) {
-				floor0_segment = current_segment;
-			}
-
-			WarpDestination floor0_dest = floor0_segment->dest;
-			floor0_dest.use_set_seed    = false;
-			if (floor0_dest.sublevel != 0) {
-				floor0_dest.sublevel = 0;
-				// If we don't find history for floor 0 in this cave, get the recommended preset for it.
-				// TODO: currently assumes the PoD preset. Adjust to reflect AT in the future
-				PresetCategory cat = PoD;
-				if (floor0_segment->preset && floor0_segment->preset->category != Generated) {
-					cat = floor0_segment->preset->category;
-				}
-				p2gz->warp->set_dest(floor0_dest);
-				p2gz->warp->set_preset(p2gz->preset_mgr->suggested_preset(floor0_dest, cat), PS_Suggested);
-			} else {
-				p2gz->warp->set_dest(floor0_dest);
-				p2gz->warp->set_preset(floor0_segment->preset, PS_Generated);
-			}
-
-			p2gz->warp->do_warp();
-			entering_next_segment = false;
+			retry_cave();
 			return;
 		}
 	}

--- a/src/p2gz/test/create_all_tests.cpp
+++ b/src/p2gz/test/create_all_tests.cpp
@@ -40,6 +40,23 @@ void expect_captain_hp(f32 expected)
 	GZEXPECT(absF(actual - expected) < 0.1f, "Captain health is incorrect");
 }
 
+#define ASSERT_LOCATION(area, cave, sublevel) (new FreeBoundDelegate3<int, int, int>(&assert_location, area, cave, sublevel))
+void assert_location(int area, int cave, int sublevel)
+{
+	Game::SingleGameSection* game = static_cast<Game::SingleGameSection*>(Game::gameSystem->mSection);
+	OSReport("current area = %d\n", game->mCurrentCourseInfo->mCourseIndex);
+	GZASSERTLINE(game->mCurrentCourseInfo->mCourseIndex == area);
+
+	Game::CourseInfo* dst_course_info = Game::stageList->getCourseInfo(area);
+	ID32 caveID(dst_course_info->getCaveID_FromIndex(cave - 1));
+
+	OSReport("current cave ID = %d\n", game->mCaveID.getID());
+	GZASSERTLINE(game->mCaveID.getID() == caveID.getID());
+
+	OSReport("current floor = %d\n", game->mCurrentFloor);
+	GZASSERTLINE(game->mCurrentFloor == sublevel - 1);
+}
+
 void assert_has_cos_upgrades()
 {
 	GZASSERTLINE(Game::playData->mOlimarData->hasItem(Game::OlimarData::ODII_SphericalAtlas));
@@ -61,6 +78,15 @@ void TestRunner::create_all_tests()
         PRESS(PAD_BUTTON_UP)
         PRESS(PAD_BUTTON_A)
         SKIP_LOAD_CUTSCENES
+    ));
+    tests.push(TEST("sublevel retry works as expected",
+        DO_ACTION(WARP_TO_DEST(1, 1, 1))
+        SKIP_LOAD_CUTSCENES
+        DO_ACTION(WARP_TO_DEST(1, 1, 2))
+        SKIP_LOAD_CUTSCENES
+        RETRY_SEGMENT
+        SKIP_LOAD_CUTSCENES
+        DO_ACTION(ASSERT_LOCATION(1, 1, 2))
     ));
 	tests.push(TEST("warp to ww",
         DBL_DPAD_L

--- a/src/p2gz/warp.cpp
+++ b/src/p2gz/warp.cpp
@@ -306,14 +306,16 @@ void Warp::reset_cave_treasure_collections(Game::SingleGameSection* game)
 
 	for (int i = 0; i < counter_otakara.getNumKinds(); i++) {
 		Game::playData->losePellet(pelmgr, i);
-		counter_otakara(i) = 0;
+		Game::playData->mCaveCropMemory->mOtakara(i) = 0;
+		counter_otakara(i)                           = 0;
 	}
 
 	pelmgr                          = Game::PelletItem::mgr;
 	Game::KindCounter& counter_item = mem->mItem;
 	for (int i = 0; i < counter_item.getNumKinds(); i++) {
 		Game::playData->losePellet(pelmgr, i);
-		counter_item(i) = 0;
+		Game::playData->mCaveCropMemory->mItem(i) = 0;
+		counter_item(i)                           = 0;
 	}
 }
 
@@ -374,6 +376,7 @@ void Warp::warp_to_cave(Game::SingleGameSection* game)
 	game->mCaveID                               = caveID;
 	game->mCaveIndex                            = caveID.getID();
 	game->mCurrentFloor                         = dest.sublevel;
+	Game::playData->mCaveSaveData.mCurrentFloor = dest.sublevel;
 	Game::playData->mCaveSaveData.mActiveNaviID = active_captain;
 	strcpy(game->mCaveFilename, cave->mCaveFilename);
 

--- a/src/plugProjectKandoU/singleGS_Load.cpp
+++ b/src/plugProjectKandoU/singleGS_Load.cpp
@@ -128,7 +128,7 @@ void LoadState::init(SingleGameSection* game, StateArg* arg)
 	} else {
 		ID32 cave_id(game->getCaveID());
 		dest.cave     = game->mCurrentCourseInfo->getCaveIndex_FromID(cave_id) + 1;
-		dest.sublevel = game->mCurrentFloor;
+		dest.sublevel = Game::playData->mCaveSaveData.mCurrentFloor;
 	}
 
 	segment->dest = dest;


### PR DESCRIPTION
- Resets cave crop data when warping or retrying to avoid getting cave completions at incorrect times
- Fixes a bug introduced in https://github.com/p2gz/p2gz/pull/197 (probably) where sublevel retry would bring you to the previous floor sometimes

~~There's some overlap in this PR with https://github.com/p2gz/p2gz/pull/222 for test code. I'll sort it out in the rebase when one of them gets merged.~~ The rebase has been sorted