### PR TITLE
Fix: drastically cut DOL size by un-inlining iterator functions

### DIFF
--- a/include/Iterator.h
+++ b/include/Iterator.h
@@ -97,7 +97,9 @@ struct Iterator {
 	 *
 	 * @return Reference to the incremented iterator.
 	 */
-	inline Iterator<T>& operator++()
+	// @P2GZ: un-inline iterator functions
+	// inline Iterator<T>& operator++()
+	Iterator<T>& operator++()
 	{
 		FORCE_DONT_INLINE; // @P2GZ: un-inline iterator functions
 		mIndex = mContainer->getNext(mIndex);
@@ -109,7 +111,9 @@ struct Iterator {
 	 *
 	 * @return true if the current element satisfies the condition, false otherwise.
 	 */
-	inline bool satisfy()
+	// @P2GZ: un-inline iterator functions
+	// inline bool satisfy()
+	bool satisfy()
 	{
 		FORCE_DONT_INLINE; // @P2GZ: un-inline iterator functions
 		return mCondition->satisfy(mContainer->get(mIndex));


### PR DESCRIPTION
Cuts the size of the DOL by a fair chunk (without changing or removing any functionality) by forcing `Iterator` functions to not inline. This creates about an extra ~110KB of space in the game heap, which we could siphon to the system heap for our purposes if we want to down the line. 

Credit to @PikHacker for the idea - thank you!