### PR TITLE
Fix seed input and retry logic

### DIFF
--- a/include/p2gz/SegmentHistory.h
+++ b/include/p2gz/SegmentHistory.h
@@ -13,6 +13,7 @@ public:
 	{
 		preset = nullptr;
 		dest   = WarpDestination();
+		use_set_seed = false;
 	}
 
 	~Segment()
@@ -25,6 +26,8 @@ public:
 
 	Preset* preset;
 	WarpDestination dest;
+	u32 seed;
+	bool use_set_seed;
 };
 
 struct SegmentHistory {

--- a/include/p2gz/gzmenu.h
+++ b/include/p2gz/gzmenu.h
@@ -213,6 +213,7 @@ public:
 	bool is_selected();
 	u32 get_selected_val();
 	void set_selected_val(u32);
+	void set_unselected();
 
 private:
 	HexKeypad* keypad;
@@ -370,17 +371,17 @@ public:
 		unselected = false;
 	}
 	bool is_unselected() { return unselected; }
+	bool unselected;
 
 private:
 	void select_digit(u32);
 	void submit();
-	void set_unselected();
+	void set_unselected_and_pop();
 
 	GridMenu* keypad;
 	u32 value;
 	u8 cur_digit;
 	const char* cancel_text;
-	bool unselected;
 
 	IDelegate1<u32>* on_selected;
 	IDelegate* on_unselected;

--- a/include/p2gz/warp.h
+++ b/include/p2gz/warp.h
@@ -19,17 +19,12 @@ public:
 		cave         = 0;
 		sublevel     = 0;
 		day          = 2;
-		use_set_seed = false;
 	}
-
-	~WarpDestination() { }
 
 	u8 area;
 	u8 cave;
 	u8 sublevel;
 	u8 day;
-	u32 seed;
-	bool use_set_seed;
 
 	// whether to do the falling animation or the ship fly-in animation when warping to AG
 	u8 enter_area_type;
@@ -59,14 +54,14 @@ public:
 	void set_allow_zero_piki_in_caves(bool allow) { allow_zero_pikmin_in_caves = allow; }
 	void set_enter_area_type(size_t type) { dest.enter_area_type = type; }
 	void set_active_captain(size_t captain) { active_captain = captain; }
+
 	void set_seed(u32);
-	void set_random_seed() { dest.use_set_seed = false; }
+	void set_random_seed();
+	bool using_set_seed() { return use_set_seed; }
+	u32 get_seed() { return seed; }
 
 	void set_preset(Preset* preset, int preset_status);
 	Preset* get_preset() { return preset; }
-
-	bool using_set_seed() { return dest.use_set_seed; }
-	u32 get_seed() { return dest.seed; }
 
 	void do_warp();
 	void do_post_warp();
@@ -110,6 +105,9 @@ private:
 	RadioMenuOption* enter_area_type_opt;
 	HexInputOption* seed_opt;
 	PresetMenuOption* preset_opt;
+
+	u32 seed;
+	bool use_set_seed;
 
 	Game::ItemCave::Item* cave;
 

--- a/src/p2gz/empressTrainer.cpp
+++ b/src/p2gz/empressTrainer.cpp
@@ -34,7 +34,6 @@ void EmpressTrainer::start()
 	dest.area         = 1;
 	dest.cave         = 1;
 	dest.sublevel     = 4;
-	dest.use_set_seed = false;
 	Preset* preset    = p2gz->preset_mgr->find("HoB5", PoD);
 
 	p2gz->warp->set_dest(dest);
@@ -123,9 +122,7 @@ void EmpressTrainer::update()
 		const Segment* current_segment = p2gz->segment_history->cur_segment();
 		GZASSERTLINE(current_segment);
 
-		WarpDestination current_dest = current_segment->dest;
-		current_dest.use_set_seed    = false;
-		p2gz->warp->set_dest(current_dest);
+		p2gz->warp->set_dest(current_segment->dest);
 		p2gz->warp->set_preset(current_segment->preset, PS_Generated);
 		p2gz->warp->do_warp();
 	}

