### PR TITLE
Add Day 2 preset

### DIFF
--- a/assets/files/presets/pod/day1.txt
+++ b/assets/files/presets/pod/day1.txt
@@ -19,30 +19,30 @@ PoD 	# category
 0 	# num flattened bags
 0 	# plugs destroyed
 15 	# num enemy spawns
-	1 	-1153.00 	47.00 	2231.00  2		# dwarf bulborb on manhole cover
-	1	-585.96		0.00	   2782.99	2		# dwarf bulborb in landing site
-	0	52.87 		9.17 	   3055.3 	1		# 5 pellet behind ship
-	0	-21.92 		0.00 	   2870.73	1		# 1 pellets behind red onion
-	37	424.30		125.00 	2897.12	1		# eggs behind ship
-	0	-400.92  	0.00 	   2646.80	1		# 1 pellet next to red onion
-	0	-259.88 	   50.00 	2476.48	1		# 10 pellet on ledge
-	0	-584.42 	   0.00 	   3160.87	1		# 1 pellet near blue onion spot
-	0	-1342.39 	4.20 	   2825.76	1		# left 5 pellet in bag area
-	0	-1340.81 	0.00 	   2606.4	1		# right 5 pellet in bag area
-   0  -524.84     60.00    3718.10  2     # left 1 pellet in louie area
-   0  -113.63     60.00    3915.37  2     # middle 1 pellet in louie area
-   0  -221.42     60.00    4188.80  2     # right 1 pellet in louie area
-   0  -14.46      100.00   3721.81  2     # left ledge 1 pellet in louie area
-   0  62.66       100.00   3768.90  2     # right ledge 1 pellet in louie area
+	1 	-1153.00 	47.00 		2231.00  2		# dwarf bulborb on manhole cover
+	1	-585.96		0.00		2782.99  2		# dwarf bulborb in landing site
+	0	52.87 		9.17 		3055.3 	 1		# 5 pellet behind ship
+	0	-21.92 		0.00 		2870.73	 1		# 1 pellets behind red onion
+	37	424.30		125.00 		2897.12	 1		# eggs behind ship
+	0	-400.92  	0.00 		2646.80	 1		# 1 pellet next to red onion
+	0	-259.88 	50.00 		2476.48	 1		# 10 pellet on ledge
+	0	-584.42 	0.00 		3160.87	 1		# 1 pellet near blue onion spot
+	0	-1342.39 	4.20 	   	2825.76	 1		# left 5 pellet in bag area
+	0	-1340.81 	0.00 	   	2606.4	 1		# right 5 pellet in bag area
+    0  -524.84     	60.00    	3718.10  2      # left 1 pellet in louie area
+    0  -113.63     	60.00    	3915.37  2      # middle 1 pellet in louie area
+    0  -221.42     	60.00    	4188.80  2      # right 1 pellet in louie area
+    0  -14.46       100.00   	3721.81  2      # left ledge 1 pellet in louie area
+    0  62.66        100.00   	3768.90  2      # right ledge 1 pellet in louie area
 10 	# num treasure spawn overrides
-   42 	2 	# Sunseed Berry
+    42 		2 	# Sunseed Berry
 	130 	2 	# Pilgrim Bulb
-	11 	2 	# Geographic Projection
+	11 		2 	# Geographic Projection
 	155 	2 	# Chance Totem
 	173 	2 	# Healing Cask
 	142 	2 	# Courage Reactor
-	62 	2 	# Pink Menace
-	87 	2 	# Utter Scrap
+	62 		2 	# Pink Menace
+	87 		2 	# Utter Scrap
 	157 	2 	# Spiny Alien Treat
-	47 	2 	# Fossilized Ursidae
+	47 		2 	# Fossilized Ursidae
 0	# bridge glitch active

--- a/assets/files/presets/pod/day2.txt
+++ b/assets/files/presets/pod/day2.txt
@@ -1,0 +1,47 @@
+Day_2 	# preset name (USE UNDERSCORES INSTEAD OF SPACES)
+PoD 	# category
+#  bl bb bf rl rb rf yl yb yf pl pb pf wl wb wf cl cb cf
+   0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  	# pikmin
+   0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  	# onions
+0 	# num sprouts
+0 0 	# bitters, bitters unlocked
+0 0 	# spicies, spicies unlocked
+7.000000 	# time of day
+2 	# day number
+-1 	# pokos (-1 if not applied)
+1 	# enter kind (FromCave = 0, FromMap = 1)
+0 	# num upgrades
+4 	# num demo flags
+	0 	# DEMO_Pluck_First_Pikmin
+	9 	# DEMO_Find_Spiderwort_Mold
+	31 	# DEMO_Day_One_Start
+	35 	# DEMO_Meet_Red_Pikmin
+0 	# num EK cutscenes
+0 	# num cave cutscene flags
+0 	# num destroyed gates
+0 	# num finished bridges
+0 	# num flattened bags
+0 	# plugs destroyed
+10 	# num enemy spawns
+	1 	-1153.00	47.00	2231.00 2		# dwarf bulborb on manhole cover
+	1	-585.96		0.00	2782.99	1		# dwarf bulborb in landing site
+	0	52.87		9.17	3055.3 	1		# 5 pellet behind ship
+	0	-21.92		0.00	2870.73	2		# 1 pellets behind red onion
+	37	424.30		125.00	2897.12	1		# eggs behind ship
+	0	-400.92		0.00	2646.80	1		# 1 pellet next to red onion
+	0	-259.88		50.00	2476.48	1		# 10 pellet on ledge
+	0	-584.42		0.00	3160.87	1		# 1 pellet near blue onion spot
+	0	-1342.39	4.20	2825.76	1		# left 5 pellet in bag area
+	0	-1340.81	0.00	2606.4	1		# right 5 pellet in bag area
+10 	# num treasure spawn overrides
+	42 		2 	# Sunseed Berry
+	130 	2 	# Pilgrim Bulb
+	11 		2 	# Geographic Projection
+	155 	2 	# Chance Totem
+	173 	2 	# Healing Cask
+	142 	2 	# Courage Reactor
+	62 		2 	# Pink Menace
+	87 		2 	# Utter Scrap
+	157 	2 	# Spiny Alien Treat
+	47 		2 	# Fossilized Ursidae
+1	# bridge glitch active

--- a/src/p2gz/preset.cpp
+++ b/src/p2gz/preset.cpp
@@ -291,6 +291,13 @@ void Preset::apply_post_load()
 		}
 	}
 
+	// Carve out for Day 2 presets. Makes the onion emit a single seed instead of playing the extinction cutscene immediately.
+	if (in_above_ground_play() && squad.getTotalSum() == 0 && onion_pikis.getTotalSum() == 0 && day > 1) {
+		p2gz->squad_editor->set_demo_flags_for_color(Game::Red);
+		Game::SingleGame::GameState* game_state = static_cast<Game::SingleGame::GameState*>(get_SGS()->mCurrentState);
+		game_state->mIsPostExtinct              = true;
+	}
+
 	// Force spawn or despawn treasures
 	FOREACH_NODE(Game::Generator, Game::generatorCache->getFirstGenerator(), gen)
 	{


### PR DESCRIPTION
Adds a preset for Day 2. Handles the extinction cutscene properly, but the preset is unusable for normal practice because the bulborb doesn't respawn correctly even though the spawn override is present due to the generator being missing on subsequent loads. Should be solved by the generator work.