### PR TITLE
collision viewer enhancements

### DIFF
--- a/include/p2gz/CollisionViewer.h
+++ b/include/p2gz/CollisionViewer.h
@@ -3,6 +3,7 @@
 
 #include <Game/mapMgr.h>
 #include <Game/mapParts.h>
+#include <Color4.h>
 #include <Sys/Edge.h>
 #include <Sys/TriIndexList.h>
 #include <Sys/Triangle.h>
@@ -59,7 +60,8 @@ public:
 
 private:
 	bool is_navi_on_triangle(Sys::Triangle*, Sys::Triangle*, Sys::VertexTable*);
-	void draw_triangles(Sys::Sphere&, int mode);
+	Color4 fill_color(Sys::Triangle* tri, Sys::VertexTable* vertTable, u32 q);
+	void emit_fills(Sys::TriangleTable* triTable, Sys::VertexTable* vertTable, bool opaque);
 	bool enabled;
 	bool need_to_reenable;
 	Sys::Sphere olimarSphere;

--- a/include/p2gz/CollisionViewer.h
+++ b/include/p2gz/CollisionViewer.h
@@ -17,8 +17,8 @@ public:
 	{
 		enabled          = false;
 		need_to_reenable = false;
-		olimar_triangle   = nullptr;
-		louie_triangle    = nullptr;
+		olimar_triangle  = nullptr;
+		louie_triangle   = nullptr;
 		tri_visited      = nullptr;
 		tri_alpha        = nullptr;
 		edge_set         = nullptr;
@@ -42,8 +42,6 @@ public:
 private:
 	static bool get_collision_tables(Sys::TriangleTable**, Sys::VertexTable**);
 
-	// working buffers, sized to the loaded map's triangle count and allocated only while
-	// the viewer is enabled (see alloc_buffers / free_buffers)
 	void alloc_buffers(int tris);
 	void free_buffers();
 
@@ -61,11 +59,11 @@ private:
 	Sys::Triangle* olimar_triangle;
 	Sys::Triangle* louie_triangle;
 
-	u8* tri_visited;     // 1 bit per triangle, gather-pass dedup
-	u8* tri_alpha;       // 1 byte per triangle, current fill alpha (eased for fade)
-	u16* gathered_tris;  // the in-range triangles, gathered once per frame
-	u32* edge_set;       // open-addressed set of drawn edges (deduped)
-	int tri_count;       // triangle-table size the buffers are sized to
+	u8* tri_visited;
+	u8* tri_alpha;
+	u16* gathered_tris;
+	u32* edge_set;
+	int tri_count;
 	int gathered_count;
 	int edge_count;
 };

--- a/include/p2gz/CollisionViewer.h
+++ b/include/p2gz/CollisionViewer.h
@@ -3,18 +3,47 @@
 
 #include <Game/mapMgr.h>
 #include <Game/mapParts.h>
+#include <Sys/Edge.h>
 #include <Sys/TriIndexList.h>
 #include <Sys/Triangle.h>
 #include <Sys/TriangleTable.h>
 #include <SysShape/Model.h>
 
 namespace gz {
+
+// 2- and 4-bit packed array accessors (used for the collision viewer's per-triangle
+// ring marks and persistent alpha levels)
+inline u32 get2(const u8* arr, int i)
+{
+	return (arr[i >> 2] >> ((i & 3) * 2)) & 3;
+}
+
+inline void min2(u8* arr, int i, u32 v)
+{
+	int shift = (i & 3) * 2;
+	if (v < ((arr[i >> 2] >> shift) & 3)) {
+		arr[i >> 2] = (u8)((arr[i >> 2] & ~(3 << shift)) | (v << shift));
+	}
+}
+
+inline u32 get4(const u8* arr, int i)
+{
+	return (arr[i >> 1] >> ((i & 1) * 4)) & 15;
+}
+
+inline void set4(u8* arr, int i, u32 v)
+{
+	int shift   = (i & 1) * 4;
+	arr[i >> 1] = (u8)((arr[i >> 1] & ~(15 << shift)) | (v << shift));
+}
+
 struct CollisionViewer {
 public:
 	CollisionViewer()
 	{
 		enabled          = false;
 		need_to_reenable = false;
+		los_valid        = false;
 	}
 	~CollisionViewer() { }
 
@@ -30,13 +59,15 @@ public:
 
 private:
 	bool is_navi_on_triangle(Sys::Triangle*, Sys::Triangle*, Sys::VertexTable*);
-	void draw_triangles(Sys::Sphere&);
+	void draw_triangles(Sys::Sphere&, int mode);
 	bool enabled;
 	bool need_to_reenable;
 	Sys::Sphere olimarSphere;
 	Sys::Sphere louieSphere;
 	Sys::Triangle* olimarTriangle;
 	Sys::Triangle* louieTriangle;
+	Sys::Edge losEdge; // camera -> active captain sight line
+	bool los_valid;
 };
 } // namespace gz
 #endif

--- a/include/p2gz/CollisionViewer.h
+++ b/include/p2gz/CollisionViewer.h
@@ -4,7 +4,6 @@
 #include <Game/mapMgr.h>
 #include <Game/mapParts.h>
 #include <Color4.h>
-#include <Sys/Edge.h>
 #include <Sys/TriIndexList.h>
 #include <Sys/Triangle.h>
 #include <Sys/TriangleTable.h>
@@ -12,39 +11,21 @@
 
 namespace gz {
 
-// 2- and 4-bit packed array accessors (used for the collision viewer's per-triangle
-// ring marks and persistent alpha levels)
-inline u32 get2(const u8* arr, int i)
-{
-	return (arr[i >> 2] >> ((i & 3) * 2)) & 3;
-}
-
-inline void min2(u8* arr, int i, u32 v)
-{
-	int shift = (i & 3) * 2;
-	if (v < ((arr[i >> 2] >> shift) & 3)) {
-		arr[i >> 2] = (u8)((arr[i >> 2] & ~(3 << shift)) | (v << shift));
-	}
-}
-
-inline u32 get4(const u8* arr, int i)
-{
-	return (arr[i >> 1] >> ((i & 1) * 4)) & 15;
-}
-
-inline void set4(u8* arr, int i, u32 v)
-{
-	int shift   = (i & 1) * 4;
-	arr[i >> 1] = (u8)((arr[i >> 1] & ~(15 << shift)) | (v << shift));
-}
-
 struct CollisionViewer {
 public:
 	CollisionViewer()
 	{
 		enabled          = false;
 		need_to_reenable = false;
-		los_valid        = false;
+		olimar_triangle   = nullptr;
+		louie_triangle    = nullptr;
+		tri_visited      = nullptr;
+		tri_alpha        = nullptr;
+		edge_set         = nullptr;
+		gathered_tris    = nullptr;
+		tri_count        = 0;
+		gathered_count   = 0;
+		edge_count       = 0;
 	}
 	~CollisionViewer() { }
 
@@ -59,17 +40,34 @@ public:
 	bool is_enabled() { return enabled; }
 
 private:
+	static bool get_collision_tables(Sys::TriangleTable**, Sys::VertexTable**);
+
+	// working buffers, sized to the loaded map's triangle count and allocated only while
+	// the viewer is enabled (see alloc_buffers / free_buffers)
+	void alloc_buffers(int tris);
+	void free_buffers();
+
+	void gather_triangles(Sys::Sphere&);
+	void edge_set_insert(int a, int b);
+
 	bool is_navi_on_triangle(Sys::Triangle*, Sys::Triangle*, Sys::VertexTable*);
-	Color4 fill_color(Sys::Triangle* tri, Sys::VertexTable* vertTable, u32 q);
-	void emit_fills(Sys::TriangleTable* triTable, Sys::VertexTable* vertTable, bool opaque);
+	Color4 get_fill_color(Sys::Triangle*, Sys::VertexTable*, u8 alpha);
+	void draw_triangles(Sys::TriangleTable*, Sys::VertexTable*, bool opaque);
+
 	bool enabled;
 	bool need_to_reenable;
-	Sys::Sphere olimarSphere;
-	Sys::Sphere louieSphere;
-	Sys::Triangle* olimarTriangle;
-	Sys::Triangle* louieTriangle;
-	Sys::Edge losEdge; // camera -> active captain sight line
-	bool los_valid;
+	Sys::Sphere olimar_sphere;
+	Sys::Sphere louie_sphere;
+	Sys::Triangle* olimar_triangle;
+	Sys::Triangle* louie_triangle;
+
+	u8* tri_visited;     // 1 bit per triangle, gather-pass dedup
+	u8* tri_alpha;       // 1 byte per triangle, current fill alpha (eased for fade)
+	u16* gathered_tris;  // the in-range triangles, gathered once per frame
+	u32* edge_set;       // open-addressed set of drawn edges (deduped)
+	int tri_count;       // triangle-table size the buffers are sized to
+	int gathered_count;
+	int edge_count;
 };
 } // namespace gz
 #endif

--- a/src/p2gz/collisionViewer.cpp
+++ b/src/p2gz/collisionViewer.cpp
@@ -15,141 +15,16 @@
 using namespace gz;
 
 const f32 RENDER_RADIUS = 1024.0f;
-const f32 LOS_RADIUS    = 1.0f; // thickness of the camera->captain sight ray
+const u32 EDGE_SET_SIZE = 4096;
 
-// alpha is stored per triangle as a 4-bit level so transitions survive across frames;
-// ring targets are levels 0/5/10 (blocker/ring1/ring2) and opaque is 15, i.e.
-// q_target = ring * 5. TRANS_STEP levels per frame -> a full opaque<->blocker swing
-// takes ~8 frames, ring-to-ring transitions less
-const u8 QALPHA[16]  = { 96, 107, 117, 128, 138, 149, 159, 170, 181, 191, 202, 212, 223, 233, 244, 255 };
-const int TRANS_STEP = 2;
+const f32 FLOOR_NORMAL_Y = 0.7f;
+const f32 CAPTAIN_HEIGHT = 30.0f;
+const u8 OCCLUDER_ALPHA  = 32;
+const int FADE_STEP      = 24;
 
