### PR TITLE
Fix crash caused by deallocating a shared Preset

### DIFF
--- a/include/p2gz/SegmentHistory.h
+++ b/include/p2gz/SegmentHistory.h
@@ -15,7 +15,13 @@ public:
 		dest   = WarpDestination();
 	}
 
-	~Segment() { delete preset; }
+	~Segment()
+	{
+		// We cannot delete preset even if it's generated because it's now
+		// potentially shared between more than one segment due to retries.
+		// TODO: can we store generated presets with a ref count or something
+		// so we can free them eventually?
+	}
 
 	Preset* preset;
 	WarpDestination dest;

--- a/include/p2gz/gzCollections.h
+++ b/include/p2gz/gzCollections.h
@@ -40,7 +40,7 @@ struct RingBuffer {
 	{
 		GZASSERTLINE(mLen > 0);
 		GZASSERTLINE(n < mLen);
-		return mBuf[(mBufHead + N - n - 1) % N];
+		return mBuf[(mBufHead + N - n) % N];
 	}
 
 	bool atCapacity() { return mLen == N; }
@@ -49,7 +49,9 @@ struct RingBuffer {
 	T getLast()
 	{
 		GZASSERTLINE(mLen == N);
-		return peekN(N - 1);
+		// the oldest thing is the thing at the current head that will be overwritten
+		// on the next call to push.
+		return peekN(0);
 	}
 
 private:

--- a/src/p2gz/segmentHistory.cpp
+++ b/src/p2gz/segmentHistory.cpp
@@ -197,13 +197,13 @@ Segment* SegmentHistory::start_segment()
 {
 	JKRHeap* prev_heap = sys->mSysHeap->becomeCurrentHeap();
 
-	Segment* segment = new Segment();
-	segment->preset  = nullptr; // pikis are not alive when this is run. it will be set later
-
 	if (segments.atCapacity()) {
 		Segment* oldestSegment = segments.getLast();
 		delete oldestSegment;
 	}
+
+	Segment* segment = new Segment();
+	segment->preset  = nullptr; // pikis are not alive when this is run. it will be set later
 	segments.push(segment);
 
 	prev_heap->becomeCurrentHeap();


### PR DESCRIPTION
We now share presets between segments on retry, but when the ring buffer of segments wrapped around it was still trying to free the preset owned by the segment. This caused a use-after-free when retrying the same sublevel 33 times. This has been fixed by correcting some of the RingBuffer logic and by not freeing presets when destructing Segments. A memory leak is technically introduced by this PR, but it's not one that should manifest unless a user plays an extremely long session.