### PR TITLE
Fix more preset-related crashes/problems

### DIFF
--- a/include/p2gz/SegmentHistory.h
+++ b/include/p2gz/SegmentHistory.h
@@ -11,8 +11,8 @@ struct Segment {
 public:
 	Segment()
 	{
-		preset = nullptr;
-		dest   = WarpDestination();
+		preset       = nullptr;
+		dest         = WarpDestination();
 		use_set_seed = false;
 	}
 
@@ -32,6 +32,13 @@ public:
 
 struct SegmentHistory {
 public:
+	SegmentHistory()
+	{
+		started_creating_map  = false;
+		entering_next_segment = false;
+		cave_floor0_preset    = nullptr;
+	}
+
 	void draw_2d();
 	void update();
 
@@ -51,6 +58,8 @@ private:
 	void draw_reset_controls(bool draw_cave_retry);
 
 	RingBuffer<32, Segment*> segments;
+	Preset* cave_floor0_preset;       // The current cave's floor-0 preset, ref'd so it survives ring buffer clearing
+	WarpDestination cave_floor0_dest; // area+cave the pinned preset belongs to
 };
 
 }; // namespace gz

--- a/include/p2gz/gzCollections.h
+++ b/include/p2gz/gzCollections.h
@@ -21,6 +21,8 @@ struct RingBuffer {
 		mLen     = 0;
 	}
 
+	~RingBuffer() { delete[] mBuf; }
+
 	size_t len() { return mLen; }
 
 	void push(T val)
@@ -49,16 +51,19 @@ struct RingBuffer {
 
 	bool atCapacity() { return mLen == N; }
 
-	/// Gets the oldest thing in the ring buffer. Only save to call if `atCapacity()` returns true.
+	/// Gets the oldest entry (the slot the next push() overwrites). Only valid when atCapacity().
 	T getLast()
 	{
 		GZASSERTLINE(mLen == N);
-		// the oldest thing is the thing at the current head that will be overwritten
-		// on the next call to push.
-		return peekN(0);
+		// push() overwrites (mBufHead + 1) % N, which holds the oldest entry == peekN(mLen - 1).
+		return peekN(mLen - 1);
 	}
 
 private:
+	// Non-copyable since we own the mBuf allocation - a shallow copy would double-free on destruction
+	RingBuffer(const RingBuffer&);
+	RingBuffer& operator=(const RingBuffer&);
+
 	size_t mLen;
 	size_t mBufHead;
 	T* mBuf;

--- a/src/p2gz/preset.cpp
+++ b/src/p2gz/preset.cpp
@@ -67,6 +67,8 @@ Preset::Preset()
 	name    = nullptr;
 	preview = nullptr;
 	bridge_glitch_active = true;
+	category             = PoD;  // default to pod so we don't get errors for null presets
+	time                 = 7.0f; // default to start of day
 	squad.clear();
 	onion_pikis.clear();
 }

--- a/src/p2gz/segmentHistory.cpp
+++ b/src/p2gz/segmentHistory.cpp
@@ -20,10 +20,10 @@ void SegmentHistory::draw_2d()
 	}
 	SceneType scene_type = Screen::gGame2DMgr->mScreenMgr->getSceneType();
 
-	bool gz_menu_open = p2gz->menu->is_open();
-	bool is_paused    = Game::gameSystem
-	              && (scene_type == SCENE_PAUSE_MENU_DOUKUTU || scene_type == SCENE_PAUSE_MENU_ITEMS || scene_type == SCENE_PAUSE_MENU_MAP
-	                  || scene_type == SCENE_PAUSE_MENU_CONTROLS);
+	bool gz_menu_open      = p2gz->menu->is_open();
+	bool is_paused         = Game::gameSystem
+	                      && (scene_type == SCENE_PAUSE_MENU_DOUKUTU || scene_type == SCENE_PAUSE_MENU_ITEMS || scene_type == SCENE_PAUSE_MENU_MAP
+	                          || scene_type == SCENE_PAUSE_MENU_CONTROLS);
 	bool is_in_load_screen = scene_type == SCENE_FLOOR && started_creating_map;
 	bool is_paused_in_cave = in_cave_play() && (is_paused || gz_menu_open);
 
@@ -85,7 +85,18 @@ void SegmentHistory::retry_cave()
 		return;
 	}
 
-	// Find segment for the first floor of the cave
+	// Prefer the pinned floor-0 preset for this cave, if it exists
+	if (cave_floor0_preset && cave_floor0_dest.area == current_dest.area && cave_floor0_dest.cave == current_dest.cave) {
+		WarpDestination floor0_dest = current_dest;
+		floor0_dest.sublevel        = 0;
+		p2gz->warp->set_dest(floor0_dest);
+		p2gz->warp->set_preset(cave_floor0_preset, PS_Suggested);
+		p2gz->warp->do_warp();
+		entering_next_segment = false;
+		return;
+	}
+
+	// Otherwise, find the floor-0 segment for the current cave by walking back from the newest segment
 	const Segment* floor0_segment = nullptr;
 	for (size_t i = 0; i < segments.len(); i++) {
 		const Segment* this_segment = segments.peekN(i);
@@ -93,12 +104,13 @@ void SegmentHistory::retry_cave()
 			break;
 		}
 
-		if (this_segment->dest.cave == current_dest.cave) {
-			if (this_segment->dest.area == current_dest.area && this_segment->dest.sublevel == 0) {
-				floor0_segment = this_segment;
-				break;
-			}
-		} else {
+		// Stop once we walk back past the current cave. Need to compare area AND cave or we run into errors, e.g. HoB vs EC
+		if (this_segment->dest.area != current_dest.area || this_segment->dest.cave != current_dest.cave) {
+			break;
+		}
+
+		if (this_segment->dest.sublevel == 0) {
+			floor0_segment = this_segment;
 			break;
 		}
 	}