--- a/src/p2gz/gzmenu.cpp
+++ b/src/p2gz/gzmenu.cpp
@@ -740,7 +740,7 @@ HexKeypad::HexKeypad(const char* title_, const char* cancel_text_, IDelegate1<u3
 		->end_row()
 		->push_to_row(new PerformActionMenuOption("submit", new Delegate<HexKeypad>(this, &submit)))
 		->end_row()
-		->push_to_row(new PerformActionMenuOption(cancel_text, new Delegate<HexKeypad>(this, &set_unselected)));
+		->push_to_row(new PerformActionMenuOption(cancel_text, new Delegate<HexKeypad>(this, &set_unselected_and_pop)));
 	// clang-format on
 }
 
@@ -758,7 +758,12 @@ HexKeypad::~HexKeypad()
 void HexKeypad::select_digit(u32 digit)
 {
 	unselected = false;
-	value |= digit << ((7 - cur_digit) * 4);
+
+	const u32 shift_amt   = (7 - cur_digit) * 4; // digit 0 = most significant bit; shift 4 bits for each hex char
+	const u32 clear_digit = (0xFFFFFFF0 << shift_amt) | (0xFFFFFFF0 >> (32 - shift_amt)); // bit rotate
+	value &= clear_digit;
+	value |= digit << shift_amt;
+
 	if (cur_digit < 7) {
 		cur_digit += 1;
 	}
@@ -767,7 +772,7 @@ void HexKeypad::select_digit(u32 digit)
 	}
 }
 
-void HexKeypad::set_unselected()
+void HexKeypad::set_unselected_and_pop()
 {
 	unselected = true;
 	if (on_unselected) {
@@ -1359,6 +1364,11 @@ u32 HexInputOption::get_selected_val()
 void HexInputOption::set_selected_val(u32 val)
 {
 	keypad->set_value(val);
+}
+
+void HexInputOption::set_unselected()
+{
+	keypad->unselected = true;
 }
 
 DecimalInputOption::DecimalInputOption(const char* title_, IDelegate1<u32>* on_selected, IDelegate* on_opened, const char* image_name_,

--- a/src/p2gz/segmentHistory.cpp
+++ b/src/p2gz/segmentHistory.cpp
@@ -50,10 +50,8 @@ void SegmentHistory::retry_segment()
 	if (!current_segment) {
 		return;
 	}
-	WarpDestination current_dest = current_segment->dest;
 
-	current_dest.use_set_seed = false;
-	p2gz->warp->set_dest(current_dest);
+	p2gz->warp->set_dest(current_segment->dest);
 	p2gz->warp->set_preset(current_segment->preset, PS_Generated);
 	p2gz->warp->do_warp();
 
@@ -66,11 +64,9 @@ void SegmentHistory::retry_same_seed()
 	if (!current_segment) {
 		return;
 	}
-	WarpDestination current_dest = current_segment->dest;
 
-	current_dest.use_set_seed = true;
-
-	p2gz->warp->set_dest(current_dest);
+	p2gz->warp->set_dest(current_segment->dest);
+	p2gz->warp->set_seed(current_segment->seed);
 	p2gz->warp->set_preset(current_segment->preset, PS_Generated);
 	p2gz->warp->do_warp();
 
@@ -112,7 +108,6 @@ void SegmentHistory::retry_cave()
 	}
 
 	WarpDestination floor0_dest = floor0_segment->dest;
-	floor0_dest.use_set_seed    = false;
 	if (floor0_dest.sublevel != 0) {
 		floor0_dest.sublevel = 0;
 		// If we don't find history for floor 0 in this cave, get the recommended preset for it.
@@ -179,7 +174,7 @@ void SegmentHistory::draw_cur_seed()
 	if (!seg) {
 		return;
 	}
-	const u32 seed = seg->dest.seed;
+	const u32 seed = seg->seed;
 
 	J2DPrint j2d = init_j2d();
 

--- a/src/p2gz/warp.cpp
+++ b/src/p2gz/warp.cpp
@@ -66,6 +66,7 @@ Warp::Warp()
 	cave                       = nullptr;
 	lockout_frames             = 0;
 	active_captain             = NAVIID_Olimar;
+	use_set_seed               = false;
 }
 
 void Warp::init()
@@ -161,11 +162,17 @@ void Warp::set_warp_sublevel(s32 sublevel)
 	update_preset_opt();
 }
 
-void Warp::set_seed(u32 seed)
+void Warp::set_seed(u32 seed_)
 {
-	dest.use_set_seed = true;
-	dest.seed         = seed;
+	use_set_seed = true;
+	seed         = seed_;
 	seed_opt->set_selected_val(seed);
+}
+
+void Warp::set_random_seed()
+{
+	use_set_seed = false;
+	seed_opt->set_unselected();
 }
 
 void Warp::update_cave_opt()
@@ -507,8 +514,12 @@ void Warp::do_post_warp()
 
 	if (needs_post_load_action && preset) {
 		preset->apply_post_load();
-		preset_status     = PS_Stale;
-		dest.use_set_seed = false;
+		preset_status = PS_Stale;
 	}
+
+	if (use_set_seed) {
+		set_random_seed();
+	}
+
 	needs_post_load_action = false;
 }