-// Working buffers, lazily heap-allocated while the viewer is enabled and freed when it
-// is off (so a feature that is usually off costs no memory). The per-index arrays are
-// sized to the loaded map's collision tables; they're tiny next to the tables
-// themselves (under 1 byte per triangle), so if the map fits, they fit.
-//   sTriVisited - one bit per triangle index: findTriLists returns the same triangle
-//     from every grid cell it touches (and from both captains' spheres), and drawing a
-//     translucent triangle twice doubles its opacity.
-//   sTriRing/sVertRing - 2-bit ring marks (0-2 = ring, 3 = unmarked). sVertRing holds
-//     the lowest ring among triangles using that vertex, which is how rings propagate
-//     to vertex-sharing neighbors with no adjacency data.
-//   sTriAlphaQ - persistent 4-bit alpha level per triangle (survives across frames for
-//     the fade smoothing).
-//   sEdgeSet - fixed-size open-addressed set of vertex-index pairs packed into u32
-//     keys, holding only the *drawn* edges, so an edge shared by two triangles is
-//     recorded once; the line pass draws straight out of it. Fixed size because it only
-//     ever holds on-screen edges (performance bounds the drawn count anyway).
-static u8* sTriVisited;
-static u8* sTriRing;
-static u8* sVertRing;
-static u8* sTriAlphaQ;
-static int sTriCount;  // == triangle table mLimit (valid index bound)
-static int sVertCount; // == vertex table mLimit
+namespace gz {
 
-const u32 EDGE_SET_SIZE = 4096; // 2^12
-static u32* sEdgeSet;
-static int sEdgeSetLoad;
-
-// the unique in-range triangles, gathered ONCE per frame from the spatial grid. all
-// the per-frame passes (blocker/ring marking, alpha easing, fills) then iterate this
-// flat list instead of re-querying findTriLists per pass - the grid query is the
-// expensive part and was previously run once per pass
-static u16* sGatheredTris;
-static int sGatheredCount;
-
-static void free_buffers()
-{
-	delete[] sTriVisited;
-	delete[] sTriRing;
-	delete[] sVertRing;
-	delete[] sTriAlphaQ;
-	delete[] sEdgeSet;
-	delete[] sGatheredTris;
-	sTriVisited   = nullptr;
-	sTriRing      = nullptr;
-	sVertRing     = nullptr;
-	sTriAlphaQ    = nullptr;
-	sEdgeSet      = nullptr;
-	sGatheredTris = nullptr;
-	sTriCount     = 0;
-	sVertCount    = 0;
-}
-
-static void alloc_buffers(int tri_count, int vert_count)
-{
-	free_buffers();
-	sTriCount  = tri_count;
-	sVertCount = vert_count;
-
-	JKRHeap* prev_heap = sys->mSysHeap->becomeCurrentHeap();
-	sTriVisited        = new u8[(tri_count + 7) / 8];
-	sTriRing           = new u8[(tri_count + 3) / 4];
-	sTriAlphaQ         = new u8[(tri_count + 1) / 2];
-	sVertRing          = new u8[(vert_count + 3) / 4];
-	sEdgeSet           = new u32[EDGE_SET_SIZE];
-	sGatheredTris      = new u16[tri_count];
-	prev_heap->becomeCurrentHeap();
-
-	// start every triangle fully opaque rather than mid-fade
-	memset(sTriAlphaQ, 0xFF, (tri_count + 1) / 2);
-}
-
-// lowest ring among the triangle's three vertices (3 = none marked)
-static u32 min_vert_ring(Sys::Triangle* tri)
-{
-	u32 ring = 3;
-	for (int i = 0; i < 3; i++) {
-		int v = tri->mVertices[i];
-		if (v >= 0 && v < sVertCount && get2(sVertRing, v) < ring) {
-			ring = get2(sVertRing, v);
-		}
-	}
-	return ring;
-}
-
-static void mark_tri_ring(Sys::Triangle* tri, int triIdx, u32 ring)
-{
-	min2(sTriRing, triIdx, ring);
-	for (int i = 0; i < 3; i++) {
-		int v = tri->mVertices[i];
-		if (v >= 0 && v < sVertCount) {
-			min2(sVertRing, v, ring);
-		}
-	}
-}
-
-static void edge_set_insert(int a, int b)
-{
-	if (a > b) {
-		int tmp = a;
-		a       = b;
-		b       = tmp;
-	}
-	// pack as ((min+1) << 16) | max so a valid key is never 0 (= empty slot)
-	if (a < 0 || a >= 0xFFFF || b > 0xFFFF) {
-		return;
-	}
-	// if the table is nearly full just drop lines rather than probe forever
-	if (sEdgeSetLoad >= (int)(EDGE_SET_SIZE - EDGE_SET_SIZE / 4)) {
-		return;
-	}
-
-	u32 key = ((u32)(a + 1) << 16) | (u32)b;
-	u32 idx = (key * 0x9E3779B9u) >> 20; // top 12 bits, EDGE_SET_SIZE = 2^12
-	while (sEdgeSet[idx]) {
-		if (sEdgeSet[idx] == key) {
-			return;
-		}
-		idx = (idx + 1) & (EDGE_SET_SIZE - 1);
-	}
-	sEdgeSet[idx] = key;
-	sEdgeSetLoad++;
-}
-
-// resolve the loaded map's collision tables (caves and above-ground store the divider
-// differently). returns false if no map / collision is loaded yet
-static bool get_collision_tables(Sys::TriangleTable** tri, Sys::VertexTable** vert)
+bool CollisionViewer::get_collision_tables(Sys::TriangleTable** tri, Sys::VertexTable** vert)
 {
 	if (!Game::mapMgr || !Game::gameSystem) {
 		return false;
@@ -172,56 +47,109 @@ static bool get_collision_tables(Sys::TriangleTable** tri, Sys::VertexTable** ve
 	return true;
 }
 
-namespace gz {
+// Allocate the working buffers, sized to this map's triangle/vertex counts.
+void CollisionViewer::alloc_buffers(int tris)
+{
+	free_buffers();
+	tri_count = tris;
+
+	JKRHeap* prev_heap = sys->mSysHeap->becomeCurrentHeap();
+	tri_visited        = new u8[(tris + 7) / 8];
+	tri_alpha          = new u8[tris];
+	edge_set           = new u32[EDGE_SET_SIZE];
+	gathered_tris      = new u16[tris];
+	prev_heap->becomeCurrentHeap();
+
+	// initialize every triangle to be opaque
+	memset(tri_alpha, 0xFF, tris);
+}
+
+// Release the working buffers.
+void CollisionViewer::free_buffers()
+{
+	delete[] tri_visited;
+	delete[] tri_alpha;
+	delete[] edge_set;
+	delete[] gathered_tris;
+	tri_visited   = nullptr;
+	tri_alpha     = nullptr;
+	edge_set      = nullptr;
+	gathered_tris = nullptr;
+	tri_count     = 0;
+}
+
+// Collect the triangles near the captain into `gathered_tris`, without duplicates.
+void CollisionViewer::gather_triangles(Sys::Sphere& sphere)
+{
+	Sys::TriIndexList* lists;
+	if (Game::gameSystem->mIsInCave) {
+		lists = static_cast<Game::RoomMapMgr*>(Game::mapMgr)->mMapCollision->mDivider->findTriLists(sphere);
+	} else {
+		lists = static_cast<Game::ShapeMapMgr*>(Game::mapMgr)->mMapCollision.mDivider->findTriLists(sphere);
+	}
+
+	// We can't use `findTriLists` directly because it may contain duplicates. Collision is stored in a grid of cells,
+	// and `findTriLists` returns the list of triangles for every cell enclosed by `sphere`. Triangles that span multiple
+	// cells are included in each cell's list, so we need to deduplicate them.
+	for (; lists; lists = static_cast<Sys::TriIndexList*>(lists->mNext)) {
+		for (int i = 0; i < lists->getNum(); i++) {
+			int idx = lists->mObjects[i];
+			if (idx < 0 || idx >= tri_count) {
+				continue;
+			}
+
+			// This is just a memory optimization: `tri_visited` stores each triangle as a single bit.
+			// If bit (idx >> 3) in byte (idx & 7) is set, we've already visited that triangle.
+			if (tri_visited[idx >> 3] & (1 << (idx & 7))) {
+				continue;
+			}
+
+			tri_visited[idx >> 3] |= (u8)(1 << (idx & 7));
+			gathered_tris[gathered_count++] = (u16)idx;
+		}
+	}
+}
+
+// Add an undirected edge to the set so an edge shared by two triangles is only stored, and therefore drawn, once.
+// https://en.wikipedia.org/wiki/Hash_function#Fibonacci_hashing
+void CollisionViewer::edge_set_insert(int a, int b)
+{
+	// order the pair so (a, b) and (b, a) are the same edge
+	if (a > b) {
+		int tmp = a;
+		a = b;
+		b = tmp;
+	}
+
+	u32 key = ((u32)(a + 1) << 16) | (u32)b;
+	u32 hash = (key * 0x9E3779B9u) >> 20;
+	while (edge_set[hash]) {
+		if (edge_set[hash] == key) {
+			return;
+		}
+		hash = (hash + 1) & (EDGE_SET_SIZE - 1);
+	}
+	edge_set[hash] = key;
+	edge_count++;
+}
+
 bool CollisionViewer::is_navi_on_triangle(Sys::Triangle* tri, Sys::Triangle* naviTriangle, Sys::VertexTable* vertTable)
 {
 	if (!tri || !naviTriangle) {
 		return false;
 	}
-
 	for (int i = 0; i < 3; i++) {
-		Vector3f* naviVertex = vertTable->getVertex(naviTriangle->mVertices[i]);
-		Vector3f* triVertex  = vertTable->getVertex(tri->mVertices[i]);
-		if (naviVertex != triVertex) {
+		if (vertTable->getVertex(naviTriangle->mVertices[i]) != vertTable->getVertex(tri->mVertices[i])) {
 			return false;
 		}
 	}
 	return true;
 }
 
-// query the spatial grid ONCE and append the unique in-range triangle indices to the
-// flat gathered list. this is the expensive call (grid traversal) - doing it once and
-// iterating the flat list for every subsequent pass is the whole point of the rewrite
-static void gather_triangles(Sys::Sphere& sphere)
-{
-	Sys::TriIndexList* triLists;
-	if (Game::gameSystem->mIsInCave) {
-		triLists = static_cast<Game::RoomMapMgr*>(Game::mapMgr)->mMapCollision->mDivider->findTriLists(sphere);
-	} else {
-		triLists = static_cast<Game::ShapeMapMgr*>(Game::mapMgr)->mMapCollision.mDivider->findTriLists(sphere);
-	}
-
-	for (; triLists; triLists = static_cast<Sys::TriIndexList*>(triLists->mNext)) {
-		for (int i = 0; i < triLists->getNum(); i++) {
-			int triIdx = triLists->mObjects[i];
-			if (triIdx < 0 || triIdx >= sTriCount) {
-				continue;
-			}
-			// dedup: the same triangle is returned from every grid cell it touches and
-			// from both captains' spheres
-			if (sTriVisited[triIdx >> 3] & (1 << (triIdx & 7))) {
-				continue;
-			}
-			sTriVisited[triIdx >> 3] |= (u8)(1 << (triIdx & 7));
-			sGatheredTris[sGatheredCount++] = (u16)triIdx;
-		}
-	}
-}
-
-Color4 CollisionViewer::fill_color(Sys::Triangle* tri, Sys::VertexTable* vertTable, u32 q)
+Color4 CollisionViewer::get_fill_color(Sys::Triangle* tri, Sys::VertexTable* vertTable, u8 alpha)
 {
 	Color4 color = Color4(200, 200, 200, 128);
-	if (!is_navi_on_triangle(tri, olimarTriangle, vertTable) && !is_navi_on_triangle(tri, louieTriangle, vertTable)) {
+	if (!is_navi_on_triangle(tri, olimar_triangle, vertTable) && !is_navi_on_triangle(tri, louie_triangle, vertTable)) {
 		switch (tri->mCode.getSlipCode()) {
 		case MapCode::Code::SlipCode_NoSlip:
 			color = Color4(0, 50 + 150 * fabs(tri->mTrianglePlane.mNormal.y), 0, 128);
@@ -234,18 +162,15 @@ Color4 CollisionViewer::fill_color(Sys::Triangle* tri, Sys::VertexTable* vertTab
 			break;
 		}
 	}
-	color.a = QALPHA[q];
+	color.a = alpha;
 	return color;
 }
 
-// draw the gathered triangles of one alpha class (settled-opaque, or mid-fade
-// translucent) in batched GXBegin calls. one GXBegin per triangle is as fatal as one
-// per line; this batches them, chunked to stay under GXBegin's u16 vertex-count limit
-void CollisionViewer::emit_fills(Sys::TriangleTable* triTable, Sys::VertexTable* vertTable, bool opaque)
+void CollisionViewer::draw_triangles(Sys::TriangleTable* triTable, Sys::VertexTable* vertTable, bool opaque)
 {
 	int total = 0;
-	for (int g = 0; g < sGatheredCount; g++) {
-		if ((get4(sTriAlphaQ, sGatheredTris[g]) == 15) == opaque) {
+	for (int i = 0; i < gathered_count; i++) {
+		if ((tri_alpha[gathered_tris[i]] == 255) == opaque) {
 			total++;
 		}
 	}
@@ -253,32 +178,22 @@ void CollisionViewer::emit_fills(Sys::TriangleTable* triTable, Sys::VertexTable*
 		return;
 	}
 
-	const int MAX_TRIS_PER_BATCH = 21000; // 3 verts each, under GXBegin's u16 limit
-	int g                        = 0;     // cursor persists across chunks
-	int remaining                = total;
-	while (remaining > 0) {
-		int batch = (remaining < MAX_TRIS_PER_BATCH) ? remaining : MAX_TRIS_PER_BATCH;
-
-		GXBegin(GX_TRIANGLES, GX_VTXFMT0, (u16)(batch * 3));
-		int emitted = 0;
-		while (emitted < batch) {
-			int triIdx = sGatheredTris[g++];
-			u32 q      = get4(sTriAlphaQ, triIdx);
-			if ((q == 15) != opaque) {
-				continue;
-			}
-			Sys::Triangle* tri = triTable->getTriangle(triIdx);
-			Color4 color       = fill_color(tri, vertTable, q);
-			for (int j = 0; j < 3; j++) {
-				Vector3f* vertex = vertTable->getVertex(tri->mVertices[j]);
-				GXPosition3f32(vertex->x, vertex->y, vertex->z);
-				GXColor4u8(color.r, color.g, color.b, color.a);
-			}
-			emitted++;
+	GXBegin(GX_TRIANGLES, GX_VTXFMT0, (u16)(total * 3));
+	for (int i = 0; i < gathered_count; i++) {
+		int idx   = gathered_tris[i];
+		u8 alpha  = tri_alpha[idx];
+		if ((alpha == 255) != opaque) {
+			continue;
 		}
-		GXEnd();
-		remaining -= batch;
+		Sys::Triangle* tri = triTable->getTriangle(idx);
+		Color4 color       = get_fill_color(tri, vertTable, alpha);
+		for (int j = 0; j < 3; j++) {
+			Vector3f* vertex = vertTable->getVertex(tri->mVertices[j]);
+			GXPosition3f32(vertex->x, vertex->y, vertex->z);
+			GXColor4u8(color.r, color.g, color.b, color.a);
+		}
 	}
+	GXEnd();
 }
 
 void CollisionViewer::toggle(bool enabled_)
@@ -293,11 +208,10 @@ void CollisionViewer::toggle(bool enabled_)
 	}
 
 	if (enabled_ && !enabled) {
-		// size the working buffers to this map's collision tables
 		Sys::TriangleTable* triTable;
 		Sys::VertexTable* vertTable;
 		if (get_collision_tables(&triTable, &vertTable)) {
-			alloc_buffers(triTable->mLimit, vertTable->mLimit);
+			alloc_buffers(triTable->mLimit);
 		}
 	} else if (!enabled_) {
 		free_buffers();
@@ -308,7 +222,8 @@ void CollisionViewer::toggle(bool enabled_)
 
 void CollisionViewer::draw()
 {
-	if (Game::naviMgr->getActiveNavi() && need_to_reenable) {
+	Game::Navi* navi = Game::naviMgr->getActiveNavi();
+	if (navi && need_to_reenable) {
 		toggle(true);
 		need_to_reenable = false;
 	}
@@ -317,137 +232,111 @@ void CollisionViewer::draw()
 		return;
 	}
 
-	// buffers may not have been allocated yet if the viewer was toggled on before the
-	// map finished loading; allocate now that we're drawing
-	if (!sTriVisited) {
-		Sys::TriangleTable* triTable;
-		Sys::VertexTable* vertTable;
-		if (!get_collision_tables(&triTable, &vertTable)) {
-			return;
-		}
-		alloc_buffers(triTable->mLimit, vertTable->mLimit);
-	}
-
-	Game::Navi* olimar = Game::naviMgr->getAt(NAVIID_Olimar);
-	if (olimar) {
-		Vector3f olimarPos = olimar->getPosition();
-		olimarSphere       = Sys::Sphere(olimarPos, RENDER_RADIUS);
-		olimarTriangle     = olimar->mFloorTriangle;
-	}
-	Game::Navi* louie = Game::naviMgr->getAt(NAVIID_Louie);
-	if (louie) {
-		Vector3f louiePos = louie->getPosition();
-		louieSphere       = Sys::Sphere(louiePos, RENDER_RADIUS);
-		louieTriangle     = louie->mFloorTriangle;
-	}
-
-	Graphics* gfx = sys->getGfx();
-	gfx->initPrimDraw(nullptr);
-
-	memset(sTriVisited, 0, (sTriCount + 7) / 8);
-	memset(sEdgeSet, 0, EDGE_SET_SIZE * sizeof(u32));
-	memset(sTriRing, 0xFF, (sTriCount + 3) / 4);
-	memset(sVertRing, 0xFF, (sVertCount + 3) / 4);
-	sEdgeSetLoad = 0;
-
-	// sight line from the camera to the active captain; triangles crossing it (and,
-	// fading back to opaque, their two rings of neighbors) are drawn translucent so
-	// they don't hide him
-	Game::Navi* navi = Game::naviMgr->getActiveNavi();
-	Viewport* vp     = sys->mGfx->mCurrentViewport;
-	los_valid        = false;
-	if (navi && vp && vp->getCamera()) {
-		Vector3f camPos  = vp->getCamera()->getPosition();
-		Vector3f naviPos = navi->getPosition();
-		naviPos.y += 15.0f; // aim at his body, not his feet
-		losEdge.setStartEnd(camPos, naviPos);
-		los_valid = true;
-	}
-
 	Sys::TriangleTable* triTable;
 	Sys::VertexTable* vertTable;
 	if (!get_collision_tables(&triTable, &vertTable)) {
 		return;
 	}
 
-	// Gather the in-range triangles ONCE (the grid query is the expensive part). Every
-	// pass below iterates this flat list instead of re-querying per pass.
-	sGatheredCount = 0;
+	if (!tri_visited) {
+		alloc_buffers(triTable->mLimit);
+	}
+
+	Game::Navi* olimar = Game::naviMgr->getAt(NAVIID_Olimar);
+	if (olimar) {
+		Vector3f pos   = olimar->getPosition();
+		olimar_sphere   = Sys::Sphere(pos, RENDER_RADIUS);
+		olimar_triangle = olimar->mFloorTriangle;
+	}
+	Game::Navi* louie = Game::naviMgr->getAt(NAVIID_Louie);
+	if (louie) {
+		Vector3f pos  = louie->getPosition();
+		louie_sphere   = Sys::Sphere(pos, RENDER_RADIUS);
+		louie_triangle = louie->mFloorTriangle;
+	}
+
+	Graphics* gfx = sys->getGfx();
+	gfx->initPrimDraw(nullptr);
+
+	memset(tri_visited, 0, (tri_count + 7) / 8);
+	memset(edge_set, 0, EDGE_SET_SIZE * sizeof(u32));
+
+	gathered_count = 0;
 	if (navi) {
-		gather_triangles(navi->mNaviIndex == NAVIID_Olimar ? olimarSphere : louieSphere);
+		gather_triangles(navi->mNaviIndex == NAVIID_Olimar ? olimar_sphere : louie_sphere);
 	} else {
 		// while switching captains, gather both only if they're far apart
-		gather_triangles(olimarSphere);
-		if (sqrDistanceXZ(olimarSphere.mPosition, louieSphere.mPosition) > RENDER_RADIUS / 3) {
-			gather_triangles(louieSphere);
+		gather_triangles(olimar_sphere);
+		if (sqrDistanceXZ(olimar_sphere.mPosition, louie_sphere.mPosition) > RENDER_RADIUS / 3) {
+			gather_triangles(louie_sphere);
 		}
 	}
 
-	// mark the sight-blockers (ring 0), then propagate two rings of adjacency outward
-	if (los_valid) {
-		for (int g = 0; g < sGatheredCount; g++) {
-			int triIdx         = sGatheredTris[g];
-			Sys::Triangle* tri = triTable->getTriangle(triIdx);
-			Vector3f hit;
-			if (get2(sTriRing, triIdx) == 3 && tri->intersect(losEdge, LOS_RADIUS, hit)) {
-				mark_tri_ring(tri, triIdx, 0);
+	// fade triangles that occlude the captain
+	Vector3f camPos   = sys->mGfx->mCurrentViewport->getCamera()->getPosition();
+	f32 sqr_navi_dist = 0.0f;
+	f32 navi_head_y   = 0.0f;
+	if (navi) {
+		Vector3f naviPos = navi->getPosition();
+		sqr_navi_dist    = camPos.sqrDistance(naviPos);
+		navi_head_y      = naviPos.y + CAPTAIN_HEIGHT;
+	}
+	for (int g = 0; g < gathered_count; g++) {
+		int idx            = gathered_tris[g];
+		Sys::Triangle* tri = triTable->getTriangle(idx);
+
+		bool occluder = false;
+		if (navi) {
+			bool not_floor  = tri->mTrianglePlane.mNormal.y < FLOOR_NORMAL_Y;
+			bool above_head = tri->mSphere.mPosition.y > navi_head_y;
+			if (not_floor || above_head) {
+				occluder = camPos.sqrDistance(tri->mSphere.mPosition) < sqr_navi_dist;
 			}
 		}
-		for (u32 ring = 1; ring <= 2; ring++) {
-			for (int g = 0; g < sGatheredCount; g++) {
-				int triIdx         = sGatheredTris[g];
-				Sys::Triangle* tri = triTable->getTriangle(triIdx);
-				if (get2(sTriRing, triIdx) == 3 && min_vert_ring(tri) < ring) {
-					mark_tri_ring(tri, triIdx, ring);
-				}
-			}
+
+		int target = occluder ? OCCLUDER_ALPHA : 255;
+		int a      = tri_alpha[idx];
+		if (a < target) {
+			a = (a + FADE_STEP < target) ? a + FADE_STEP : target;
+		} else if (a > target) {
+			a = (a - FADE_STEP > target) ? a - FADE_STEP : target;
 		}
+		tri_alpha[idx] = (u8)a;
 	}
 
-	// ease every gathered triangle's alpha one step toward its ring's target
-	for (int g = 0; g < sGatheredCount; g++) {
-		int triIdx = sGatheredTris[g];
-		u32 target = get2(sTriRing, triIdx) * 5; // rings 0/1/2 -> q 0/5/10, opaque -> 15
-		int q      = (int)get4(sTriAlphaQ, triIdx);
-		if (q < (int)target) {
-			q = (q + TRANS_STEP < (int)target) ? q + TRANS_STEP : (int)target;
-		} else if (q > (int)target) {
-			q = (q - TRANS_STEP > (int)target) ? q - TRANS_STEP : (int)target;
-		}
-		set4(sTriAlphaQ, triIdx, (u32)q);
-	}
+	// opaque triangles
+	draw_triangles(triTable, vertTable, true);
 
-	// settled-opaque fills first (blend still off from initPrimDraw), then the
-	// translucent set on top. vertex alpha only matters once blending is switched on
-	emit_fills(triTable, vertTable, true);
+	// translucent triangles
 	GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_CLEAR);
-	GXSetZMode(GX_TRUE, GX_LESS, GX_FALSE); // translucent fills shouldn't occlude anything
-	emit_fills(triTable, vertTable, false);
+	GXSetZMode(GX_TRUE, GX_LESS, GX_FALSE);
+	draw_triangles(triTable, vertTable, false);
 
-	// collect outline edges for every gathered triangle (same radius as the fills); the
-	// set dedups edges shared between triangles
-	for (int g = 0; g < sGatheredCount; g++) {
-		Sys::Triangle* tri = triTable->getTriangle(sGatheredTris[g]);
+	// find unique opaque triangle edges
+	edge_count = 0;
+	for (int g = 0; g < gathered_count; g++) {
+		int idx = gathered_tris[g];
+		if (tri_alpha[idx] != 255) {
+			continue;
+		}
+		Sys::Triangle* tri = triTable->getTriangle(idx);
 		edge_set_insert(tri->mVertices[0], tri->mVertices[1]);
 		edge_set_insert(tri->mVertices[1], tri->mVertices[2]);
 		edge_set_insert(tri->mVertices[2], tri->mVertices[0]);
 	}
 
-	// thin outlines along the (deduplicated) triangle edges
-	GXSetBlendMode(GX_BM_NONE, GX_BL_ONE, GX_BL_ONE, GX_LO_CLEAR);
-	GXSetZMode(GX_TRUE, GX_LEQUAL, GX_TRUE); // LEQUAL so lines coplanar with fills pass the z test
-	GXSetLineWidth(6, GX_TO_ZERO);
-
-	if (sEdgeSetLoad == 0) {
+	if (edge_count == 0) {
 		return;
 	}
 
-	// Emit ALL line segments in a single GXBegin batch. A per-edge GXBegin/GXEnd makes
-	// each 2-vertex line its own GP primitive setup - thousands of those tank the frame
-	// rate (worst-case setup-to-pixel ratio). One batch is one setup for the whole set.
-	GXBegin(GX_LINES, GX_VTXFMT0, (u16)(sEdgeSetLoad * 2));
+	// edges
+	GXSetBlendMode(GX_BM_NONE, GX_BL_ONE, GX_BL_ONE, GX_LO_CLEAR);
+	GXSetZMode(GX_TRUE, GX_LEQUAL, GX_TRUE);
+	GXSetLineWidth(6, GX_TO_ZERO);
+
+	GXBegin(GX_LINES, GX_VTXFMT0, (u16)(edge_count * 2));
 	for (u32 i = 0; i < EDGE_SET_SIZE; i++) {
-		u32 key = sEdgeSet[i];
+		u32 key = edge_set[i];
 		if (!key) {
 			continue;
 		}

--- a/src/p2gz/collisionViewer.cpp
+++ b/src/p2gz/collisionViewer.cpp
@@ -4,12 +4,111 @@
 #include <Sys/Triangle.h>
 #include <Sys/TriangleTable.h>
 #include <Graphics.h>
+#include <Viewport.h>
+#include <Camera.h>
 #include <stl/math.h>
+#include <string.h>
 #include <Game/MapMgr.h>
 #include <Game/mapParts.h>
 #include <p2gz/p2gz.h>
 
+using namespace gz;
+
 const f32 RENDER_RADIUS = 1024.0f;
+const f32 LOS_RADIUS    = 1.0f; // thickness of the camera->captain sight ray
+
+// the passes draw_triangles runs in, in order: sight-blockers and the two rings of
+// adjacent triangles are marked first, every triangle's alpha then eases one step
+// toward its ring's target, and finally the settled-opaque and translucent sets draw
+enum {
+	MODE_MARK_BLOCKERS    = 0,
+	MODE_MARK_RING1       = 1,
+	MODE_MARK_RING2       = 2,
+	MODE_UPDATE_ALPHA     = 3,
+	MODE_DRAW_OPAQUE      = 4,
+	MODE_DRAW_TRANSLUCENT = 5,
+	MODE_COUNT            = 6,
+};
+
+// alpha is stored per triangle as a 4-bit level so transitions survive across frames;
+// ring targets are levels 0/5/10 (blocker/ring1/ring2) and opaque is 15, i.e.
+// q_target = ring * 5. TRANS_STEP levels per frame -> a full opaque<->blocker swing
+// takes ~8 frames, ring-to-ring transitions less
+const u8 QALPHA[16]  = { 96, 107, 117, 128, 138, 149, 159, 170, 181, 191, 202, 212, 223, 233, 244, 255 };
+const int TRANS_STEP = 2;
+
+// per-frame dedup state, static so it costs DOL bss instead of the tight sys heap.
+// sTriVisited has one bit per triangle index: findTriLists returns the same triangle
+// from every grid cell it touches (and from both captains' spheres), and drawing a
+// translucent triangle twice doubles its opacity.
+// sEdgeSet is an open-addressed set of vertex-index pairs packed into u32 keys, so an
+// edge shared by two triangles is recorded once; the line pass then draws straight out
+// of the table.
+static u8 sTriVisited[65536 / 8];
+const u32 EDGE_SET_SIZE = 8192;
+static u32 sEdgeSet[EDGE_SET_SIZE];
+static int sEdgeSetLoad;
+
+// per-frame ring marks, 2 bits each: 0-2 = ring, 3 = unmarked/opaque. sVertRing holds
+// the lowest ring among the triangles using that vertex, which is how rings propagate
+// to vertex-sharing neighbors without any adjacency data
+static u8 sTriRing[65536 / 4];
+static u8 sVertRing[65536 / 4];
+
+// persistent 4-bit alpha level per triangle (survives across frames for smoothing)
+static u8 sTriAlphaQ[65536 / 2];
+
+// lowest ring among the triangle's three vertices (3 = none marked)
+static u32 min_vert_ring(Sys::Triangle* tri)
+{
+	u32 ring = 3;
+	for (int i = 0; i < 3; i++) {
+		int v = tri->mVertices[i];
+		if ((u32)v < sizeof(sVertRing) * 4 && get2(sVertRing, v) < ring) {
+			ring = get2(sVertRing, v);
+		}
+	}
+	return ring;
+}
+
+static void mark_tri_ring(Sys::Triangle* tri, int triIdx, u32 ring)
+{
+	min2(sTriRing, triIdx, ring);
+	for (int i = 0; i < 3; i++) {
+		int v = tri->mVertices[i];
+		if ((u32)v < sizeof(sVertRing) * 4) {
+			min2(sVertRing, v, ring);
+		}
+	}
+}
+
+static void edge_set_insert(int a, int b)
+{
+	if (a > b) {
+		int tmp = a;
+		a       = b;
+		b       = tmp;
+	}
+	// pack as ((min+1) << 16) | max so a valid key is never 0 (= empty slot)
+	if (a >= 0xFFFF || b > 0xFFFF) {
+		return;
+	}
+	// if the table is nearly full just drop lines rather than probe forever
+	if (sEdgeSetLoad >= (int)(EDGE_SET_SIZE - EDGE_SET_SIZE / 4)) {
+		return;
+	}
+
+	u32 key = ((u32)(a + 1) << 16) | (u32)b;
+	u32 idx = (key * 0x9E3779B9u) >> 19; // top 13 bits, EDGE_SET_SIZE = 2^13
+	while (sEdgeSet[idx]) {
+		if (sEdgeSet[idx] == key) {
+			return;
+		}
+		idx = (idx + 1) & (EDGE_SET_SIZE - 1);
+	}
+	sEdgeSet[idx] = key;
+	sEdgeSetLoad++;
+}
 
 namespace gz {
 bool CollisionViewer::is_navi_on_triangle(Sys::Triangle* tri, Sys::Triangle* naviTriangle, Sys::VertexTable* vertTable)
@@ -28,7 +127,7 @@ bool CollisionViewer::is_navi_on_triangle(Sys::Triangle* tri, Sys::Triangle* nav
 	return true;
 }
 
-void CollisionViewer::draw_triangles(Sys::Sphere& sphere)
+void CollisionViewer::draw_triangles(Sys::Sphere& sphere, int mode)
 {
 	Sys::TriIndexList* triLists;
 	Sys::VertexTable* vertTable;
@@ -51,8 +150,59 @@ void CollisionViewer::draw_triangles(Sys::Sphere& sphere)
 
 	for (triLists; triLists; triLists = static_cast<Sys::TriIndexList*>(triLists->mNext)) {
 		for (int i = 0; i < triLists->getNum(); i++) {
-			Sys::Triangle* tri = triTable->getTriangle(triLists->mObjects[i]);
-			Color4 color       = Color4(200, 200, 200, 128);
+			int triIdx = triLists->mObjects[i];
+			if ((u32)triIdx >= sizeof(sTriRing) * 4) {
+				continue; // out of dedup/ring range; nothing sane to do with it
+			}
+			Sys::Triangle* tri = triTable->getTriangle(triIdx);
+
+			if (mode == MODE_MARK_BLOCKERS) {
+				if (get2(sTriRing, triIdx) == 3 && los_valid) {
+					Vector3f hit;
+					if (tri->intersect(losEdge, LOS_RADIUS, hit)) {
+						mark_tri_ring(tri, triIdx, 0);
+					}
+				}
+				continue;
+			}
+
+			if (mode == MODE_MARK_RING1 || mode == MODE_MARK_RING2) {
+				// pull triangles touching a marked vertex into the next ring out
+				u32 ring = (mode == MODE_MARK_RING1) ? 1 : 2;
+				if (get2(sTriRing, triIdx) == 3 && min_vert_ring(tri) < ring) {
+					mark_tri_ring(tri, triIdx, ring);
+				}
+				continue;
+			}
+
+			// remaining modes must process each triangle exactly once (it appears in
+			// several grid cells and possibly both captains' spheres)
+			if (sTriVisited[triIdx >> 3] & (1 << (triIdx & 7))) {
+				continue;
+			}
+
+			if (mode == MODE_UPDATE_ALPHA) {
+				sTriVisited[triIdx >> 3] |= (u8)(1 << (triIdx & 7));
+				u32 target = get2(sTriRing, triIdx) * 5; // rings 0/1/2 -> q 0/5/10, opaque -> 15
+				int q      = (int)get4(sTriAlphaQ, triIdx);
+				if (q < (int)target) {
+					q = (q + TRANS_STEP < (int)target) ? q + TRANS_STEP : (int)target;
+				} else if (q > (int)target) {
+					q = (q - TRANS_STEP > (int)target) ? q - TRANS_STEP : (int)target;
+				}
+				set4(sTriAlphaQ, triIdx, (u32)q);
+				continue;
+			}
+
+			// draw modes: anything mid-transition still needs blending, so the split
+			// is by current alpha level, not by ring
+			u32 q = get4(sTriAlphaQ, triIdx);
+			if ((q == 15) != (mode == MODE_DRAW_OPAQUE)) {
+				continue;
+			}
+			sTriVisited[triIdx >> 3] |= (u8)(1 << (triIdx & 7));
+
+			Color4 color = Color4(200, 200, 200, 128);
 			if (!is_navi_on_triangle(tri, olimarTriangle, vertTable) && !is_navi_on_triangle(tri, louieTriangle, vertTable)) {
 				switch (tri->mCode.getSlipCode()) {
 				case MapCode::Code::SlipCode_NoSlip:
@@ -66,14 +216,20 @@ void CollisionViewer::draw_triangles(Sys::Sphere& sphere)
 					break;
 				}
 			}
+			color.a = QALPHA[q];
 
 			GXBegin(GX_TRIANGLES, GX_VTXFMT0, 3);
-			for (int i = 0; i < 3; i++) {
-				Vector3f* vertex = vertTable->getVertex(tri->mVertices[i]);
+			for (int j = 0; j < 3; j++) {
+				Vector3f* vertex = vertTable->getVertex(tri->mVertices[j]);
 				GXPosition3f32(vertex->x, vertex->y, vertex->z);
 				GXColor4u8(color.r, color.g, color.b, color.a);
 			}
 			GXEnd();
+
+			// record the outline edges; the set collapses edges shared between triangles
+			edge_set_insert(tri->mVertices[0], tri->mVertices[1]);
+			edge_set_insert(tri->mVertices[1], tri->mVertices[2]);
+			edge_set_insert(tri->mVertices[2], tri->mVertices[0]);
 		}
 	}
 }
@@ -87,6 +243,11 @@ void CollisionViewer::toggle(bool enabled_)
 		} else {
 			mapModel->show();
 		}
+	}
+
+	if (enabled_ && !enabled) {
+		// start everything fully opaque rather than mid-fade from a previous session
+		memset(sTriAlphaQ, 0xFF, sizeof(sTriAlphaQ));
 	}
 
 	enabled = enabled_;
@@ -119,16 +280,77 @@ void CollisionViewer::draw()
 	Graphics* gfx = sys->getGfx();
 	gfx->initPrimDraw(nullptr);
 
+	memset(sTriVisited, 0, sizeof(sTriVisited));
+	memset(sEdgeSet, 0, sizeof(sEdgeSet));
+	memset(sTriRing, 0xFF, sizeof(sTriRing));
+	memset(sVertRing, 0xFF, sizeof(sVertRing));
+	sEdgeSetLoad = 0;
+
+	// sight line from the camera to the active captain; triangles crossing it (and,
+	// fading back to opaque, their two rings of neighbors) are drawn translucent so
+	// they don't hide him
 	Game::Navi* navi = Game::naviMgr->getActiveNavi();
-	if (navi) {
-		draw_triangles(navi->mNaviIndex == NAVIID_Olimar ? olimarSphere : louieSphere);
-	} else {
-		// Minimize duplicate triangles while switching captains by only drawing triangles for both
-		// if they are arbitrarily far apart.
-		draw_triangles(olimarSphere);
-		if (sqrDistanceXZ(olimarSphere.mPosition, louieSphere.mPosition) > RENDER_RADIUS / 3) {
-			draw_triangles(louieSphere);
+	Viewport* vp     = sys->mGfx->mCurrentViewport;
+	los_valid        = false;
+	if (navi && vp && vp->getCamera()) {
+		Vector3f camPos  = vp->getCamera()->getPosition();
+		Vector3f naviPos = navi->getPosition();
+		naviPos.y += 15.0f; // aim at his body, not his feet
+		losEdge.setStartEnd(camPos, naviPos);
+		los_valid = true;
+	}
+
+	// mark blockers + adjacency rings, ease every triangle's alpha one step toward
+	// its target, then draw: settled-opaque fills first, the translucent set on top.
+	// vertex alpha only has an effect once blending is switched on - initPrimDraw
+	// leaves GX_BM_NONE, which renders everything opaque regardless of alpha
+	for (int mode = 0; mode < MODE_COUNT; mode++) {
+		if (mode == MODE_DRAW_OPAQUE) {
+			// the alpha-update sweep consumed the visited bits; draw passes re-dedup
+			memset(sTriVisited, 0, sizeof(sTriVisited));
 		}
+		if (mode == MODE_DRAW_TRANSLUCENT) {
+			GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_CLEAR);
+			GXSetZMode(GX_TRUE, GX_LESS, GX_FALSE); // translucent fills shouldn't occlude anything
+		}
+		if (navi) {
+			draw_triangles(navi->mNaviIndex == NAVIID_Olimar ? olimarSphere : louieSphere, mode);
+		} else {
+			// Minimize duplicate triangles while switching captains by only drawing triangles for both
+			// if they are arbitrarily far apart.
+			draw_triangles(olimarSphere, mode);
+			if (sqrDistanceXZ(olimarSphere.mPosition, louieSphere.mPosition) > RENDER_RADIUS / 3) {
+				draw_triangles(louieSphere, mode);
+			}
+		}
+	}
+
+	// thin outlines along the (deduplicated) triangle edges
+	GXSetBlendMode(GX_BM_NONE, GX_BL_ONE, GX_BL_ONE, GX_LO_CLEAR);
+	GXSetZMode(GX_TRUE, GX_LEQUAL, GX_TRUE); // LEQUAL so lines coplanar with fills pass the z test
+	GXSetLineWidth(6, GX_TO_ZERO);
+
+	Sys::VertexTable* vertTable = nullptr;
+	if (Game::gameSystem->mIsInCave) {
+		vertTable = static_cast<Game::RoomMapMgr*>(Game::mapMgr)->mMapCollision->mDivider->mVertexTable;
+	}
+	vertTable = static_cast<Game::ShapeMapMgr*>(Game::mapMgr)->mMapCollision.mDivider->mVertexTable;
+
+	for (u32 i = 0; i < EDGE_SET_SIZE; i++) {
+		u32 key = sEdgeSet[i];
+		if (!key) {
+			continue;
+		}
+
+		Vector3f* va = vertTable->getVertex((int)(key >> 16) - 1);
+		Vector3f* vb = vertTable->getVertex((int)(key & 0xFFFF));
+
+		GXBegin(GX_LINES, GX_VTXFMT0, 2);
+		GXPosition3f32(va->x, va->y, va->z);
+		GXColor4u8(20, 20, 20, 255);
+		GXPosition3f32(vb->x, vb->y, vb->z);
+		GXColor4u8(20, 20, 20, 255);
+		GXEnd();
 	}
 }
 } // namespace gz

--- a/src/p2gz/collisionViewer.cpp
+++ b/src/p2gz/collisionViewer.cpp
@@ -17,19 +17,6 @@ using namespace gz;
 const f32 RENDER_RADIUS = 1024.0f;
 const f32 LOS_RADIUS    = 1.0f; // thickness of the camera->captain sight ray
 
-// the passes draw_triangles runs in, in order: sight-blockers and the two rings of
-// adjacent triangles are marked first, every triangle's alpha then eases one step
-// toward its ring's target, and finally the settled-opaque and translucent sets draw
-enum {
-	MODE_MARK_BLOCKERS    = 0,
-	MODE_MARK_RING1       = 1,
-	MODE_MARK_RING2       = 2,
-	MODE_UPDATE_ALPHA     = 3,
-	MODE_DRAW_OPAQUE      = 4,
-	MODE_DRAW_TRANSLUCENT = 5,
-	MODE_COUNT            = 6,
-};
-
 // alpha is stored per triangle as a 4-bit level so transitions survive across frames;
 // ring targets are levels 0/5/10 (blocker/ring1/ring2) and opaque is 15, i.e.
 // q_target = ring * 5. TRANS_STEP levels per frame -> a full opaque<->blocker swing
@@ -37,26 +24,76 @@ enum {
 const u8 QALPHA[16]  = { 96, 107, 117, 128, 138, 149, 159, 170, 181, 191, 202, 212, 223, 233, 244, 255 };
 const int TRANS_STEP = 2;
 
-// per-frame dedup state, static so it costs DOL bss instead of the tight sys heap.
-// sTriVisited has one bit per triangle index: findTriLists returns the same triangle
-// from every grid cell it touches (and from both captains' spheres), and drawing a
-// translucent triangle twice doubles its opacity.
-// sEdgeSet is an open-addressed set of vertex-index pairs packed into u32 keys, so an
-// edge shared by two triangles is recorded once; the line pass then draws straight out
-// of the table.
-static u8 sTriVisited[65536 / 8];
-const u32 EDGE_SET_SIZE = 8192;
-static u32 sEdgeSet[EDGE_SET_SIZE];
+// Working buffers, lazily heap-allocated while the viewer is enabled and freed when it
+// is off (so a feature that is usually off costs no memory). The per-index arrays are
+// sized to the loaded map's collision tables; they're tiny next to the tables
+// themselves (under 1 byte per triangle), so if the map fits, they fit.
+//   sTriVisited - one bit per triangle index: findTriLists returns the same triangle
+//     from every grid cell it touches (and from both captains' spheres), and drawing a
+//     translucent triangle twice doubles its opacity.
+//   sTriRing/sVertRing - 2-bit ring marks (0-2 = ring, 3 = unmarked). sVertRing holds
+//     the lowest ring among triangles using that vertex, which is how rings propagate
+//     to vertex-sharing neighbors with no adjacency data.
+//   sTriAlphaQ - persistent 4-bit alpha level per triangle (survives across frames for
+//     the fade smoothing).
+//   sEdgeSet - fixed-size open-addressed set of vertex-index pairs packed into u32
+//     keys, holding only the *drawn* edges, so an edge shared by two triangles is
+//     recorded once; the line pass draws straight out of it. Fixed size because it only
+//     ever holds on-screen edges (performance bounds the drawn count anyway).
+static u8* sTriVisited;
+static u8* sTriRing;
+static u8* sVertRing;
+static u8* sTriAlphaQ;
+static int sTriCount;  // == triangle table mLimit (valid index bound)
+static int sVertCount; // == vertex table mLimit
+
+const u32 EDGE_SET_SIZE = 4096; // 2^12
+static u32* sEdgeSet;
 static int sEdgeSetLoad;
 
-// per-frame ring marks, 2 bits each: 0-2 = ring, 3 = unmarked/opaque. sVertRing holds
-// the lowest ring among the triangles using that vertex, which is how rings propagate
-// to vertex-sharing neighbors without any adjacency data
-static u8 sTriRing[65536 / 4];
-static u8 sVertRing[65536 / 4];
+// the unique in-range triangles, gathered ONCE per frame from the spatial grid. all
+// the per-frame passes (blocker/ring marking, alpha easing, fills) then iterate this
+// flat list instead of re-querying findTriLists per pass - the grid query is the
+// expensive part and was previously run once per pass
+static u16* sGatheredTris;
+static int sGatheredCount;
 
-// persistent 4-bit alpha level per triangle (survives across frames for smoothing)
-static u8 sTriAlphaQ[65536 / 2];
+static void free_buffers()
+{
+	delete[] sTriVisited;
+	delete[] sTriRing;
+	delete[] sVertRing;
+	delete[] sTriAlphaQ;
+	delete[] sEdgeSet;
+	delete[] sGatheredTris;
+	sTriVisited   = nullptr;
+	sTriRing      = nullptr;
+	sVertRing     = nullptr;
+	sTriAlphaQ    = nullptr;
+	sEdgeSet      = nullptr;
+	sGatheredTris = nullptr;
+	sTriCount     = 0;
+	sVertCount    = 0;
+}
+
+static void alloc_buffers(int tri_count, int vert_count)
+{
+	free_buffers();
+	sTriCount  = tri_count;
+	sVertCount = vert_count;
+
+	JKRHeap* prev_heap = sys->mSysHeap->becomeCurrentHeap();
+	sTriVisited        = new u8[(tri_count + 7) / 8];
+	sTriRing           = new u8[(tri_count + 3) / 4];
+	sTriAlphaQ         = new u8[(tri_count + 1) / 2];
+	sVertRing          = new u8[(vert_count + 3) / 4];
+	sEdgeSet           = new u32[EDGE_SET_SIZE];
+	sGatheredTris      = new u16[tri_count];
+	prev_heap->becomeCurrentHeap();
+
+	// start every triangle fully opaque rather than mid-fade
+	memset(sTriAlphaQ, 0xFF, (tri_count + 1) / 2);
+}
 
 // lowest ring among the triangle's three vertices (3 = none marked)
 static u32 min_vert_ring(Sys::Triangle* tri)
@@ -64,7 +101,7 @@ static u32 min_vert_ring(Sys::Triangle* tri)
 	u32 ring = 3;
 	for (int i = 0; i < 3; i++) {
 		int v = tri->mVertices[i];
-		if ((u32)v < sizeof(sVertRing) * 4 && get2(sVertRing, v) < ring) {
+		if (v >= 0 && v < sVertCount && get2(sVertRing, v) < ring) {
 			ring = get2(sVertRing, v);
 		}
 	}
@@ -76,7 +113,7 @@ static void mark_tri_ring(Sys::Triangle* tri, int triIdx, u32 ring)
 	min2(sTriRing, triIdx, ring);
 	for (int i = 0; i < 3; i++) {
 		int v = tri->mVertices[i];
-		if ((u32)v < sizeof(sVertRing) * 4) {
+		if (v >= 0 && v < sVertCount) {
 			min2(sVertRing, v, ring);
 		}
 	}
@@ -90,7 +127,7 @@ static void edge_set_insert(int a, int b)
 		b       = tmp;
 	}
 	// pack as ((min+1) << 16) | max so a valid key is never 0 (= empty slot)
-	if (a >= 0xFFFF || b > 0xFFFF) {
+	if (a < 0 || a >= 0xFFFF || b > 0xFFFF) {
 		return;
 	}
 	// if the table is nearly full just drop lines rather than probe forever
@@ -99,7 +136,7 @@ static void edge_set_insert(int a, int b)
 	}
 
 	u32 key = ((u32)(a + 1) << 16) | (u32)b;
-	u32 idx = (key * 0x9E3779B9u) >> 19; // top 13 bits, EDGE_SET_SIZE = 2^13
+	u32 idx = (key * 0x9E3779B9u) >> 20; // top 12 bits, EDGE_SET_SIZE = 2^12
 	while (sEdgeSet[idx]) {
 		if (sEdgeSet[idx] == key) {
 			return;
@@ -108,6 +145,31 @@ static void edge_set_insert(int a, int b)
 	}
 	sEdgeSet[idx] = key;
 	sEdgeSetLoad++;
+}
+
+// resolve the loaded map's collision tables (caves and above-ground store the divider
+// differently). returns false if no map / collision is loaded yet
+static bool get_collision_tables(Sys::TriangleTable** tri, Sys::VertexTable** vert)
+{
+	if (!Game::mapMgr || !Game::gameSystem) {
+		return false;
+	}
+	if (Game::gameSystem->mIsInCave) {
+		Game::RoomMapMgr* m = static_cast<Game::RoomMapMgr*>(Game::mapMgr);
+		if (!m->mMapCollision || !m->mMapCollision->mDivider) {
+			return false;
+		}
+		*tri  = m->mMapCollision->mDivider->mTriangleTable;
+		*vert = m->mMapCollision->mDivider->mVertexTable;
+	} else {
+		Game::ShapeMapMgr* m = static_cast<Game::ShapeMapMgr*>(Game::mapMgr);
+		if (!m->mMapCollision.mDivider) {
+			return false;
+		}
+		*tri  = m->mMapCollision.mDivider->mTriangleTable;
+		*vert = m->mMapCollision.mDivider->mVertexTable;
+	}
+	return true;
 }
 
 namespace gz {
@@ -127,110 +189,95 @@ bool CollisionViewer::is_navi_on_triangle(Sys::Triangle* tri, Sys::Triangle* nav
 	return true;
 }
 
-void CollisionViewer::draw_triangles(Sys::Sphere& sphere, int mode)
+// query the spatial grid ONCE and append the unique in-range triangle indices to the
+// flat gathered list. this is the expensive call (grid traversal) - doing it once and
+// iterating the flat list for every subsequent pass is the whole point of the rewrite
+static void gather_triangles(Sys::Sphere& sphere)
 {
 	Sys::TriIndexList* triLists;
-	Sys::VertexTable* vertTable;
-	Sys::TriangleTable* triTable;
 	if (Game::gameSystem->mIsInCave) {
-		Game::RoomMapMgr* roomMapMgr = static_cast<Game::RoomMapMgr*>(Game::mapMgr);
-		triLists                     = roomMapMgr->mMapCollision->mDivider->findTriLists(sphere);
-		vertTable                    = roomMapMgr->mMapCollision->mDivider->mVertexTable;
-		triTable                     = roomMapMgr->mMapCollision->mDivider->mTriangleTable;
+		triLists = static_cast<Game::RoomMapMgr*>(Game::mapMgr)->mMapCollision->mDivider->findTriLists(sphere);
 	} else {
-		Game::ShapeMapMgr* shapeMapMgr = static_cast<Game::ShapeMapMgr*>(Game::mapMgr);
-		triLists                       = shapeMapMgr->mMapCollision.mDivider->findTriLists(sphere);
-		vertTable                      = shapeMapMgr->mMapCollision.mDivider->mVertexTable;
-		triTable                       = shapeMapMgr->mMapCollision.mDivider->mTriangleTable;
+		triLists = static_cast<Game::ShapeMapMgr*>(Game::mapMgr)->mMapCollision.mDivider->findTriLists(sphere);
 	}
 
-	if (!triLists) {
-		return;
-	}
-
-	for (triLists; triLists; triLists = static_cast<Sys::TriIndexList*>(triLists->mNext)) {
+	for (; triLists; triLists = static_cast<Sys::TriIndexList*>(triLists->mNext)) {
 		for (int i = 0; i < triLists->getNum(); i++) {
 			int triIdx = triLists->mObjects[i];
-			if ((u32)triIdx >= sizeof(sTriRing) * 4) {
-				continue; // out of dedup/ring range; nothing sane to do with it
-			}
-			Sys::Triangle* tri = triTable->getTriangle(triIdx);
-
-			if (mode == MODE_MARK_BLOCKERS) {
-				if (get2(sTriRing, triIdx) == 3 && los_valid) {
-					Vector3f hit;
-					if (tri->intersect(losEdge, LOS_RADIUS, hit)) {
-						mark_tri_ring(tri, triIdx, 0);
-					}
-				}
+			if (triIdx < 0 || triIdx >= sTriCount) {
 				continue;
 			}
-
-			if (mode == MODE_MARK_RING1 || mode == MODE_MARK_RING2) {
-				// pull triangles touching a marked vertex into the next ring out
-				u32 ring = (mode == MODE_MARK_RING1) ? 1 : 2;
-				if (get2(sTriRing, triIdx) == 3 && min_vert_ring(tri) < ring) {
-					mark_tri_ring(tri, triIdx, ring);
-				}
-				continue;
-			}
-
-			// remaining modes must process each triangle exactly once (it appears in
-			// several grid cells and possibly both captains' spheres)
+			// dedup: the same triangle is returned from every grid cell it touches and
+			// from both captains' spheres
 			if (sTriVisited[triIdx >> 3] & (1 << (triIdx & 7))) {
 				continue;
 			}
-
-			if (mode == MODE_UPDATE_ALPHA) {
-				sTriVisited[triIdx >> 3] |= (u8)(1 << (triIdx & 7));
-				u32 target = get2(sTriRing, triIdx) * 5; // rings 0/1/2 -> q 0/5/10, opaque -> 15
-				int q      = (int)get4(sTriAlphaQ, triIdx);
-				if (q < (int)target) {
-					q = (q + TRANS_STEP < (int)target) ? q + TRANS_STEP : (int)target;
-				} else if (q > (int)target) {
-					q = (q - TRANS_STEP > (int)target) ? q - TRANS_STEP : (int)target;
-				}
-				set4(sTriAlphaQ, triIdx, (u32)q);
-				continue;
-			}
-
-			// draw modes: anything mid-transition still needs blending, so the split
-			// is by current alpha level, not by ring
-			u32 q = get4(sTriAlphaQ, triIdx);
-			if ((q == 15) != (mode == MODE_DRAW_OPAQUE)) {
-				continue;
-			}
 			sTriVisited[triIdx >> 3] |= (u8)(1 << (triIdx & 7));
+			sGatheredTris[sGatheredCount++] = (u16)triIdx;
+		}
+	}
+}
 
-			Color4 color = Color4(200, 200, 200, 128);
-			if (!is_navi_on_triangle(tri, olimarTriangle, vertTable) && !is_navi_on_triangle(tri, louieTriangle, vertTable)) {
-				switch (tri->mCode.getSlipCode()) {
-				case MapCode::Code::SlipCode_NoSlip:
-					color = Color4(0, 50 + 150 * fabs(tri->mTrianglePlane.mNormal.y), 0, 128);
-					break;
-				case MapCode::Code::SlipCode_Gradual:
-					color = Color4(0, 0, 50 + 150 * fabs(tri->mTrianglePlane.mNormal.y), 128);
-					break;
-				case MapCode::Code::SlipCode_Steep:
-					color = Color4(50 + 150 * fabs(tri->mTrianglePlane.mNormal.y), 0, 0, 128);
-					break;
-				}
+Color4 CollisionViewer::fill_color(Sys::Triangle* tri, Sys::VertexTable* vertTable, u32 q)
+{
+	Color4 color = Color4(200, 200, 200, 128);
+	if (!is_navi_on_triangle(tri, olimarTriangle, vertTable) && !is_navi_on_triangle(tri, louieTriangle, vertTable)) {
+		switch (tri->mCode.getSlipCode()) {
+		case MapCode::Code::SlipCode_NoSlip:
+			color = Color4(0, 50 + 150 * fabs(tri->mTrianglePlane.mNormal.y), 0, 128);
+			break;
+		case MapCode::Code::SlipCode_Gradual:
+			color = Color4(0, 0, 50 + 150 * fabs(tri->mTrianglePlane.mNormal.y), 128);
+			break;
+		case MapCode::Code::SlipCode_Steep:
+			color = Color4(50 + 150 * fabs(tri->mTrianglePlane.mNormal.y), 0, 0, 128);
+			break;
+		}
+	}
+	color.a = QALPHA[q];
+	return color;
+}
+
+// draw the gathered triangles of one alpha class (settled-opaque, or mid-fade
+// translucent) in batched GXBegin calls. one GXBegin per triangle is as fatal as one
+// per line; this batches them, chunked to stay under GXBegin's u16 vertex-count limit
+void CollisionViewer::emit_fills(Sys::TriangleTable* triTable, Sys::VertexTable* vertTable, bool opaque)
+{
+	int total = 0;
+	for (int g = 0; g < sGatheredCount; g++) {
+		if ((get4(sTriAlphaQ, sGatheredTris[g]) == 15) == opaque) {
+			total++;
+		}
+	}
+	if (total == 0) {
+		return;
+	}
+
+	const int MAX_TRIS_PER_BATCH = 21000; // 3 verts each, under GXBegin's u16 limit
+	int g                        = 0;     // cursor persists across chunks
+	int remaining                = total;
+	while (remaining > 0) {
+		int batch = (remaining < MAX_TRIS_PER_BATCH) ? remaining : MAX_TRIS_PER_BATCH;
+
+		GXBegin(GX_TRIANGLES, GX_VTXFMT0, (u16)(batch * 3));
+		int emitted = 0;
+		while (emitted < batch) {
+			int triIdx = sGatheredTris[g++];
+			u32 q      = get4(sTriAlphaQ, triIdx);
+			if ((q == 15) != opaque) {
+				continue;
 			}
-			color.a = QALPHA[q];
-
-			GXBegin(GX_TRIANGLES, GX_VTXFMT0, 3);
+			Sys::Triangle* tri = triTable->getTriangle(triIdx);
+			Color4 color       = fill_color(tri, vertTable, q);
 			for (int j = 0; j < 3; j++) {
 				Vector3f* vertex = vertTable->getVertex(tri->mVertices[j]);
 				GXPosition3f32(vertex->x, vertex->y, vertex->z);
 				GXColor4u8(color.r, color.g, color.b, color.a);
 			}
-			GXEnd();
-
-			// record the outline edges; the set collapses edges shared between triangles
-			edge_set_insert(tri->mVertices[0], tri->mVertices[1]);
-			edge_set_insert(tri->mVertices[1], tri->mVertices[2]);
-			edge_set_insert(tri->mVertices[2], tri->mVertices[0]);
+			emitted++;
 		}
+		GXEnd();
+		remaining -= batch;
 	}
 }
 
@@ -246,8 +293,14 @@ void CollisionViewer::toggle(bool enabled_)
 	}
 
 	if (enabled_ && !enabled) {
-		// start everything fully opaque rather than mid-fade from a previous session
-		memset(sTriAlphaQ, 0xFF, sizeof(sTriAlphaQ));
+		// size the working buffers to this map's collision tables
+		Sys::TriangleTable* triTable;
+		Sys::VertexTable* vertTable;
+		if (get_collision_tables(&triTable, &vertTable)) {
+			alloc_buffers(triTable->mLimit, vertTable->mLimit);
+		}
+	} else if (!enabled_) {
+		free_buffers();
 	}
 
 	enabled = enabled_;
@@ -262,6 +315,17 @@ void CollisionViewer::draw()
 
 	if (!enabled) {
 		return;
+	}
+
+	// buffers may not have been allocated yet if the viewer was toggled on before the
+	// map finished loading; allocate now that we're drawing
+	if (!sTriVisited) {
+		Sys::TriangleTable* triTable;
+		Sys::VertexTable* vertTable;
+		if (!get_collision_tables(&triTable, &vertTable)) {
+			return;
+		}
+		alloc_buffers(triTable->mLimit, vertTable->mLimit);
 	}
 
 	Game::Navi* olimar = Game::naviMgr->getAt(NAVIID_Olimar);
@@ -280,10 +344,10 @@ void CollisionViewer::draw()
 	Graphics* gfx = sys->getGfx();
 	gfx->initPrimDraw(nullptr);
 
-	memset(sTriVisited, 0, sizeof(sTriVisited));
-	memset(sEdgeSet, 0, sizeof(sEdgeSet));
-	memset(sTriRing, 0xFF, sizeof(sTriRing));
-	memset(sVertRing, 0xFF, sizeof(sVertRing));
+	memset(sTriVisited, 0, (sTriCount + 7) / 8);
+	memset(sEdgeSet, 0, EDGE_SET_SIZE * sizeof(u32));
+	memset(sTriRing, 0xFF, (sTriCount + 3) / 4);
+	memset(sVertRing, 0xFF, (sVertCount + 3) / 4);
 	sEdgeSetLoad = 0;
 
 	// sight line from the camera to the active captain; triangles crossing it (and,
@@ -300,29 +364,73 @@ void CollisionViewer::draw()
 		los_valid = true;
 	}
 
-	// mark blockers + adjacency rings, ease every triangle's alpha one step toward
-	// its target, then draw: settled-opaque fills first, the translucent set on top.
-	// vertex alpha only has an effect once blending is switched on - initPrimDraw
-	// leaves GX_BM_NONE, which renders everything opaque regardless of alpha
-	for (int mode = 0; mode < MODE_COUNT; mode++) {
-		if (mode == MODE_DRAW_OPAQUE) {
-			// the alpha-update sweep consumed the visited bits; draw passes re-dedup
-			memset(sTriVisited, 0, sizeof(sTriVisited));
+	Sys::TriangleTable* triTable;
+	Sys::VertexTable* vertTable;
+	if (!get_collision_tables(&triTable, &vertTable)) {
+		return;
+	}
+
+	// Gather the in-range triangles ONCE (the grid query is the expensive part). Every
+	// pass below iterates this flat list instead of re-querying per pass.
+	sGatheredCount = 0;
+	if (navi) {
+		gather_triangles(navi->mNaviIndex == NAVIID_Olimar ? olimarSphere : louieSphere);
+	} else {
+		// while switching captains, gather both only if they're far apart
+		gather_triangles(olimarSphere);
+		if (sqrDistanceXZ(olimarSphere.mPosition, louieSphere.mPosition) > RENDER_RADIUS / 3) {
+			gather_triangles(louieSphere);
 		}
-		if (mode == MODE_DRAW_TRANSLUCENT) {
-			GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_CLEAR);
-			GXSetZMode(GX_TRUE, GX_LESS, GX_FALSE); // translucent fills shouldn't occlude anything
-		}
-		if (navi) {
-			draw_triangles(navi->mNaviIndex == NAVIID_Olimar ? olimarSphere : louieSphere, mode);
-		} else {
-			// Minimize duplicate triangles while switching captains by only drawing triangles for both
-			// if they are arbitrarily far apart.
-			draw_triangles(olimarSphere, mode);
-			if (sqrDistanceXZ(olimarSphere.mPosition, louieSphere.mPosition) > RENDER_RADIUS / 3) {
-				draw_triangles(louieSphere, mode);
+	}
+
+	// mark the sight-blockers (ring 0), then propagate two rings of adjacency outward
+	if (los_valid) {
+		for (int g = 0; g < sGatheredCount; g++) {
+			int triIdx         = sGatheredTris[g];
+			Sys::Triangle* tri = triTable->getTriangle(triIdx);
+			Vector3f hit;
+			if (get2(sTriRing, triIdx) == 3 && tri->intersect(losEdge, LOS_RADIUS, hit)) {
+				mark_tri_ring(tri, triIdx, 0);
 			}
 		}
+		for (u32 ring = 1; ring <= 2; ring++) {
+			for (int g = 0; g < sGatheredCount; g++) {
+				int triIdx         = sGatheredTris[g];
+				Sys::Triangle* tri = triTable->getTriangle(triIdx);
+				if (get2(sTriRing, triIdx) == 3 && min_vert_ring(tri) < ring) {
+					mark_tri_ring(tri, triIdx, ring);
+				}
+			}
+		}
+	}
+
+	// ease every gathered triangle's alpha one step toward its ring's target
+	for (int g = 0; g < sGatheredCount; g++) {
+		int triIdx = sGatheredTris[g];
+		u32 target = get2(sTriRing, triIdx) * 5; // rings 0/1/2 -> q 0/5/10, opaque -> 15
+		int q      = (int)get4(sTriAlphaQ, triIdx);
+		if (q < (int)target) {
+			q = (q + TRANS_STEP < (int)target) ? q + TRANS_STEP : (int)target;
+		} else if (q > (int)target) {
+			q = (q - TRANS_STEP > (int)target) ? q - TRANS_STEP : (int)target;
+		}
+		set4(sTriAlphaQ, triIdx, (u32)q);
+	}
+
+	// settled-opaque fills first (blend still off from initPrimDraw), then the
+	// translucent set on top. vertex alpha only matters once blending is switched on
+	emit_fills(triTable, vertTable, true);
+	GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_CLEAR);
+	GXSetZMode(GX_TRUE, GX_LESS, GX_FALSE); // translucent fills shouldn't occlude anything
+	emit_fills(triTable, vertTable, false);
+
+	// collect outline edges for every gathered triangle (same radius as the fills); the
+	// set dedups edges shared between triangles
+	for (int g = 0; g < sGatheredCount; g++) {
+		Sys::Triangle* tri = triTable->getTriangle(sGatheredTris[g]);
+		edge_set_insert(tri->mVertices[0], tri->mVertices[1]);
+		edge_set_insert(tri->mVertices[1], tri->mVertices[2]);
+		edge_set_insert(tri->mVertices[2], tri->mVertices[0]);
 	}
 
 	// thin outlines along the (deduplicated) triangle edges
@@ -330,28 +438,27 @@ void CollisionViewer::draw()
 	GXSetZMode(GX_TRUE, GX_LEQUAL, GX_TRUE); // LEQUAL so lines coplanar with fills pass the z test
 	GXSetLineWidth(6, GX_TO_ZERO);
 
-	Sys::VertexTable* vertTable = nullptr;
-	if (Game::gameSystem->mIsInCave) {
-		vertTable = static_cast<Game::RoomMapMgr*>(Game::mapMgr)->mMapCollision->mDivider->mVertexTable;
+	if (sEdgeSetLoad == 0) {
+		return;
 	}
-	vertTable = static_cast<Game::ShapeMapMgr*>(Game::mapMgr)->mMapCollision.mDivider->mVertexTable;
 
+	// Emit ALL line segments in a single GXBegin batch. A per-edge GXBegin/GXEnd makes
+	// each 2-vertex line its own GP primitive setup - thousands of those tank the frame
+	// rate (worst-case setup-to-pixel ratio). One batch is one setup for the whole set.
+	GXBegin(GX_LINES, GX_VTXFMT0, (u16)(sEdgeSetLoad * 2));
 	for (u32 i = 0; i < EDGE_SET_SIZE; i++) {
 		u32 key = sEdgeSet[i];
 		if (!key) {
 			continue;
 		}
-
 		Vector3f* va = vertTable->getVertex((int)(key >> 16) - 1);
 		Vector3f* vb = vertTable->getVertex((int)(key & 0xFFFF));
-
-		GXBegin(GX_LINES, GX_VTXFMT0, 2);
 		GXPosition3f32(va->x, va->y, va->z);
 		GXColor4u8(20, 20, 20, 255);
 		GXPosition3f32(vb->x, vb->y, vb->z);
 		GXColor4u8(20, 20, 20, 255);
-		GXEnd();
 	}
+	GXEnd();
 }
 } // namespace gz
 

--- a/src/p2gz/collisionViewer.cpp
+++ b/src/p2gz/collisionViewer.cpp
@@ -114,6 +114,10 @@ void CollisionViewer::gather_triangles(Sys::Sphere& sphere)
 // https://en.wikipedia.org/wiki/Hash_function#Fibonacci_hashing
 void CollisionViewer::edge_set_insert(int a, int b)
 {
+	if (edge_count >= EDGE_SET_SIZE) {
+		return;
+	}
+
 	// order the pair so (a, b) and (b, a) are the same edge
 	if (a > b) {
 		int tmp = a;


### PR DESCRIPTION
Draws edges between collision triangles and reduces the opacity of triangles that occlude the captain.
<img width="642" height="512" alt="image" src="https://github.com/user-attachments/assets/a94c1de9-b3c0-485e-af87-33b58d8c2c55" />
<img width="642" height="512" alt="image" src="https://github.com/user-attachments/assets/939887d2-2a34-492f-9047-8299d29a0349" />
