### PR TITLE
Add "eggs always drop mitites" setting

### DIFF
--- a/include/p2gz/DropEditor.h
+++ b/include/p2gz/DropEditor.h
@@ -1,0 +1,25 @@
+#ifndef _GZ_DROP_EDITOR_H
+#define _GZ_DROP_EDITOR_H
+
+#include <types.h>
+
+namespace gz {
+
+// structure for editing enemy drops - currently just eggs, but could force spray drops or specific pellets later
+struct DropEditor {
+public:
+	DropEditor()
+	    : enabled_egg_always_mitites(false)
+	{
+	}
+
+	void set_egg_always_mitites(bool enabled) { enabled_egg_always_mitites = enabled; }
+	bool is_egg_always_mitites() { return enabled_egg_always_mitites; }
+
+private:
+	bool enabled_egg_always_mitites;
+};
+
+} // namespace gz
+
+#endif

--- a/include/p2gz/p2gz.h
+++ b/include/p2gz/p2gz.h
@@ -31,6 +31,7 @@
 #include <p2gz/Test.h>
 #include <p2gz/Trainers.h>
 #include <p2gz/OnionEditor.h>
+#include <p2gz/DropEditor.h>
 
 /*!!! VERSION NUMBER - TO BE UPDATED EACH RELEASE !!!*/
 #define P2GZ_VERSION "alpha5"
@@ -80,6 +81,7 @@ public:
 	gz::Localization* localization_op;
 	gz::EmpressTrainer* empress_trainer;
 	gz::OnionEditor* onion_editor;
+	gz::DropEditor* drop_editor;
 
 	gz::test::TestRunner* test_runner;
 

--- a/src/p2gz/gzmenu.cpp
+++ b/src/p2gz/gzmenu.cpp
@@ -138,6 +138,7 @@ void GZMenu::init_menu()
             ->push(new ToggleMenuOption("skippable cutscenes", true, new Delegate1<SkippableCutscenes, bool>(p2gz->skippable_cutscenes, &SkippableCutscenes::toggle_skippable)))
             ->push(new ToggleMenuOption("skip save prompts", true, new Delegate1<SkipSave, bool>(p2gz->skip_save, &SkipSave::toggle_save_skip)))
 			->push(new ToggleMenuOption("allow 0 pikmin in caves", true, new Delegate1<Warp, bool>(p2gz->warp, &Warp::set_allow_zero_piki_in_caves)))
+			->push(new ToggleMenuOption("eggs always drop mitites", false, new Delegate1<DropEditor, bool>(p2gz->drop_editor, &DropEditor::set_egg_always_mitites)))
 			->push(new PerformActionMenuOption("increase text size", new Delegate<GZMenu>(p2gz->menu, &GZMenu::increase_text_size)))
             ->push(new PerformActionMenuOption("decrease text size", new Delegate<GZMenu>(p2gz->menu, &GZMenu::decrease_text_size)))
         ));

--- a/src/p2gz/p2gz.cpp
+++ b/src/p2gz/p2gz.cpp
@@ -63,6 +63,7 @@ P2GZ::P2GZ()
 	onion_editor         = new OnionEditor();
 	localization_op      = new Localization();
 	empress_trainer      = new EmpressTrainer();
+	drop_editor          = new DropEditor();
 
 #ifdef GZ_TEST
 	test_runner = new test::TestRunner();

--- a/src/plugProjectMorimuraU/egg.cpp
+++ b/src/plugProjectMorimuraU/egg.cpp
@@ -6,6 +6,7 @@
 #include "Game/generalEnemyMgr.h"
 #include "Game/Entities/PelletNumber.h"
 #include "Dolphin/rand.h"
+#include <p2gz/p2gz.h>
 
 namespace Game {
 namespace Egg {
@@ -286,6 +287,11 @@ void Obj::genItem()
 		} else if (dropType == EGGDROP_Bitter && !playData->isDemoFlag(DEMO_First_Bitter_Spray_Made)) {
 			dropType = EGGDROP_SingleNectar;
 		}
+	}
+
+	// @P2GZ: eggs always drop mitites setting
+	if (p2gz->drop_editor->is_egg_always_mitites()) {
+		dropType = EGGDROP_Mitites;
 	}
 
 	mititeGroup = nullptr;


### PR DESCRIPTION
Adds a toggle option under settings to make all eggs (including freestanding, falling in alcoves, connected to honeywisps, etc) drop mitites on breaking. Should be helpful to practice Day 4 and enter HoB with mitite drops, either reacting to bad RNG or for exploring routing variations. 