--- a/src/plugProjectKandoU/singleGS_Load.cpp
+++ b/src/plugProjectKandoU/singleGS_Load.cpp
@@ -106,8 +106,14 @@ void LoadState::init(SingleGameSection* game, StateArg* arg)
 	// Start new segment on any loading screen
 	gz::Segment* segment = p2gz->segment_history->start_segment();
 	gz::Preset* preset   = p2gz->warp->get_preset();
-	if (p2gz->warp->warping && preset) {
-		segment->preset = preset;
+	if (p2gz->warp->warping) {
+		if (preset) {
+			segment->preset = preset;
+		}
+		if (p2gz->warp->using_set_seed()) {
+			segment->seed         = p2gz->warp->get_seed();
+			segment->use_set_seed = true;
+		}
 	} else {
 		segment->preset      = p2gz->preset_mgr->create();
 		segment->preset->day = Game::gameSystem->mTimeMgr->mDayCount;
@@ -116,7 +122,6 @@ void LoadState::init(SingleGameSection* game, StateArg* arg)
 	gz::WarpDestination dest;
 	dest.area         = game->mCurrentCourseInfo->mCourseIndex;
 	dest.day          = Game::gameSystem->mTimeMgr->mDayCount;
-	dest.use_set_seed = false;
 
 	if (!(mIsCaveLoad || mIsCaveDeeper)) {
 		dest.cave = 0;

--- a/src/plugProjectNishimuraU/MapCreator.cpp
+++ b/src/plugProjectNishimuraU/MapCreator.cpp
@@ -31,8 +31,14 @@ void RoomMapMgr::nishimuraCreateRandomMap(MapUnitInterface* muiArray, int p2, Ca
 	// @P2GZ - record seed for this sublevel
 	p2gz->segment_history->started_creating_map = true;
 	gz::Segment* segment                        = p2gz->segment_history->cur_segment();
-	segment->dest.seed                          = get_rng_seed();
-	segment->dest.use_set_seed                  = true;
+	GZASSERTLINE(segment);
+	if (segment->use_set_seed) {
+		// seed was set via warp menu - apply it here
+		srand(segment->seed);
+	} else {
+		// seed was not set - record it in case we want to retry
+		segment->seed = get_rng_seed();
+	}
 
 	Cave::randMapMgr = new Cave::RandMapMgr(isVersusHiba);
 	Cave::randMapMgr->loadResource(muiArray, p2, floorInfo, lastFloor, unit);


### PR DESCRIPTION
- Fixes incorrect logic in the seed keypad where lower numbers would not overwrite higher numbers, etc.
- Fixes https://github.com/p2gz/p2gz/issues/240
- Moves seeds into `Segment` rather than `WarpDestination` to prepare for future enhancements