@@ -110,14 +122,19 @@ void SegmentHistory::retry_cave()
 	WarpDestination floor0_dest = floor0_segment->dest;
 	if (floor0_dest.sublevel != 0) {
 		floor0_dest.sublevel = 0;
-		// If we don't find history for floor 0 in this cave, get the recommended preset for it.
+		// No floor-0 history for this cave; fall back to the recommended preset.
 		// TODO: currently assumes the PoD preset. Adjust to reflect AT in the future
 		PresetCategory cat = PoD;
 		if (floor0_segment->preset) {
 			cat = floor0_segment->preset->category;
 		}
+		PresetPreview* suggested = p2gz->preset_mgr->suggested_preset(floor0_dest, cat);
+		if (!suggested) {
+			// No floor-0 preset for this cave - restart the cave anyway and bring the current squad along
+			OSReport("[P2GZ]: restart cave: no floor-0 preset for this cave, restarting with current squad\n");
+		}
 		p2gz->warp->set_dest(floor0_dest);
-		p2gz->warp->set_preset(p2gz->preset_mgr->suggested_preset(floor0_dest, cat), PS_Suggested);
+		p2gz->warp->set_preset(suggested, PS_Suggested);
 	} else {
 		p2gz->warp->set_dest(floor0_dest);
 		p2gz->warp->set_preset(floor0_segment->preset, PS_Suggested);
@@ -241,4 +258,15 @@ void SegmentHistory::record_squad()
 	segment->preset->squad.clear();
 	segment->preset->onion_pikis.clear();
 	PresetMgr::fill_current_pikis(segment->preset);
+
+	// Pin this cave's floor-0 preset (ref'd) so "restart cave" can still restore the floor-0 squad
+	// even after it's fallen out of the ring buffer
+	if (segment->dest.cave != 0 && segment->dest.sublevel == 0 && cave_floor0_preset != segment->preset) {
+		if (cave_floor0_preset) {
+			cave_floor0_preset->del();
+		}
+		cave_floor0_preset = segment->preset;
+		cave_floor0_preset->ref();
+		cave_floor0_dest = segment->dest;
+	}
 }

--- a/src/p2gz/squadEditor.cpp
+++ b/src/p2gz/squadEditor.cpp
@@ -213,6 +213,12 @@ Game::PikiContainer SquadEditor::get_squad()
 {
 	Game::PikiContainer squad;
 
+	// managers don't exist until a level loads so when the menu is opened
+	// from the file-select screen, there's no squad to count yet. return the default.
+	if (!Game::pikiMgr) {
+		return squad;
+	}
+
 	Iterator<Game::Piki> iterator(Game::pikiMgr);
 	CI_LOOP(iterator)
 	{
@@ -220,12 +226,14 @@ Game::PikiContainer SquadEditor::get_squad()
 		squad.getCount(piki->mPikiKind, piki->mHappaKind)++;
 	}
 
-	Iterator<Game::ItemPikihead::Item> iPikihead = Game::ItemPikihead::mgr;
-	CI_LOOP(iPikihead)
-	{
-		Game::ItemPikihead::Item* item = *iPikihead;
-		if (item->isAlive()) {
-			squad.getCount(item->mColor, item->mHeadType)++;
+	if (Game::ItemPikihead::mgr) {
+		Iterator<Game::ItemPikihead::Item> iPikihead = Game::ItemPikihead::mgr;
+		CI_LOOP(iPikihead)
+		{
+			Game::ItemPikihead::Item* item = *iPikihead;
+			if (item->isAlive()) {
+				squad.getCount(item->mColor, item->mHeadType)++;
+			}
 		}
 	}
 

--- a/src/p2gz/warp.cpp
+++ b/src/p2gz/warp.cpp
@@ -533,9 +533,9 @@ void Warp::do_post_warp()
 		preset_during_warp->del();
 	}
 
-	if (next_preset_p) {
-		next_preset = nullptr;
-	}
+	// Clear both pointers so a stale next_preset can't dangle or report a phantom pending preset
+	next_preset   = nullptr;
+	next_preset_p = nullptr;
 
 	if (use_set_seed) {
 		set_random_seed();

--- a/src/plugProjectKandoU/singleGS_Load.cpp
+++ b/src/plugProjectKandoU/singleGS_Load.cpp
@@ -123,9 +123,10 @@ void LoadState::init(SingleGameSection* game, StateArg* arg)
 	}
 
 	if (!preset) {
-		segment->preset      = p2gz->preset_mgr->create();
-		segment->preset->day = Game::gameSystem->mTimeMgr->mDayCount;
-		dest.day             = Game::gameSystem->mTimeMgr->mDayCount;
+		segment->preset       = p2gz->preset_mgr->create();
+		segment->preset->day  = Game::gameSystem->mTimeMgr->mDayCount;
+		segment->preset->time = Game::gameSystem->mTimeMgr->mCurrentTimeOfDay;
+		dest.day              = Game::gameSystem->mTimeMgr->mDayCount;
 	}
 
 	if (!(mIsCaveLoad || mIsCaveDeeper)) {


### PR DESCRIPTION
Fixes a couple preset-related issues, and fixes some loop-holes we had in the RingBuffer and preset system:

- Fixes #272 due to a ring buffer bug, and also adds some first-cave-floor-specific protections to avoid overwriting it in the ring buffer
- Fixes #231 and a related/new crash where selecting "no preset" from the file select screen crashes the game, by adding some pikimgr-specific protections. eventually, we should add some more presets to the suggestion tree, now that AT presets are done

Note: this had Claude input, but has been de-slopped and triple checked. Has been useful for picking up some picky memory-related issues that otherwise would've been insane to try and track down.