### PR TITLE
Fix enemy presets + stale warp menu bug

### DIFF
--- a/assets/files/presets/at/bk1-4.txt
+++ b/assets/files/presets/at/bk1-4.txt
@@ -114,43 +114,50 @@ AT 	# category
 2	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
 	2	1408.7	1625.2				0	# SR plug
-10 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	1	-1
-	84 	-899.460022 -20.000000 1109.540039 	2	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	10 	-347.220001 -20.000000 4107.390137 	1	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	15 	-383.959991 30.000000 575.849976 	1	-1
-	15 	-71.489998 -20.000000 1117.589966 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	0 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	1 	# Onion Replica
-	72 	1 	# Aquatic Mine
-	77 	1 	# Impediment Scourge
-	118 	1 	# Massage Girdle
-	140 	1 	# Optical Illustration
-	152 	1 	# Fortified Delicacy
-	172 	1 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+25 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	9	# AW Cloaking Burrow-nit
+	1	15	-383.960480 29.999977 575.847656	9	# AW Cloaking Burrow-nit (BO)
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	1	10	-347.220551 -20.000000 4107.389648	9	# AW Iridescent Glint Beetle (SH)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+	2	101	950.000000 -57.000000 475.000000	8	# PP Toady Bloyster
+18 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
+	2	53	0	# PP Onion Replica
+	2	72	0	# PP Aquatic Mine
+	2	77	0	# PP Impediment Scourge
+	2	118	0	# PP Massage Girdle
+	2	140	0	# PP Optical Illustration
+	2	152	0	# PP Fortified Delicacy
+	2	172	0	# PP Gherkin Gate
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/bk5-6.txt
+++ b/assets/files/presets/at/bk5-6.txt
@@ -114,43 +114,50 @@ AT 	# category
 2	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
 	2	1408.7	1625.2				0	# SR plug
-10 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	1	-1
-	84 	-899.460022 -20.000000 1109.540039 	2	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	10 	-347.220001 -20.000000 4107.390137 	1	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	15 	-383.959991 30.000000 575.849976 	1	-1
-	15 	-71.489998 -20.000000 1117.589966 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	0 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	1 	# Onion Replica
-	72 	1 	# Aquatic Mine
-	77 	1 	# Impediment Scourge
-	118 	1 	# Massage Girdle
-	140 	1 	# Optical Illustration
-	152 	1 	# Fortified Delicacy
-	172 	1 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+25 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	9	# AW Cloaking Burrow-nit
+	1	15	-383.960480 29.999977 575.847656	9	# AW Cloaking Burrow-nit (BO)
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	1	10	-347.220551 -20.000000 4107.389648	9	# AW Iridescent Glint Beetle (SH)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+	2	101	950.000000 -57.000000 475.000000	8	# PP Toady Bloyster
+18 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
+	2	53	0	# PP Onion Replica
+	2	72	0	# PP Aquatic Mine
+	2	77	0	# PP Impediment Scourge
+	2	118	0	# PP Massage Girdle
+	2	140	0	# PP Optical Illustration
+	2	152	0	# PP Fortified Delicacy
+	2	172	0	# PP Gherkin Gate
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/bk7.txt
+++ b/assets/files/presets/at/bk7.txt
@@ -114,43 +114,50 @@ AT 	# category
 2	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
 	2	1408.7	1625.2				0	# SR plug
-10 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	1	-1
-	84 	-899.460022 -20.000000 1109.540039 	2	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	10 	-347.220001 -20.000000 4107.390137 	1	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	15 	-383.959991 30.000000 575.849976 	1	-1
-	15 	-71.489998 -20.000000 1117.589966 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	0 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	1 	# Onion Replica
-	72 	1 	# Aquatic Mine
-	77 	1 	# Impediment Scourge
-	118 	1 	# Massage Girdle
-	140 	1 	# Optical Illustration
-	152 	1 	# Fortified Delicacy
-	172 	1 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+25 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	9	# AW Cloaking Burrow-nit
+	1	15	-383.960480 29.999977 575.847656	9	# AW Cloaking Burrow-nit (BO)
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	1	10	-347.220551 -20.000000 4107.389648	9	# AW Iridescent Glint Beetle (SH)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+	2	101	950.000000 -57.000000 475.000000	8	# PP Toady Bloyster
+18 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
+	2	53	0	# PP Onion Replica
+	2	72	0	# PP Aquatic Mine
+	2	77	0	# PP Impediment Scourge
+	2	118	0	# PP Massage Girdle
+	2	140	0	# PP Optical Illustration
+	2	152	0	# PP Fortified Delicacy
+	2	172	0	# PP Gherkin Gate
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/coc1-10.txt
+++ b/assets/files/presets/at/coc1-10.txt
@@ -120,53 +120,60 @@ AT 	# category
 2	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
 	2	1408.7	1625.2				0	# SR plug
-20 	# num enemy spawns
-	78 	-1576.150024 20.000000 1320.489990 	1	-1
-	1 	-3232.669922 0.000000 -123.870003 	1	-1
-	1 	-2245.250000 50.000000 676.880005 	1	-1
-	23 	-2781.399902 -30.000000 162.669998 	2	-1
-	95 	-3007.169922 -30.000000 574.859985 	1	-1
-	15 	-1340.170044 30.000000 491.329987 	1	-1
-	24 	-1310.869995 30.000000 346.839996 	1	-1
-	21 	-1218.459961 23.950001 766.489990 	2	-1
-	21 	-1220.699951 22.190001 679.390015 	2	-1
-	17 	-1500.079956 -10.000000 1002.669983 	2	-1
-	55 	-342.399994 0.000000 1391.130005 	2	-1
-	55 	-92.239998 0.000000 1681.890015 	2	-1
-	84 	-145.679993 0.000000 1537.790039 	2	-1
-	84 	-467.910004 0.000000 1477.599976 	2	-1
-	84 	-241.839996 0.000000 1716.819946 	2	-1
-	63 	-3538.899902 -30.000000 1044.170044 	2	-1
-	14 	-2976.199951 0.000000 2237.370117 	2	-1
-	75 	-2172.050049 30.000000 2714.399902 	2	-1
-	24 	-2992.959961 0.000000 1651.540039 	2	-1
-	25 	-3244.419922 0.000000 2052.760010 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	1
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	185 	1 	# Air Brake
-	53 	1 	# Onion Replica
-	72 	1 	# Aquatic Mine
-	77 	1 	# Impediment Scourge
-	118 	1 	# Massage Girdle
-	140 	1 	# Optical Illustration
-	152 	1 	# Fortified Delicacy
-	172 	1 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	1 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+31 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	9	# AW Cloaking Burrow-nit
+	1	15	-383.960480 29.999977 575.847656	9	# AW Cloaking Burrow-nit (BO)
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	1	10	-347.220551 -20.000000 4107.389648	9	# AW Iridescent Glint Beetle (SH)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+	2	101	950.000000 -57.000000 475.000000	8	# PP Toady Bloyster
+	3	1	-3232.669922 0.000000 -123.870003	10	# WW Dwarf Bulborb x2 (base)
+	3	1	-2245.250000 50.000000 676.880005	10	# WW Dwarf Bulborb x3
+	3	78	-1576.150024 20.000000 1320.489990	10	# WW Gatling Groink
+	3	95	-3007.169922 -30.000000 574.859985	10	# WW Decorated Cannon Beetle
+	3	15	-1340.170044 30.000000 491.329987	10	# WW Cloaking Burrow-nit
+	3	24	-1310.869995 30.000000 346.839996	10	# WW Fiery Blowhog
+22 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	44	0	# AW Decorative Goo
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	1	185	0	# AW Air Brake
+	2	53	0	# PP Onion Replica
+	2	72	0	# PP Aquatic Mine
+	2	77	0	# PP Impediment Scourge
+	2	118	0	# PP Massage Girdle
+	2	140	0	# PP Optical Illustration
+	2	152	0	# PP Fortified Delicacy
+	2	172	0	# PP Gherkin Gate
+	3	76	0	# WW Doomsday Apparatus
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/cos1-2.txt
+++ b/assets/files/presets/at/cos1-2.txt
@@ -93,38 +93,37 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-5 	# num enemy spawns
-	17 	-950.000000 6.250000 -150.000000 	1	-1
-	0 	-480.000000 89.010002 -1115.000000 	1	-1
-	0 	-666.000000 89.010002 -800.000000 	1	-1
-	0 	-375.000000 89.010002 -800.000000 	1	-1
-	23 	-650.000000 52.889999 -1800.000000 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+19 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP (YO)
+11 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/cos3-5.txt
+++ b/assets/files/presets/at/cos3-5.txt
@@ -93,38 +93,37 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-5 	# num enemy spawns
-	17 	-950.000000 6.250000 -150.000000 	1	-1
-	0 	-480.000000 89.010002 -1115.000000 	1	-1
-	0 	-666.000000 89.010002 -800.000000 	1	-1
-	0 	-375.000000 89.010002 -800.000000 	1	-1
-	23 	-650.000000 52.889999 -1800.000000 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+19 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP (YO)
+11 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/day2.txt
+++ b/assets/files/presets/at/day2.txt
@@ -21,27 +21,7 @@ AT 	# category
 0 	# num finished bridges
 0 	# num flattened bags
 0	# num plugs destroyed
-10 	# num enemy spawns
-	1 	-1153.00	47.00	2231.00 2	-1	# dwarf bulborb on manhole cover
-	1	-585.96		0.00	2782.99	2	-1	# dwarf bulborb in landing site
-	0	52.87		9.17	3055.3 	1	-1	# 5 pellet behind ship
-	0	-21.92		0.00	2870.73	2	-1	# 1 pellets behind red onion
-	37	424.30		125.00	2897.12	1	-1	# eggs behind ship
-	0	-400.92		0.00	2646.80	1	-1	# 1 pellet next to red onion
-	0	-259.88		50.00	2476.48	1	-1	# 10 pellet on ledge
-	0	-584.42		0.00	3160.87	1	-1	# 1 pellet near blue onion spot
-	0	-1342.39	4.20	2825.76	1	-1	# left 5 pellet in bag area
-	0	-1340.81	0.00	2606.4	1	-1	# right 5 pellet in bag area
-10 	# num treasure spawn overrides
-	42 		2 	# Sunseed Berry
-	130 	2 	# Pilgrim Bulb
-	11 		2 	# Geographic Projection
-	155 	2 	# Chance Totem
-	173 	2 	# Healing Cask
-	142 	2 	# Courage Reactor
-	62 		2 	# Pink Menace
-	87 		2 	# Utter Scrap
-	157 	2 	# Spiny Alien Treat
-	47 		2 	# Fossilized Ursidae
+0 	# num enemy spawns
+0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/day4.txt
+++ b/assets/files/presets/at/day4.txt
@@ -27,8 +27,7 @@ AT 	# category
 0 	# num finished bridges
 0 	# num flattened bags
 0	# num plugs destroyed
-1 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	2	-1
+0 	# num enemy spawns
 0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/day_5_cleanup.txt
+++ b/assets/files/presets/at/day_5_cleanup.txt
@@ -66,42 +66,10 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-9 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	1	-1
-	84 	-899.460022 -20.000000 1109.540039 	2	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	17 	-1631.420044 -53.000000 3351.949951 	2	-1
-	17 	-1388.689941 -53.000000 3972.270020 	2	-1
-26 	# num treasure spawn overrides
-	47 	2 	# Fossilized Ursidae
-	62 	2 	# Pink Menace
-	71 	2 	# Unspeakable Wonder
-	73 	2 	# Temporal Mechanism
-	87 	2 	# Utter Scrap
-	142 	2 	# Courage Reactor
-	157 	2 	# Spiny Alien Treat
-	11 	2 	# Geographic Projection
-	42 	2 	# Sunseed Berry
-	43 	0
-	130 	2 	# Pilgrim Bulb
-	155 	0 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	2 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+3 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/dd1-9.txt
+++ b/assets/files/presets/at/dd1-9.txt
@@ -122,53 +122,62 @@ AT 	# category
 2	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
 	2	1408.7	1625.2				0	# SR plug
-20 	# num enemy spawns
-	78 	-1576.150024 20.000000 1320.489990 	1	-1
-	1 	-3232.669922 0.000000 -123.870003 	1	-1
-	1 	-2245.250000 50.000000 676.880005 	1	-1
-	23 	-2781.399902 -30.000000 162.669998 	1	-1
-	95 	-3007.169922 -30.000000 574.859985 	1	-1
-	15 	-1340.170044 30.000000 491.329987 	1	-1
-	24 	-1310.869995 30.000000 346.839996 	1	-1
-	21 	-1218.459961 23.950001 766.489990 	2	-1
-	21 	-1220.699951 22.190001 679.390015 	2	-1
-	17 	-1500.079956 -10.000000 1002.669983 	2	-1
-	55 	-342.399994 0.000000 1391.130005 	2	-1
-	55 	-92.239998 0.000000 1681.890015 	2	-1
-	84 	-145.679993 0.000000 1537.790039 	2	-1
-	84 	-467.910004 0.000000 1477.599976 	2	-1
-	84 	-241.839996 0.000000 1716.819946 	2	-1
-	63 	-3538.899902 -30.000000 1044.170044 	2	-1
-	14 	-2976.199951 0.000000 2237.370117 	2	-1
-	75 	-2172.050049 30.000000 2714.399902 	2	-1
-	24 	-2992.959961 0.000000 1651.540039 	2	-1
-	25 	-3244.419922 0.000000 2052.760010 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	1
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	185 	1 	# Air Brake
-	53 	1 	# Onion Replica
-	72 	1 	# Aquatic Mine
-	77 	1 	# Impediment Scourge
-	118 	1 	# Massage Girdle
-	140 	1 	# Optical Illustration
-	152 	1 	# Fortified Delicacy
-	172 	1 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	1 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+33 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	9	# AW Cloaking Burrow-nit
+	1	15	-383.960480 29.999977 575.847656	9	# AW Cloaking Burrow-nit (BO)
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	1	10	-347.220551 -20.000000 4107.389648	9	# AW Iridescent Glint Beetle (SH)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+	2	101	950.000000 -57.000000 475.000000	8	# PP Toady Bloyster
+	3	1	-3232.669922 0.000000 -123.870003	10	# WW Dwarf Bulborb x2 (base)
+	3	1	-2245.250000 50.000000 676.880005	10	# WW Dwarf Bulborb x3
+	3	78	-1576.150024 20.000000 1320.489990	10	# WW Gatling Groink
+	3	95	-3007.169922 -30.000000 574.859985	10	# WW Decorated Cannon Beetle
+	3	15	-1340.170044 30.000000 491.329987	10	# WW Cloaking Burrow-nit
+	3	24	-1310.869995 30.000000 346.839996	10	# WW Fiery Blowhog
+	3	23	-2781.398193 -30.000000 162.671936	10	# WW Swooping Snitchbug
+	3	37	-2818.194824 40.000000 671.756287	10	# WW Egg x3
+22 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	44	0	# AW Decorative Goo
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	1	185	0	# AW Air Brake
+	2	53	0	# PP Onion Replica
+	2	72	0	# PP Aquatic Mine
+	2	77	0	# PP Impediment Scourge
+	2	118	0	# PP Massage Girdle
+	2	140	0	# PP Optical Illustration
+	2	152	0	# PP Fortified Delicacy
+	2	172	0	# PP Gherkin Gate
+	3	76	0	# WW Doomsday Apparatus
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/dd10-14.txt
+++ b/assets/files/presets/at/dd10-14.txt
@@ -122,53 +122,62 @@ AT 	# category
 2	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
 	2	1408.7	1625.2				0	# SR plug
-20 	# num enemy spawns
-	78 	-1576.150024 20.000000 1320.489990 	1	-1
-	1 	-3232.669922 0.000000 -123.870003 	1	-1
-	1 	-2245.250000 50.000000 676.880005 	1	-1
-	23 	-2781.399902 -30.000000 162.669998 	1	-1
-	95 	-3007.169922 -30.000000 574.859985 	1	-1
-	15 	-1340.170044 30.000000 491.329987 	1	-1
-	24 	-1310.869995 30.000000 346.839996 	1	-1
-	21 	-1218.459961 23.950001 766.489990 	2	-1
-	21 	-1220.699951 22.190001 679.390015 	2	-1
-	17 	-1500.079956 -10.000000 1002.669983 	2	-1
-	55 	-342.399994 0.000000 1391.130005 	2	-1
-	55 	-92.239998 0.000000 1681.890015 	2	-1
-	84 	-145.679993 0.000000 1537.790039 	2	-1
-	84 	-467.910004 0.000000 1477.599976 	2	-1
-	84 	-241.839996 0.000000 1716.819946 	2	-1
-	63 	-3538.899902 -30.000000 1044.170044 	2	-1
-	14 	-2976.199951 0.000000 2237.370117 	2	-1
-	75 	-2172.050049 30.000000 2714.399902 	2	-1
-	24 	-2992.959961 0.000000 1651.540039 	2	-1
-	25 	-3244.419922 0.000000 2052.760010 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	1
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	185 	1 	# Air Brake
-	53 	1 	# Onion Replica
-	72 	1 	# Aquatic Mine
-	77 	1 	# Impediment Scourge
-	118 	1 	# Massage Girdle
-	140 	1 	# Optical Illustration
-	152 	1 	# Fortified Delicacy
-	172 	1 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	1 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+33 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	9	# AW Cloaking Burrow-nit
+	1	15	-383.960480 29.999977 575.847656	9	# AW Cloaking Burrow-nit (BO)
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	1	10	-347.220551 -20.000000 4107.389648	9	# AW Iridescent Glint Beetle (SH)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+	2	101	950.000000 -57.000000 475.000000	8	# PP Toady Bloyster
+	3	1	-3232.669922 0.000000 -123.870003	10	# WW Dwarf Bulborb x2 (base)
+	3	1	-2245.250000 50.000000 676.880005	10	# WW Dwarf Bulborb x3
+	3	78	-1576.150024 20.000000 1320.489990	10	# WW Gatling Groink
+	3	95	-3007.169922 -30.000000 574.859985	10	# WW Decorated Cannon Beetle
+	3	15	-1340.170044 30.000000 491.329987	10	# WW Cloaking Burrow-nit
+	3	24	-1310.869995 30.000000 346.839996	10	# WW Fiery Blowhog
+	3	23	-2781.398193 -30.000000 162.671936	10	# WW Swooping Snitchbug
+	3	37	-2818.194824 40.000000 671.756287	10	# WW Egg x3
+22 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	44	0	# AW Decorative Goo
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	1	185	0	# AW Air Brake
+	2	53	0	# PP Onion Replica
+	2	72	0	# PP Aquatic Mine
+	2	77	0	# PP Impediment Scourge
+	2	118	0	# PP Massage Girdle
+	2	140	0	# PP Optical Illustration
+	2	152	0	# PP Fortified Delicacy
+	2	172	0	# PP Gherkin Gate
+	3	76	0	# WW Doomsday Apparatus
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/ec1-2_2nd_visit.txt
+++ b/assets/files/presets/at/ec1-2_2nd_visit.txt
@@ -41,7 +41,8 @@ AT 	# category
 	0 	-910.700012 2769.199951 	0 	# landing area bag (15)
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 0	# num plugs destroyed
-0 	# num enemy spawns
+1 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
 0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/ec1_1st_visit.txt
+++ b/assets/files/presets/at/ec1_1st_visit.txt
@@ -35,7 +35,8 @@ AT 	# category
 	0 	-910.700012 2769.199951 	0 	# landing area bag (15)
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 0	# num plugs destroyed
-0 	# num enemy spawns
+1 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
 0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/ec2_1st_visit.txt
+++ b/assets/files/presets/at/ec2_1st_visit.txt
@@ -37,7 +37,8 @@ AT 	# category
 	0 	-910.700012 2769.199951 	0 	# landing area bag (15)
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 0	# num plugs destroyed
-0 	# num enemy spawns
+1 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
 0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/enter_bk.txt
+++ b/assets/files/presets/at/enter_bk.txt
@@ -109,43 +109,47 @@ AT 	# category
 2	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
 	2	1408.7	1625.2				0	# SR plug
-10 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	2	-1
-	84 	-899.460022 -20.000000 1109.540039 	2	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	10 	-347.220001 -20.000000 4107.390137 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	15 	-383.959991 30.000000 575.849976 	2	-1
-	15 	-71.489998 -20.000000 1117.589966 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	1 	# Onion Replica
-	72 	1 	# Aquatic Mine
-	77 	1 	# Impediment Scourge
-	118 	1 	# Massage Girdle
-	140 	1 	# Optical Illustration
-	152 	1 	# Fortified Delicacy
-	172 	1 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+22 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+	2	101	950.000000 -57.000000 475.000000	8	# PP Toady Bloyster
+18 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
+	2	53	0	# PP Onion Replica
+	2	72	0	# PP Aquatic Mine
+	2	77	0	# PP Impediment Scourge
+	2	118	0	# PP Massage Girdle
+	2	140	0	# PP Optical Illustration
+	2	152	0	# PP Fortified Delicacy
+	2	172	0	# PP Gherkin Gate
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/enter_coc.txt
+++ b/assets/files/presets/at/enter_coc.txt
@@ -118,53 +118,53 @@ AT 	# category
 2	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
 	2	1408.7	1625.2				0	# SR plug
-20 	# num enemy spawns
-	78 	-1576.150024 20.000000 1320.489990 	2	-1
-	1 	-3232.669922 0.000000 -123.870003 	2	-1
-	1 	-2245.250000 50.000000 676.880005 	2	-1
-	23 	-2781.399902 -30.000000 162.669998 	2	-1
-	95 	-3007.169922 -30.000000 574.859985 	2	-1
-	15 	-1340.170044 30.000000 491.329987 	2	-1
-	24 	-1310.869995 30.000000 346.839996 	2	-1
-	21 	-1218.459961 23.950001 766.489990 	2	-1
-	21 	-1220.699951 22.190001 679.390015 	2	-1
-	17 	-1500.079956 -10.000000 1002.669983 	2	-1
-	55 	-342.399994 0.000000 1391.130005 	2	-1
-	55 	-92.239998 0.000000 1681.890015 	2	-1
-	84 	-145.679993 0.000000 1537.790039 	2	-1
-	84 	-467.910004 0.000000 1477.599976 	2	-1
-	84 	-241.839996 0.000000 1716.819946 	2	-1
-	63 	-3538.899902 -30.000000 1044.170044 	2	-1
-	14 	-2976.199951 0.000000 2237.370117 	2	-1
-	75 	-2172.050049 30.000000 2714.399902 	2	-1
-	24 	-2992.959961 0.000000 1651.540039 	2	-1
-	25 	-3244.419922 0.000000 2052.760010 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	1
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	185 	1 	# Air Brake
-	53 	1 	# Onion Replica
-	72 	1 	# Aquatic Mine
-	77 	1 	# Impediment Scourge
-	118 	1 	# Massage Girdle
-	140 	1 	# Optical Illustration
-	152 	1 	# Fortified Delicacy
-	172 	1 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+25 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	9	# AW Cloaking Burrow-nit
+	1	15	-383.960480 29.999977 575.847656	9	# AW Cloaking Burrow-nit (BO)
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	1	10	-347.220551 -20.000000 4107.389648	9	# AW Iridescent Glint Beetle (SH)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+	2	101	950.000000 -57.000000 475.000000	8	# PP Toady Bloyster
+21 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	44	0	# AW Decorative Goo
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	1	185	0	# AW Air Brake
+	2	53	0	# PP Onion Replica
+	2	72	0	# PP Aquatic Mine
+	2	77	0	# PP Impediment Scourge
+	2	118	0	# PP Massage Girdle
+	2	140	0	# PP Optical Illustration
+	2	152	0	# PP Fortified Delicacy
+	2	172	0	# PP Gherkin Gate
 0	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/enter_cos.txt
+++ b/assets/files/presets/at/enter_cos.txt
@@ -90,37 +90,33 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-4 	# num enemy spawns
-	17 	-950.000000 6.250000 -150.000000 	2	-1
-	0 	-480.000000 89.010002 -1115.000000 	2	-1
-	0 	-666.000000 89.010002 -800.000000 	2	-1
-	0 	-375.000000 89.010002 -800.000000 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+15 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+11 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 0	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/enter_dd.txt
+++ b/assets/files/presets/at/enter_dd.txt
@@ -120,53 +120,60 @@ AT 	# category
 2	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
 	2	1408.7	1625.2				0	# SR plug
-20 	# num enemy spawns
-	78 	-1576.150024 20.000000 1320.489990 	1	-1
-	1 	-3232.669922 0.000000 -123.870003 	1	-1
-	1 	-2245.250000 50.000000 676.880005 	1	-1
-	23 	-2781.399902 -30.000000 162.669998 	2	-1
-	95 	-3007.169922 -30.000000 574.859985 	1	-1
-	15 	-1340.170044 30.000000 491.329987 	1	-1
-	24 	-1310.869995 30.000000 346.839996 	1	-1
-	21 	-1218.459961 23.950001 766.489990 	2	-1
-	21 	-1220.699951 22.190001 679.390015 	2	-1
-	17 	-1500.079956 -10.000000 1002.669983 	2	-1
-	55 	-342.399994 0.000000 1391.130005 	2	-1
-	55 	-92.239998 0.000000 1681.890015 	2	-1
-	84 	-145.679993 0.000000 1537.790039 	2	-1
-	84 	-467.910004 0.000000 1477.599976 	2	-1
-	84 	-241.839996 0.000000 1716.819946 	2	-1
-	63 	-3538.899902 -30.000000 1044.170044 	2	-1
-	14 	-2976.199951 0.000000 2237.370117 	2	-1
-	75 	-2172.050049 30.000000 2714.399902 	2	-1
-	24 	-2992.959961 0.000000 1651.540039 	2	-1
-	25 	-3244.419922 0.000000 2052.760010 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	1
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	185 	1 	# Air Brake
-	53 	1 	# Onion Replica
-	72 	1 	# Aquatic Mine
-	77 	1 	# Impediment Scourge
-	118 	1 	# Massage Girdle
-	140 	1 	# Optical Illustration
-	152 	1 	# Fortified Delicacy
-	172 	1 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	1 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+31 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	9	# AW Cloaking Burrow-nit
+	1	15	-383.960480 29.999977 575.847656	9	# AW Cloaking Burrow-nit (BO)
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	1	10	-347.220551 -20.000000 4107.389648	9	# AW Iridescent Glint Beetle (SH)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+	2	101	950.000000 -57.000000 475.000000	8	# PP Toady Bloyster
+	3	1	-3232.669922 0.000000 -123.870003	10	# WW Dwarf Bulborb x2 (base)
+	3	1	-2245.250000 50.000000 676.880005	10	# WW Dwarf Bulborb x3
+	3	78	-1576.150024 20.000000 1320.489990	10	# WW Gatling Groink
+	3	95	-3007.169922 -30.000000 574.859985	10	# WW Decorated Cannon Beetle
+	3	15	-1340.170044 30.000000 491.329987	10	# WW Cloaking Burrow-nit
+	3	24	-1310.869995 30.000000 346.839996	10	# WW Fiery Blowhog
+22 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	44	0	# AW Decorative Goo
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	1	185	0	# AW Air Brake
+	2	53	0	# PP Onion Replica
+	2	72	0	# PP Aquatic Mine
+	2	77	0	# PP Impediment Scourge
+	2	118	0	# PP Massage Girdle
+	2	140	0	# PP Optical Illustration
+	2	152	0	# PP Fortified Delicacy
+	2	172	0	# PP Gherkin Gate
+	3	76	0	# WW Doomsday Apparatus
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/enter_fc.txt
+++ b/assets/files/presets/at/enter_fc.txt
@@ -82,42 +82,18 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-9 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	1	-1
-	24 	548.539978 100.000000 546.479980 	2	-1
-	24 	300.910004 100.000000 361.600006 	2	-1
-	26 	340.790009 15.000000 868.559998 	2	-1
-	26 	145.539993 18.870001 618.030029 	2	-1
-	95 	-244.220001 100.000000 326.779999 	2	-1
-	95 	302.179993 100.000000 -177.910004 	2	-1
-	96 	182.160004 210.000000 -1559.790039 	2	-1
-	55 	-271.089996 114.000000 -1387.319946 	2	-1
-26 	# num treasure spawn overrides
-	47 	2 	# Fossilized Ursidae
-	62 	2 	# Pink Menace
-	71 	2 	# Unspeakable Wonder
-	73 	2 	# Temporal Mechanism
-	87 	0 	# Utter Scrap
-	142 	2 	# Courage Reactor
-	157 	2 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+7 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+4 	# num treasure spawn overrides
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/enter_gk.txt
+++ b/assets/files/presets/at/enter_gk.txt
@@ -94,38 +94,37 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-5 	# num enemy spawns
-	17 	-950.000000 6.250000 -150.000000 	1	-1
-	0 	-480.000000 89.010002 -1115.000000 	1	-1
-	0 	-666.000000 89.010002 -800.000000 	1	-1
-	0 	-375.000000 89.010002 -800.000000 	1	-1
-	23 	-650.000000 52.889999 -1800.000000 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+19 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP (YO)
+11 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/enter_hob.txt
+++ b/assets/files/presets/at/enter_hob.txt
@@ -55,45 +55,10 @@ AT 	# category
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 0	# num plugs destroyed
-12 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	1	-1
-	84 	-899.460022 -20.000000 1109.540039 	2	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	0 	13.000000 15.000000 211.000000 	2	-1
-	0 	209.000000 10.000000 -206.000000 	2	-1
-	0 	14.000000 15.000000 -263.000000 	2	-1
-	0 	-258.000000 15.000000 -133.000000 	2	-1
-	27 	-36.439999 15.000000 -104.839996 	2	-1
-26 	# num treasure spawn overrides
-	47 	2 	# Fossilized Ursidae
-	62 	2 	# Pink Menace
-	71 	2 	# Unspeakable Wonder
-	73 	2 	# Temporal Mechanism
-	87 	2 	# Utter Scrap
-	142 	2 	# Courage Reactor
-	157 	2 	# Spiny Alien Treat
-	11 	2 	# Geographic Projection
-	42 	2 	# Sunseed Berry
-	43 	2
-	130 	2 	# Pilgrim Bulb
-	155 	2 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	2 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+3 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/enter_hoh.txt
+++ b/assets/files/presets/at/enter_hoh.txt
@@ -124,53 +124,62 @@ AT 	# category
 2	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
 	2	1408.7	1625.2				0	# SR plug
-20 	# num enemy spawns
-	78 	-1576.150024 20.000000 1320.489990 	1	-1
-	1 	-3232.669922 0.000000 -123.870003 	1	-1
-	1 	-2245.250000 50.000000 676.880005 	1	-1
-	23 	-2781.399902 -30.000000 162.669998 	1	-1
-	95 	-3007.169922 -30.000000 574.859985 	1	-1
-	15 	-1340.170044 30.000000 491.329987 	1	-1
-	24 	-1310.869995 30.000000 346.839996 	1	-1
-	21 	-1218.459961 23.950001 766.489990 	2	-1
-	21 	-1220.699951 22.190001 679.390015 	2	-1
-	17 	-1500.079956 -10.000000 1002.669983 	2	-1
-	55 	-342.399994 0.000000 1391.130005 	2	-1
-	55 	-92.239998 0.000000 1681.890015 	2	-1
-	84 	-145.679993 0.000000 1537.790039 	2	-1
-	84 	-467.910004 0.000000 1477.599976 	2	-1
-	84 	-241.839996 0.000000 1716.819946 	2	-1
-	63 	-3538.899902 -30.000000 1044.170044 	2	-1
-	14 	-2976.199951 0.000000 2237.370117 	2	-1
-	75 	-2172.050049 30.000000 2714.399902 	2	-1
-	24 	-2992.959961 0.000000 1651.540039 	2	-1
-	25 	-3244.419922 0.000000 2052.760010 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	1
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	185 	1 	# Air Brake
-	53 	1 	# Onion Replica
-	72 	1 	# Aquatic Mine
-	77 	1 	# Impediment Scourge
-	118 	1 	# Massage Girdle
-	140 	1 	# Optical Illustration
-	152 	1 	# Fortified Delicacy
-	172 	1 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	1 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+33 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	9	# AW Cloaking Burrow-nit
+	1	15	-383.960480 29.999977 575.847656	9	# AW Cloaking Burrow-nit (BO)
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	1	10	-347.220551 -20.000000 4107.389648	9	# AW Iridescent Glint Beetle (SH)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+	2	101	950.000000 -57.000000 475.000000	8	# PP Toady Bloyster
+	3	1	-3232.669922 0.000000 -123.870003	10	# WW Dwarf Bulborb x2 (base)
+	3	1	-2245.250000 50.000000 676.880005	10	# WW Dwarf Bulborb x3
+	3	78	-1576.150024 20.000000 1320.489990	10	# WW Gatling Groink
+	3	95	-3007.169922 -30.000000 574.859985	10	# WW Decorated Cannon Beetle
+	3	15	-1340.170044 30.000000 491.329987	10	# WW Cloaking Burrow-nit
+	3	24	-1310.869995 30.000000 346.839996	10	# WW Fiery Blowhog
+	3	23	-2781.398193 -30.000000 162.671936	10	# WW Swooping Snitchbug
+	3	37	-2818.194824 40.000000 671.756287	10	# WW Egg x3
+22 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	44	0	# AW Decorative Goo
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	1	185	0	# AW Air Brake
+	2	53	0	# PP Onion Replica
+	2	72	0	# PP Aquatic Mine
+	2	77	0	# PP Impediment Scourge
+	2	118	0	# PP Massage Girdle
+	2	140	0	# PP Optical Illustration
+	2	152	0	# PP Fortified Delicacy
+	2	172	0	# PP Gherkin Gate
+	3	76	0	# WW Doomsday Apparatus
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/enter_scx.txt
+++ b/assets/files/presets/at/enter_scx.txt
@@ -74,38 +74,16 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 0	# num plugs destroyed
 6 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	2	-1
-	24 	548.539978 100.000000 546.479980 	2	-1
-	24 	300.910004 100.000000 361.600006 	2	-1
-	26 	340.790009 15.000000 868.559998 	2	-1
-	26 	145.539993 18.870001 618.030029 	2	-1
-	95 	-244.220001 100.000000 326.779999 	2	-1
-26 	# num treasure spawn overrides
-	47 	2 	# Fossilized Ursidae
-	62 	2 	# Pink Menace
-	71 	2 	# Unspeakable Wonder
-	73 	2 	# Temporal Mechanism
-	87 	2 	# Utter Scrap
-	142 	2 	# Courage Reactor
-	157 	2 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+4 	# num treasure spawn overrides
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/enter_sh.txt
+++ b/assets/files/presets/at/enter_sh.txt
@@ -116,43 +116,50 @@ AT 	# category
 2	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
 	2	1408.7	1625.2				0	# SR plug
-10 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	1	-1
-	84 	-899.460022 -20.000000 1109.540039 	2	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	10 	-347.220001 -20.000000 4107.390137 	1	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	15 	-383.959991 30.000000 575.849976 	1	-1
-	15 	-71.489998 -20.000000 1117.589966 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	0 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	1 	# Onion Replica
-	72 	1 	# Aquatic Mine
-	77 	1 	# Impediment Scourge
-	118 	1 	# Massage Girdle
-	140 	1 	# Optical Illustration
-	152 	1 	# Fortified Delicacy
-	172 	1 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+25 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	9	# AW Cloaking Burrow-nit
+	1	15	-383.960480 29.999977 575.847656	9	# AW Cloaking Burrow-nit (BO)
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	1	10	-347.220551 -20.000000 4107.389648	9	# AW Iridescent Glint Beetle (SH)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+	2	101	950.000000 -57.000000 475.000000	8	# PP Toady Bloyster
+18 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
+	2	53	0	# PP Onion Replica
+	2	72	0	# PP Aquatic Mine
+	2	77	0	# PP Impediment Scourge
+	2	118	0	# PP Massage Girdle
+	2	140	0	# PP Optical Illustration
+	2	152	0	# PP Fortified Delicacy
+	2	172	0	# PP Gherkin Gate
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/enter_smc.txt
+++ b/assets/files/presets/at/enter_smc.txt
@@ -97,46 +97,37 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-13 	# num enemy spawns
-	17 	-950.000000 6.250000 -150.000000 	1	-1
-	0 	-480.000000 89.010002 -1115.000000 	1	-1
-	0 	-666.000000 89.010002 -800.000000 	1	-1
-	0 	-375.000000 89.010002 -800.000000 	1	-1
-	23 	-650.000000 52.889999 -1800.000000 	2	-1
-	26 	-400.000000 -57.000000 -2950.000000 	2	-1
-	63 	-900.000000 -57.000000 -3000.000000 	2	-1
-	63 	-1100.000000 -57.000000 -3200.000000 	2	-1
-	55 	0.000000 -57.000000 -3000.000000 	2	-1
-	14 	-25.000000 0.000000 -75.000000 	2	-1
-	14 	275.000000 16.480000 -275.000000 	2	-1
-	27 	1350.000000 -91.400002 1450.000000 	2	-1
-	27 	1400.000000 -90.050003 1825.000000 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+19 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP (YO)
+11 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/enter_sr.txt
+++ b/assets/files/presets/at/enter_sr.txt
@@ -103,50 +103,42 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-17 	# num enemy spawns
-	17 	-950.000000 6.250000 -150.000000 	1	-1
-	0 	-480.000000 89.010002 -1115.000000 	1	-1
-	0 	-666.000000 89.010002 -800.000000 	1	-1
-	0 	-375.000000 89.010002 -800.000000 	1	-1
-	23 	-650.000000 52.889999 -1800.000000 	1	-1
-	26 	-400.000000 -57.000000 -2950.000000 	1	-1
-	55 	0.000000 -57.000000 -3000.000000 	1	-1
-	14 	-25.000000 0.000000 -75.000000 	1	-1
-	14 	275.000000 16.480000 -275.000000 	1	-1
-	27 	1350.000000 -91.400002 1450.000000 	2	-1
-	27 	1400.000000 -90.050003 1825.000000 	2	-1
-	23 	375.000000 7.240000 -1375.000000 	2	-1
-	101 	950.000000 57.000000 475.000000 	2	-1
-	26 	150.000000 -57.000000 1950.000000 	2	-1
-	17 	400.000000 -57.000000 1600.000000 	2	-1
-	17 	750.000000 -57.000000 1350.000000 	2	-1
-	24 	550.000000 17.690001 -1000.000000 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	0 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+24 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+11 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/enter_wfg.txt
+++ b/assets/files/presets/at/enter_wfg.txt
@@ -43,45 +43,8 @@ AT 	# category
 	0 	-910.700012 2769.199951 	0 	# landing area bag (15)
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 0	# num plugs destroyed
-12 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	2	-1
-	15 	-672.000000 -20.000000 1392.000000 	2	-1
-	84 	-899.460022 -20.000000 1109.540039 	2	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	0 	13.000000 15.000000 211.000000 	2	-1
-	0 	209.000000 10.000000 -206.000000 	2	-1
-	0 	14.000000 15.000000 -263.000000 	2	-1
-	0 	-258.000000 15.000000 -133.000000 	2	-1
-	27 	-36.439999 15.000000 -104.839996 	2	-1
-26 	# num treasure spawn overrides
-	47 	2 	# Fossilized Ursidae
-	62 	2 	# Pink Menace
-	71 	2 	# Unspeakable Wonder
-	73 	2 	# Temporal Mechanism
-	87 	2 	# Utter Scrap
-	142 	2 	# Courage Reactor
-	157 	2 	# Spiny Alien Treat
-	11 	2 	# Geographic Projection
-	42 	2 	# Sunseed Berry
-	43 	2
-	130 	2 	# Pilgrim Bulb
-	155 	2 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	2 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+1 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+0 	# num treasure spawn overrides
 0	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/fc1.txt
+++ b/assets/files/presets/at/fc1.txt
@@ -84,52 +84,22 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-19 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	1	-1
-	24 	548.539978 100.000000 546.479980 	1	-1
-	24 	300.910004 100.000000 361.600006 	2	-1
-	26 	340.790009 15.000000 868.559998 	2	-1
-	26 	145.539993 18.870001 618.030029 	2	-1
-	95 	-244.220001 100.000000 326.779999 	2	-1
-	95 	302.179993 100.000000 -177.910004 	1	-1
-	96 	182.160004 210.000000 -1559.790039 	1	-1
-	55 	-271.089996 114.000000 -1387.319946 	1	-1
-	26 	-679.409973 60.000000 -24.930000 	2	-1
-	26 	-810.080017 60.000000 -378.640015 	2	-1
-	33 	-616.059998 100.000000 -778.380005 	2	-1
-	0 	-259.880005 50.000000 2476.479980 	2	-1
-	0 	52.869999 9.170000 3055.310059 	2	-1
-	0 	-1342.390015 4.200000 2825.760010 	2	-1
-	0 	-1340.810059 0.000000 2606.399902 	2	-1
-	0 	-584.419983 0.000000 3160.870117 	2	-1
-	0 	-21.920000 0.000000 2870.729980 	2	-1
-	0 	-400.920013 0.000000 2646.800049 	2	-1
-26 	# num treasure spawn overrides
-	47 	2 	# Fossilized Ursidae
-	62 	2 	# Pink Menace
-	71 	2 	# Unspeakable Wonder
-	73 	2 	# Temporal Mechanism
-	87 	0 	# Utter Scrap
-	142 	2 	# Courage Reactor
-	157 	2 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+11 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+4 	# num treasure spawn overrides
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/fc2-3.txt
+++ b/assets/files/presets/at/fc2-3.txt
@@ -85,52 +85,22 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-19 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	1	-1
-	24 	548.539978 100.000000 546.479980 	1	-1
-	24 	300.910004 100.000000 361.600006 	2	-1
-	26 	340.790009 15.000000 868.559998 	2	-1
-	26 	145.539993 18.870001 618.030029 	2	-1
-	95 	-244.220001 100.000000 326.779999 	2	-1
-	95 	302.179993 100.000000 -177.910004 	1	-1
-	96 	182.160004 210.000000 -1559.790039 	1	-1
-	55 	-271.089996 114.000000 -1387.319946 	1	-1
-	26 	-679.409973 60.000000 -24.930000 	2	-1
-	26 	-810.080017 60.000000 -378.640015 	2	-1
-	33 	-616.059998 100.000000 -778.380005 	2	-1
-	0 	-259.880005 50.000000 2476.479980 	2	-1
-	0 	52.869999 9.170000 3055.310059 	2	-1
-	0 	-1342.390015 4.200000 2825.760010 	2	-1
-	0 	-1340.810059 0.000000 2606.399902 	2	-1
-	0 	-584.419983 0.000000 3160.870117 	2	-1
-	0 	-21.920000 0.000000 2870.729980 	2	-1
-	0 	-400.920013 0.000000 2646.800049 	2	-1
-26 	# num treasure spawn overrides
-	47 	2 	# Fossilized Ursidae
-	62 	2 	# Pink Menace
-	71 	2 	# Unspeakable Wonder
-	73 	2 	# Temporal Mechanism
-	87 	0 	# Utter Scrap
-	142 	2 	# Courage Reactor
-	157 	2 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+11 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+4 	# num treasure spawn overrides
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/fc4.txt
+++ b/assets/files/presets/at/fc4.txt
@@ -85,52 +85,22 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-19 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	1	-1
-	24 	548.539978 100.000000 546.479980 	1	-1
-	24 	300.910004 100.000000 361.600006 	2	-1
-	26 	340.790009 15.000000 868.559998 	2	-1
-	26 	145.539993 18.870001 618.030029 	2	-1
-	95 	-244.220001 100.000000 326.779999 	2	-1
-	95 	302.179993 100.000000 -177.910004 	1	-1
-	96 	182.160004 210.000000 -1559.790039 	1	-1
-	55 	-271.089996 114.000000 -1387.319946 	1	-1
-	26 	-679.409973 60.000000 -24.930000 	2	-1
-	26 	-810.080017 60.000000 -378.640015 	2	-1
-	33 	-616.059998 100.000000 -778.380005 	2	-1
-	0 	-259.880005 50.000000 2476.479980 	2	-1
-	0 	52.869999 9.170000 3055.310059 	2	-1
-	0 	-1342.390015 4.200000 2825.760010 	2	-1
-	0 	-1340.810059 0.000000 2606.399902 	2	-1
-	0 	-584.419983 0.000000 3160.870117 	2	-1
-	0 	-21.920000 0.000000 2870.729980 	2	-1
-	0 	-400.920013 0.000000 2646.800049 	2	-1
-26 	# num treasure spawn overrides
-	47 	2 	# Fossilized Ursidae
-	62 	2 	# Pink Menace
-	71 	2 	# Unspeakable Wonder
-	73 	2 	# Temporal Mechanism
-	87 	0 	# Utter Scrap
-	142 	2 	# Courage Reactor
-	157 	2 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+11 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+4 	# num treasure spawn overrides
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/fc5.txt
+++ b/assets/files/presets/at/fc5.txt
@@ -86,52 +86,22 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-19 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	1	-1
-	24 	548.539978 100.000000 546.479980 	1	-1
-	24 	300.910004 100.000000 361.600006 	2	-1
-	26 	340.790009 15.000000 868.559998 	2	-1
-	26 	145.539993 18.870001 618.030029 	2	-1
-	95 	-244.220001 100.000000 326.779999 	2	-1
-	95 	302.179993 100.000000 -177.910004 	1	-1
-	96 	182.160004 210.000000 -1559.790039 	1	-1
-	55 	-271.089996 114.000000 -1387.319946 	1	-1
-	26 	-679.409973 60.000000 -24.930000 	2	-1
-	26 	-810.080017 60.000000 -378.640015 	2	-1
-	33 	-616.059998 100.000000 -778.380005 	2	-1
-	0 	-259.880005 50.000000 2476.479980 	2	-1
-	0 	52.869999 9.170000 3055.310059 	2	-1
-	0 	-1342.390015 4.200000 2825.760010 	2	-1
-	0 	-1340.810059 0.000000 2606.399902 	2	-1
-	0 	-584.419983 0.000000 3160.870117 	2	-1
-	0 	-21.920000 0.000000 2870.729980 	2	-1
-	0 	-400.920013 0.000000 2646.800049 	2	-1
-26 	# num treasure spawn overrides
-	47 	2 	# Fossilized Ursidae
-	62 	2 	# Pink Menace
-	71 	2 	# Unspeakable Wonder
-	73 	2 	# Temporal Mechanism
-	87 	0 	# Utter Scrap
-	142 	2 	# Courage Reactor
-	157 	2 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+11 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+4 	# num treasure spawn overrides
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/fc6.txt
+++ b/assets/files/presets/at/fc6.txt
@@ -88,52 +88,22 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-19 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	1	-1
-	24 	548.539978 100.000000 546.479980 	1	-1
-	24 	300.910004 100.000000 361.600006 	2	-1
-	26 	340.790009 15.000000 868.559998 	2	-1
-	26 	145.539993 18.870001 618.030029 	2	-1
-	95 	-244.220001 100.000000 326.779999 	2	-1
-	95 	302.179993 100.000000 -177.910004 	1	-1
-	96 	182.160004 210.000000 -1559.790039 	1	-1
-	55 	-271.089996 114.000000 -1387.319946 	1	-1
-	26 	-679.409973 60.000000 -24.930000 	2	-1
-	26 	-810.080017 60.000000 -378.640015 	2	-1
-	33 	-616.059998 100.000000 -778.380005 	2	-1
-	0 	-259.880005 50.000000 2476.479980 	2	-1
-	0 	52.869999 9.170000 3055.310059 	2	-1
-	0 	-1342.390015 4.200000 2825.760010 	2	-1
-	0 	-1340.810059 0.000000 2606.399902 	2	-1
-	0 	-584.419983 0.000000 3160.870117 	2	-1
-	0 	-21.920000 0.000000 2870.729980 	2	-1
-	0 	-400.920013 0.000000 2646.800049 	2	-1
-26 	# num treasure spawn overrides
-	47 	2 	# Fossilized Ursidae
-	62 	2 	# Pink Menace
-	71 	2 	# Unspeakable Wonder
-	73 	2 	# Temporal Mechanism
-	87 	0 	# Utter Scrap
-	142 	2 	# Courage Reactor
-	157 	2 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+11 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+4 	# num treasure spawn overrides
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/fc7.txt
+++ b/assets/files/presets/at/fc7.txt
@@ -88,52 +88,22 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-19 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	1	-1
-	24 	548.539978 100.000000 546.479980 	1	-1
-	24 	300.910004 100.000000 361.600006 	2	-1
-	26 	340.790009 15.000000 868.559998 	2	-1
-	26 	145.539993 18.870001 618.030029 	2	-1
-	95 	-244.220001 100.000000 326.779999 	2	-1
-	95 	302.179993 100.000000 -177.910004 	1	-1
-	96 	182.160004 210.000000 -1559.790039 	1	-1
-	55 	-271.089996 114.000000 -1387.319946 	1	-1
-	26 	-679.409973 60.000000 -24.930000 	2	-1
-	26 	-810.080017 60.000000 -378.640015 	2	-1
-	33 	-616.059998 100.000000 -778.380005 	2	-1
-	0 	-259.880005 50.000000 2476.479980 	2	-1
-	0 	52.869999 9.170000 3055.310059 	2	-1
-	0 	-1342.390015 4.200000 2825.760010 	2	-1
-	0 	-1340.810059 0.000000 2606.399902 	2	-1
-	0 	-584.419983 0.000000 3160.870117 	2	-1
-	0 	-21.920000 0.000000 2870.729980 	2	-1
-	0 	-400.920013 0.000000 2646.800049 	2	-1
-26 	# num treasure spawn overrides
-	47 	2 	# Fossilized Ursidae
-	62 	2 	# Pink Menace
-	71 	2 	# Unspeakable Wonder
-	73 	2 	# Temporal Mechanism
-	87 	0 	# Utter Scrap
-	142 	2 	# Courage Reactor
-	157 	2 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+11 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+4 	# num treasure spawn overrides
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/fc8.txt
+++ b/assets/files/presets/at/fc8.txt
@@ -88,52 +88,22 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-19 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	1	-1
-	24 	548.539978 100.000000 546.479980 	1	-1
-	24 	300.910004 100.000000 361.600006 	2	-1
-	26 	340.790009 15.000000 868.559998 	2	-1
-	26 	145.539993 18.870001 618.030029 	2	-1
-	95 	-244.220001 100.000000 326.779999 	2	-1
-	95 	302.179993 100.000000 -177.910004 	1	-1
-	96 	182.160004 210.000000 -1559.790039 	1	-1
-	55 	-271.089996 114.000000 -1387.319946 	1	-1
-	26 	-679.409973 60.000000 -24.930000 	2	-1
-	26 	-810.080017 60.000000 -378.640015 	2	-1
-	33 	-616.059998 100.000000 -778.380005 	2	-1
-	0 	-259.880005 50.000000 2476.479980 	2	-1
-	0 	52.869999 9.170000 3055.310059 	2	-1
-	0 	-1342.390015 4.200000 2825.760010 	2	-1
-	0 	-1340.810059 0.000000 2606.399902 	2	-1
-	0 	-584.419983 0.000000 3160.870117 	2	-1
-	0 	-21.920000 0.000000 2870.729980 	2	-1
-	0 	-400.920013 0.000000 2646.800049 	2	-1
-26 	# num treasure spawn overrides
-	47 	2 	# Fossilized Ursidae
-	62 	2 	# Pink Menace
-	71 	2 	# Unspeakable Wonder
-	73 	2 	# Temporal Mechanism
-	87 	0 	# Utter Scrap
-	142 	2 	# Courage Reactor
-	157 	2 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+11 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+4 	# num treasure spawn overrides
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/gk1-5.txt
+++ b/assets/files/presets/at/gk1-5.txt
@@ -95,46 +95,37 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-13 	# num enemy spawns
-	17 	-950.000000 6.250000 -150.000000 	1	-1
-	0 	-480.000000 89.010002 -1115.000000 	1	-1
-	0 	-666.000000 89.010002 -800.000000 	1	-1
-	0 	-375.000000 89.010002 -800.000000 	1	-1
-	23 	-650.000000 52.889999 -1800.000000 	2	-1
-	26 	-400.000000 -57.000000 -2950.000000 	2	-1
-	63 	-900.000000 -57.000000 -3000.000000 	2	-1
-	63 	-1100.000000 -57.000000 -3200.000000 	2	-1
-	55 	0.000000 -57.000000 -3000.000000 	2	-1
-	14 	-25.000000 0.000000 -75.000000 	2	-1
-	14 	275.000000 16.480000 -275.000000 	2	-1
-	27 	1350.000000 -91.400002 1450.000000 	2	-1
-	27 	1400.000000 -90.050003 1825.000000 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+19 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP (YO)
+11 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/gk6.txt
+++ b/assets/files/presets/at/gk6.txt
@@ -95,46 +95,37 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-13 	# num enemy spawns
-	17 	-950.000000 6.250000 -150.000000 	1	-1
-	0 	-480.000000 89.010002 -1115.000000 	1	-1
-	0 	-666.000000 89.010002 -800.000000 	1	-1
-	0 	-375.000000 89.010002 -800.000000 	1	-1
-	23 	-650.000000 52.889999 -1800.000000 	2	-1
-	26 	-400.000000 -57.000000 -2950.000000 	2	-1
-	63 	-900.000000 -57.000000 -3000.000000 	2	-1
-	63 	-1100.000000 -57.000000 -3200.000000 	2	-1
-	55 	0.000000 -57.000000 -3000.000000 	2	-1
-	14 	-25.000000 0.000000 -75.000000 	2	-1
-	14 	275.000000 16.480000 -275.000000 	2	-1
-	27 	1350.000000 -91.400002 1450.000000 	2	-1
-	27 	1400.000000 -90.050003 1825.000000 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+19 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP (YO)
+11 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/hob1-2.txt
+++ b/assets/files/presets/at/hob1-2.txt
@@ -62,42 +62,10 @@ AT 	# category
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 0	# num plugs destroyed
-9 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	1	-1
-	84 	-899.460022 -20.000000 1109.540039 	2	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	17 	-1631.420044 -53.000000 3351.949951 	2	-1
-	17 	-1388.689941 -53.000000 3972.270020 	2	-1
-26 	# num treasure spawn overrides
-	47 	2 	# Fossilized Ursidae
-	62 	2 	# Pink Menace
-	71 	2 	# Unspeakable Wonder
-	73 	2 	# Temporal Mechanism
-	87 	2 	# Utter Scrap
-	142 	2 	# Courage Reactor
-	157 	2 	# Spiny Alien Treat
-	11 	2 	# Geographic Projection
-	42 	2 	# Sunseed Berry
-	43 	0
-	130 	2 	# Pilgrim Bulb
-	155 	0 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	2 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+3 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/hob3.txt
+++ b/assets/files/presets/at/hob3.txt
@@ -62,42 +62,10 @@ AT 	# category
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 0	# num plugs destroyed
-9 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	1	-1
-	84 	-899.460022 -20.000000 1109.540039 	2	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	17 	-1631.420044 -53.000000 3351.949951 	2	-1
-	17 	-1388.689941 -53.000000 3972.270020 	2	-1
-26 	# num treasure spawn overrides
-	47 	2 	# Fossilized Ursidae
-	62 	2 	# Pink Menace
-	71 	2 	# Unspeakable Wonder
-	73 	2 	# Temporal Mechanism
-	87 	2 	# Utter Scrap
-	142 	2 	# Courage Reactor
-	157 	2 	# Spiny Alien Treat
-	11 	2 	# Geographic Projection
-	42 	2 	# Sunseed Berry
-	43 	0
-	130 	2 	# Pilgrim Bulb
-	155 	0 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	2 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+3 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/hob4.txt
+++ b/assets/files/presets/at/hob4.txt
@@ -63,42 +63,10 @@ AT 	# category
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 0	# num plugs destroyed
-9 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	1	-1
-	84 	-899.460022 -20.000000 1109.540039 	2	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	17 	-1631.420044 -53.000000 3351.949951 	2	-1
-	17 	-1388.689941 -53.000000 3972.270020 	2	-1
-26 	# num treasure spawn overrides
-	47 	2 	# Fossilized Ursidae
-	62 	2 	# Pink Menace
-	71 	2 	# Unspeakable Wonder
-	73 	2 	# Temporal Mechanism
-	87 	2 	# Utter Scrap
-	142 	2 	# Courage Reactor
-	157 	2 	# Spiny Alien Treat
-	11 	2 	# Geographic Projection
-	42 	2 	# Sunseed Berry
-	43 	0
-	130 	2 	# Pilgrim Bulb
-	155 	0 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	2 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+3 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/hob5.txt
+++ b/assets/files/presets/at/hob5.txt
@@ -63,42 +63,10 @@ AT 	# category
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 0	# num plugs destroyed
-9 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	1	-1
-	84 	-899.460022 -20.000000 1109.540039 	2	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	17 	-1631.420044 -53.000000 3351.949951 	2	-1
-	17 	-1388.689941 -53.000000 3972.270020 	2	-1
-26 	# num treasure spawn overrides
-	47 	2 	# Fossilized Ursidae
-	62 	2 	# Pink Menace
-	71 	2 	# Unspeakable Wonder
-	73 	2 	# Temporal Mechanism
-	87 	2 	# Utter Scrap
-	142 	2 	# Courage Reactor
-	157 	2 	# Spiny Alien Treat
-	11 	2 	# Geographic Projection
-	42 	2 	# Sunseed Berry
-	43 	0
-	130 	2 	# Pilgrim Bulb
-	155 	0 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	2 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+3 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/hoh1-5.txt
+++ b/assets/files/presets/at/hoh1-5.txt
@@ -128,53 +128,72 @@ AT 	# category
 	0	800.0	1380.0				0	# bridge plug
 	2	1408.7	1625.2				0	# SR plug
 	3	-2773.3	1328.5				0	# plants plug
-20 	# num enemy spawns
-	78 	-1576.150024 20.000000 1320.489990 	1	-1
-	1 	-3232.669922 0.000000 -123.870003 	1	-1
-	1 	-2245.250000 50.000000 676.880005 	1	-1
-	23 	-2781.399902 -30.000000 162.669998 	1	-1
-	95 	-3007.169922 -30.000000 574.859985 	1	-1
-	15 	-1340.170044 30.000000 491.329987 	1	-1
-	24 	-1310.869995 30.000000 346.839996 	1	-1
-	21 	-1218.459961 23.950001 766.489990 	1	-1
-	21 	-1220.699951 22.190001 679.390015 	1	-1
-	17 	-1500.079956 -10.000000 1002.669983 	2	-1
-	55 	-342.399994 0.000000 1391.130005 	2	-1
-	55 	-92.239998 0.000000 1681.890015 	2	-1
-	84 	-145.679993 0.000000 1537.790039 	1	-1
-	84 	-467.910004 0.000000 1477.599976 	2	-1
-	84 	-241.839996 0.000000 1716.819946 	2	-1
-	63 	-3538.899902 -30.000000 1044.170044 	2	-1
-	14 	-2976.199951 0.000000 2237.370117 	2	-1
-	75 	-2172.050049 30.000000 2714.399902 	2	-1
-	24 	-2992.959961 0.000000 1651.540039 	2	-1
-	25 	-3244.419922 0.000000 2052.760010 	2	-1
+10 	# num enemy spawns
+38 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	9	# AW Cloaking Burrow-nit
+	1	15	-383.960480 29.999977 575.847656	9	# AW Cloaking Burrow-nit (BO)
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	1	10	-347.220551 -20.000000 4107.389648	9	# AW Iridescent Glint Beetle (SH)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+	2	101	950.000000 -57.000000 475.000000	8	# PP Toady Bloyster
+	3	1	-3232.669922 0.000000 -123.870003	10	# WW Dwarf Bulborb x2 (base)
+	3	1	-2245.250000 50.000000 676.880005	10	# WW Dwarf Bulborb x3
+	3	78	-1576.150024 20.000000 1320.489990	10	# WW Gatling Groink
+	3	95	-3007.169922 -30.000000 574.859985	10	# WW Decorated Cannon Beetle
+	3	15	-1340.170044 30.000000 491.329987	10	# WW Cloaking Burrow-nit
+	3	24	-1310.869995 30.000000 346.839996	10	# WW Fiery Blowhog
+	3	23	-2781.398193 -30.000000 162.671936	10	# WW Swooping Snitchbug
+	3	37	-2818.194824 40.000000 671.756287	10	# WW Egg x3
+	3	21	-1218.459961 23.950001 766.489990	10	# WW Gas Pipe (DD gate)
+	3	21	-1220.699951 22.190001 679.390015	10	# WW Gas Pipe (DD gate)
+	3	84	-145.679993 0.000000 1537.790039	10	# WW Creeping Chrysanthemum (nut)
+	3	37	-844.542847 69.230003 1850.569458	10	# WW Egg x3
+	3	37	-63.606934 -30.000000 753.387573	10	# WW Egg x4
 26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	1
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	185 	1 	# Air Brake
-	53 	1 	# Onion Replica
-	72 	1 	# Aquatic Mine
-	77 	1 	# Impediment Scourge
-	118 	1 	# Massage Girdle
-	140 	1 	# Optical Illustration
-	152 	1 	# Fortified Delicacy
-	172 	1 	# Gherkin Gate
-	27 	1 	# Armored Nut
-	45 	1 	# Anti-hiccup Fungus
-	50 	1 	# Conifer Spire
-	76 	1 	# Doomsday Apparatus
-	183 	1 	# Seed of Greed
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	44	0	# AW Decorative Goo
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	1	185	0	# AW Air Brake
+	2	53	0	# PP Onion Replica
+	2	72	0	# PP Aquatic Mine
+	2	77	0	# PP Impediment Scourge
+	2	118	0	# PP Massage Girdle
+	2	140	0	# PP Optical Illustration
+	2	152	0	# PP Fortified Delicacy
+	2	172	0	# PP Gherkin Gate
+	3	27	0	# WW Armored Nut
+	3	45	0	# WW Anti-hiccup Fungus
+	3	50	0	# WW Conifer Spire
+	3	76	0	# WW Doomsday Apparatus
+	3	183	0	# WW Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/hoh6-8.txt
+++ b/assets/files/presets/at/hoh6-8.txt
@@ -128,53 +128,71 @@ AT 	# category
 	0	800.0	1380.0				0	# bridge plug
 	2	1408.7	1625.2				0	# SR plug
 	3	-2773.3	1328.5				0	# plants plug
-20 	# num enemy spawns
-	78 	-1576.150024 20.000000 1320.489990 	1	-1
-	1 	-3232.669922 0.000000 -123.870003 	1	-1
-	1 	-2245.250000 50.000000 676.880005 	1	-1
-	23 	-2781.399902 -30.000000 162.669998 	1	-1
-	95 	-3007.169922 -30.000000 574.859985 	1	-1
-	15 	-1340.170044 30.000000 491.329987 	1	-1
-	24 	-1310.869995 30.000000 346.839996 	1	-1
-	21 	-1218.459961 23.950001 766.489990 	1	-1
-	21 	-1220.699951 22.190001 679.390015 	1	-1
-	17 	-1500.079956 -10.000000 1002.669983 	2	-1
-	55 	-342.399994 0.000000 1391.130005 	2	-1
-	55 	-92.239998 0.000000 1681.890015 	2	-1
-	84 	-145.679993 0.000000 1537.790039 	1	-1
-	84 	-467.910004 0.000000 1477.599976 	2	-1
-	84 	-241.839996 0.000000 1716.819946 	2	-1
-	63 	-3538.899902 -30.000000 1044.170044 	2	-1
-	14 	-2976.199951 0.000000 2237.370117 	2	-1
-	75 	-2172.050049 30.000000 2714.399902 	2	-1
-	24 	-2992.959961 0.000000 1651.540039 	2	-1
-	25 	-3244.419922 0.000000 2052.760010 	2	-1
+38 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	9	# AW Cloaking Burrow-nit
+	1	15	-383.960480 29.999977 575.847656	9	# AW Cloaking Burrow-nit (BO)
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	1	10	-347.220551 -20.000000 4107.389648	9	# AW Iridescent Glint Beetle (SH)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+	2	101	950.000000 -57.000000 475.000000	8	# PP Toady Bloyster
+	3	1	-3232.669922 0.000000 -123.870003	10	# WW Dwarf Bulborb x2 (base)
+	3	1	-2245.250000 50.000000 676.880005	10	# WW Dwarf Bulborb x3
+	3	78	-1576.150024 20.000000 1320.489990	10	# WW Gatling Groink
+	3	95	-3007.169922 -30.000000 574.859985	10	# WW Decorated Cannon Beetle
+	3	15	-1340.170044 30.000000 491.329987	10	# WW Cloaking Burrow-nit
+	3	24	-1310.869995 30.000000 346.839996	10	# WW Fiery Blowhog
+	3	23	-2781.398193 -30.000000 162.671936	10	# WW Swooping Snitchbug
+	3	37	-2818.194824 40.000000 671.756287	10	# WW Egg x3
+	3	21	-1218.459961 23.950001 766.489990	10	# WW Gas Pipe (DD gate)
+	3	21	-1220.699951 22.190001 679.390015	10	# WW Gas Pipe (DD gate)
+	3	84	-145.679993 0.000000 1537.790039	10	# WW Creeping Chrysanthemum (nut)
+	3	37	-844.542847 69.230003 1850.569458	10	# WW Egg x3
+	3	37	-63.606934 -30.000000 753.387573	10	# WW Egg x4
 26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	1
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	185 	1 	# Air Brake
-	53 	1 	# Onion Replica
-	72 	1 	# Aquatic Mine
-	77 	1 	# Impediment Scourge
-	118 	1 	# Massage Girdle
-	140 	1 	# Optical Illustration
-	152 	1 	# Fortified Delicacy
-	172 	1 	# Gherkin Gate
-	27 	1 	# Armored Nut
-	45 	1 	# Anti-hiccup Fungus
-	50 	1 	# Conifer Spire
-	76 	1 	# Doomsday Apparatus
-	183 	1 	# Seed of Greed
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	44	0	# AW Decorative Goo
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	1	185	0	# AW Air Brake
+	2	53	0	# PP Onion Replica
+	2	72	0	# PP Aquatic Mine
+	2	77	0	# PP Impediment Scourge
+	2	118	0	# PP Massage Girdle
+	2	140	0	# PP Optical Illustration
+	2	152	0	# PP Fortified Delicacy
+	2	172	0	# PP Gherkin Gate
+	3	27	0	# WW Armored Nut
+	3	45	0	# WW Anti-hiccup Fungus
+	3	50	0	# WW Conifer Spire
+	3	76	0	# WW Doomsday Apparatus
+	3	183	0	# WW Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/hoh9-15.txt
+++ b/assets/files/presets/at/hoh9-15.txt
@@ -128,53 +128,71 @@ AT 	# category
 	0	800.0	1380.0				0	# bridge plug
 	2	1408.7	1625.2				0	# SR plug
 	3	-2773.3	1328.5				0	# plants plug
-20 	# num enemy spawns
-	78 	-1576.150024 20.000000 1320.489990 	1	-1
-	1 	-3232.669922 0.000000 -123.870003 	1	-1
-	1 	-2245.250000 50.000000 676.880005 	1	-1
-	23 	-2781.399902 -30.000000 162.669998 	1	-1
-	95 	-3007.169922 -30.000000 574.859985 	1	-1
-	15 	-1340.170044 30.000000 491.329987 	1	-1
-	24 	-1310.869995 30.000000 346.839996 	1	-1
-	21 	-1218.459961 23.950001 766.489990 	1	-1
-	21 	-1220.699951 22.190001 679.390015 	1	-1
-	17 	-1500.079956 -10.000000 1002.669983 	2	-1
-	55 	-342.399994 0.000000 1391.130005 	2	-1
-	55 	-92.239998 0.000000 1681.890015 	2	-1
-	84 	-145.679993 0.000000 1537.790039 	1	-1
-	84 	-467.910004 0.000000 1477.599976 	2	-1
-	84 	-241.839996 0.000000 1716.819946 	2	-1
-	63 	-3538.899902 -30.000000 1044.170044 	2	-1
-	14 	-2976.199951 0.000000 2237.370117 	2	-1
-	75 	-2172.050049 30.000000 2714.399902 	2	-1
-	24 	-2992.959961 0.000000 1651.540039 	2	-1
-	25 	-3244.419922 0.000000 2052.760010 	2	-1
+38 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	9	# AW Cloaking Burrow-nit
+	1	15	-383.960480 29.999977 575.847656	9	# AW Cloaking Burrow-nit (BO)
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	1	10	-347.220551 -20.000000 4107.389648	9	# AW Iridescent Glint Beetle (SH)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+	2	101	950.000000 -57.000000 475.000000	8	# PP Toady Bloyster
+	3	1	-3232.669922 0.000000 -123.870003	10	# WW Dwarf Bulborb x2 (base)
+	3	1	-2245.250000 50.000000 676.880005	10	# WW Dwarf Bulborb x3
+	3	78	-1576.150024 20.000000 1320.489990	10	# WW Gatling Groink
+	3	95	-3007.169922 -30.000000 574.859985	10	# WW Decorated Cannon Beetle
+	3	15	-1340.170044 30.000000 491.329987	10	# WW Cloaking Burrow-nit
+	3	24	-1310.869995 30.000000 346.839996	10	# WW Fiery Blowhog
+	3	23	-2781.398193 -30.000000 162.671936	10	# WW Swooping Snitchbug
+	3	37	-2818.194824 40.000000 671.756287	10	# WW Egg x3
+	3	21	-1218.459961 23.950001 766.489990	10	# WW Gas Pipe (DD gate)
+	3	21	-1220.699951 22.190001 679.390015	10	# WW Gas Pipe (DD gate)
+	3	84	-145.679993 0.000000 1537.790039	10	# WW Creeping Chrysanthemum (nut)
+	3	37	-844.542847 69.230003 1850.569458	10	# WW Egg x3
+	3	37	-63.606934 -30.000000 753.387573	10	# WW Egg x4
 26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	1
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	185 	1 	# Air Brake
-	53 	1 	# Onion Replica
-	72 	1 	# Aquatic Mine
-	77 	1 	# Impediment Scourge
-	118 	1 	# Massage Girdle
-	140 	1 	# Optical Illustration
-	152 	1 	# Fortified Delicacy
-	172 	1 	# Gherkin Gate
-	27 	1 	# Armored Nut
-	45 	1 	# Anti-hiccup Fungus
-	50 	1 	# Conifer Spire
-	76 	1 	# Doomsday Apparatus
-	183 	1 	# Seed of Greed
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	44	0	# AW Decorative Goo
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	1	185	0	# AW Air Brake
+	2	53	0	# PP Onion Replica
+	2	72	0	# PP Aquatic Mine
+	2	77	0	# PP Impediment Scourge
+	2	118	0	# PP Massage Girdle
+	2	140	0	# PP Optical Illustration
+	2	152	0	# PP Fortified Delicacy
+	2	172	0	# PP Gherkin Gate
+	3	27	0	# WW Armored Nut
+	3	45	0	# WW Anti-hiccup Fungus
+	3	50	0	# WW Conifer Spire
+	3	76	0	# WW Doomsday Apparatus
+	3	183	0	# WW Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/purple_farm.txt
+++ b/assets/files/presets/at/purple_farm.txt
@@ -118,53 +118,53 @@ AT 	# category
 2	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
 	2	1408.7	1625.2				0	# SR plug
-20 	# num enemy spawns
-	78 	-1576.150024 20.000000 1320.489990 	2	-1
-	1 	-3232.669922 0.000000 -123.870003 	2	-1
-	1 	-2245.250000 50.000000 676.880005 	2	-1
-	23 	-2781.399902 -30.000000 162.669998 	2	-1
-	95 	-3007.169922 -30.000000 574.859985 	2	-1
-	15 	-1340.170044 30.000000 491.329987 	2	-1
-	24 	-1310.869995 30.000000 346.839996 	2	-1
-	21 	-1218.459961 23.950001 766.489990 	2	-1
-	21 	-1220.699951 22.190001 679.390015 	2	-1
-	17 	-1500.079956 -10.000000 1002.669983 	2	-1
-	55 	-342.399994 0.000000 1391.130005 	2	-1
-	55 	-92.239998 0.000000 1681.890015 	2	-1
-	84 	-145.679993 0.000000 1537.790039 	2	-1
-	84 	-467.910004 0.000000 1477.599976 	2	-1
-	84 	-241.839996 0.000000 1716.819946 	2	-1
-	63 	-3538.899902 -30.000000 1044.170044 	2	-1
-	14 	-2976.199951 0.000000 2237.370117 	2	-1
-	75 	-2172.050049 30.000000 2714.399902 	2	-1
-	24 	-2992.959961 0.000000 1651.540039 	2	-1
-	25 	-3244.419922 0.000000 2052.760010 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	1
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	185 	1 	# Air Brake
-	53 	1 	# Onion Replica
-	72 	1 	# Aquatic Mine
-	77 	1 	# Impediment Scourge
-	118 	1 	# Massage Girdle
-	140 	1 	# Optical Illustration
-	152 	1 	# Fortified Delicacy
-	172 	1 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+25 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	9	# AW Cloaking Burrow-nit
+	1	15	-383.960480 29.999977 575.847656	9	# AW Cloaking Burrow-nit (BO)
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	1	10	-347.220551 -20.000000 4107.389648	9	# AW Iridescent Glint Beetle (SH)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+	2	101	950.000000 -57.000000 475.000000	8	# PP Toady Bloyster
+21 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	44	0	# AW Decorative Goo
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	1	185	0	# AW Air Brake
+	2	53	0	# PP Onion Replica
+	2	72	0	# PP Aquatic Mine
+	2	77	0	# PP Impediment Scourge
+	2	118	0	# PP Massage Girdle
+	2	140	0	# PP Optical Illustration
+	2	152	0	# PP Fortified Delicacy
+	2	172	0	# PP Gherkin Gate
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/scx1-3.txt
+++ b/assets/files/presets/at/scx1-3.txt
@@ -79,42 +79,18 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-9 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	1	-1
-	24 	548.539978 100.000000 546.479980 	2	-1
-	24 	300.910004 100.000000 361.600006 	2	-1
-	26 	340.790009 15.000000 868.559998 	2	-1
-	26 	145.539993 18.870001 618.030029 	2	-1
-	95 	-244.220001 100.000000 326.779999 	2	-1
-	95 	302.179993 100.000000 -177.910004 	2	-1
-	96 	182.160004 210.000000 -1559.790039 	2	-1
-	55 	-271.089996 114.000000 -1387.319946 	2	-1
-26 	# num treasure spawn overrides
-	47 	2 	# Fossilized Ursidae
-	62 	2 	# Pink Menace
-	71 	2 	# Unspeakable Wonder
-	73 	2 	# Temporal Mechanism
-	87 	0 	# Utter Scrap
-	142 	2 	# Courage Reactor
-	157 	2 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+7 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+4 	# num treasure spawn overrides
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/scx4.txt
+++ b/assets/files/presets/at/scx4.txt
@@ -79,42 +79,18 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-9 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	1	-1
-	24 	548.539978 100.000000 546.479980 	2	-1
-	24 	300.910004 100.000000 361.600006 	2	-1
-	26 	340.790009 15.000000 868.559998 	2	-1
-	26 	145.539993 18.870001 618.030029 	2	-1
-	95 	-244.220001 100.000000 326.779999 	2	-1
-	95 	302.179993 100.000000 -177.910004 	2	-1
-	96 	182.160004 210.000000 -1559.790039 	2	-1
-	55 	-271.089996 114.000000 -1387.319946 	2	-1
-26 	# num treasure spawn overrides
-	47 	2 	# Fossilized Ursidae
-	62 	2 	# Pink Menace
-	71 	2 	# Unspeakable Wonder
-	73 	2 	# Temporal Mechanism
-	87 	0 	# Utter Scrap
-	142 	2 	# Courage Reactor
-	157 	2 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+7 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+4 	# num treasure spawn overrides
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/scx5-8.txt
+++ b/assets/files/presets/at/scx5-8.txt
@@ -79,42 +79,18 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-9 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	1	-1
-	24 	548.539978 100.000000 546.479980 	2	-1
-	24 	300.910004 100.000000 361.600006 	2	-1
-	26 	340.790009 15.000000 868.559998 	2	-1
-	26 	145.539993 18.870001 618.030029 	2	-1
-	95 	-244.220001 100.000000 326.779999 	2	-1
-	95 	302.179993 100.000000 -177.910004 	2	-1
-	96 	182.160004 210.000000 -1559.790039 	2	-1
-	55 	-271.089996 114.000000 -1387.319946 	2	-1
-26 	# num treasure spawn overrides
-	47 	2 	# Fossilized Ursidae
-	62 	2 	# Pink Menace
-	71 	2 	# Unspeakable Wonder
-	73 	2 	# Temporal Mechanism
-	87 	0 	# Utter Scrap
-	142 	2 	# Courage Reactor
-	157 	2 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+7 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+4 	# num treasure spawn overrides
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/scx9.txt
+++ b/assets/files/presets/at/scx9.txt
@@ -79,42 +79,18 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-9 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	1	-1
-	24 	548.539978 100.000000 546.479980 	2	-1
-	24 	300.910004 100.000000 361.600006 	2	-1
-	26 	340.790009 15.000000 868.559998 	2	-1
-	26 	145.539993 18.870001 618.030029 	2	-1
-	95 	-244.220001 100.000000 326.779999 	2	-1
-	95 	302.179993 100.000000 -177.910004 	2	-1
-	96 	182.160004 210.000000 -1559.790039 	2	-1
-	55 	-271.089996 114.000000 -1387.319946 	2	-1
-26 	# num treasure spawn overrides
-	47 	2 	# Fossilized Ursidae
-	62 	2 	# Pink Menace
-	71 	2 	# Unspeakable Wonder
-	73 	2 	# Temporal Mechanism
-	87 	0 	# Utter Scrap
-	142 	2 	# Courage Reactor
-	157 	2 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+7 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+4 	# num treasure spawn overrides
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/sh1-3.txt
+++ b/assets/files/presets/at/sh1-3.txt
@@ -116,53 +116,53 @@ AT 	# category
 2	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
 	2	1408.7	1625.2				0	# SR plug
-20 	# num enemy spawns
-	78 	-1576.150024 20.000000 1320.489990 	2	-1
-	1 	-3232.669922 0.000000 -123.870003 	2	-1
-	1 	-2245.250000 50.000000 676.880005 	2	-1
-	23 	-2781.399902 -30.000000 162.669998 	2	-1
-	95 	-3007.169922 -30.000000 574.859985 	2	-1
-	15 	-1340.170044 30.000000 491.329987 	2	-1
-	24 	-1310.869995 30.000000 346.839996 	2	-1
-	21 	-1218.459961 23.950001 766.489990 	2	-1
-	21 	-1220.699951 22.190001 679.390015 	2	-1
-	17 	-1500.079956 -10.000000 1002.669983 	2	-1
-	55 	-342.399994 0.000000 1391.130005 	2	-1
-	55 	-92.239998 0.000000 1681.890015 	2	-1
-	84 	-145.679993 0.000000 1537.790039 	2	-1
-	84 	-467.910004 0.000000 1477.599976 	2	-1
-	84 	-241.839996 0.000000 1716.819946 	2	-1
-	63 	-3538.899902 -30.000000 1044.170044 	2	-1
-	14 	-2976.199951 0.000000 2237.370117 	2	-1
-	75 	-2172.050049 30.000000 2714.399902 	2	-1
-	24 	-2992.959961 0.000000 1651.540039 	2	-1
-	25 	-3244.419922 0.000000 2052.760010 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	1
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	185 	1 	# Air Brake
-	53 	1 	# Onion Replica
-	72 	1 	# Aquatic Mine
-	77 	1 	# Impediment Scourge
-	118 	1 	# Massage Girdle
-	140 	1 	# Optical Illustration
-	152 	1 	# Fortified Delicacy
-	172 	1 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+25 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	9	# AW Cloaking Burrow-nit
+	1	15	-383.960480 29.999977 575.847656	9	# AW Cloaking Burrow-nit (BO)
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	1	10	-347.220551 -20.000000 4107.389648	9	# AW Iridescent Glint Beetle (SH)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+	2	101	950.000000 -57.000000 475.000000	8	# PP Toady Bloyster
+21 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	44	0	# AW Decorative Goo
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	1	185	0	# AW Air Brake
+	2	53	0	# PP Onion Replica
+	2	72	0	# PP Aquatic Mine
+	2	77	0	# PP Impediment Scourge
+	2	118	0	# PP Massage Girdle
+	2	140	0	# PP Optical Illustration
+	2	152	0	# PP Fortified Delicacy
+	2	172	0	# PP Gherkin Gate
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/sh4-7.txt
+++ b/assets/files/presets/at/sh4-7.txt
@@ -116,53 +116,53 @@ AT 	# category
 2	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
 	2	1408.7	1625.2				0	# SR plug
-20 	# num enemy spawns
-	78 	-1576.150024 20.000000 1320.489990 	2	-1
-	1 	-3232.669922 0.000000 -123.870003 	2	-1
-	1 	-2245.250000 50.000000 676.880005 	2	-1
-	23 	-2781.399902 -30.000000 162.669998 	2	-1
-	95 	-3007.169922 -30.000000 574.859985 	2	-1
-	15 	-1340.170044 30.000000 491.329987 	2	-1
-	24 	-1310.869995 30.000000 346.839996 	2	-1
-	21 	-1218.459961 23.950001 766.489990 	2	-1
-	21 	-1220.699951 22.190001 679.390015 	2	-1
-	17 	-1500.079956 -10.000000 1002.669983 	2	-1
-	55 	-342.399994 0.000000 1391.130005 	2	-1
-	55 	-92.239998 0.000000 1681.890015 	2	-1
-	84 	-145.679993 0.000000 1537.790039 	2	-1
-	84 	-467.910004 0.000000 1477.599976 	2	-1
-	84 	-241.839996 0.000000 1716.819946 	2	-1
-	63 	-3538.899902 -30.000000 1044.170044 	2	-1
-	14 	-2976.199951 0.000000 2237.370117 	2	-1
-	75 	-2172.050049 30.000000 2714.399902 	2	-1
-	24 	-2992.959961 0.000000 1651.540039 	2	-1
-	25 	-3244.419922 0.000000 2052.760010 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	1
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	185 	1 	# Air Brake
-	53 	1 	# Onion Replica
-	72 	1 	# Aquatic Mine
-	77 	1 	# Impediment Scourge
-	118 	1 	# Massage Girdle
-	140 	1 	# Optical Illustration
-	152 	1 	# Fortified Delicacy
-	172 	1 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+25 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	9	# AW Cloaking Burrow-nit
+	1	15	-383.960480 29.999977 575.847656	9	# AW Cloaking Burrow-nit (BO)
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	1	10	-347.220551 -20.000000 4107.389648	9	# AW Iridescent Glint Beetle (SH)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+	2	101	950.000000 -57.000000 475.000000	8	# PP Toady Bloyster
+21 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	44	0	# AW Decorative Goo
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	1	185	0	# AW Air Brake
+	2	53	0	# PP Onion Replica
+	2	72	0	# PP Aquatic Mine
+	2	77	0	# PP Impediment Scourge
+	2	118	0	# PP Massage Girdle
+	2	140	0	# PP Optical Illustration
+	2	152	0	# PP Fortified Delicacy
+	2	172	0	# PP Gherkin Gate
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/smc1-2.txt
+++ b/assets/files/presets/at/smc1-2.txt
@@ -101,50 +101,42 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-17 	# num enemy spawns
-	17 	-950.000000 6.250000 -150.000000 	1	-1
-	0 	-480.000000 89.010002 -1115.000000 	1	-1
-	0 	-666.000000 89.010002 -800.000000 	1	-1
-	0 	-375.000000 89.010002 -800.000000 	1	-1
-	23 	-650.000000 52.889999 -1800.000000 	1	-1
-	26 	-400.000000 -57.000000 -2950.000000 	1	-1
-	55 	0.000000 -57.000000 -3000.000000 	1	-1
-	14 	-25.000000 0.000000 -75.000000 	1	-1
-	14 	275.000000 16.480000 -275.000000 	1	-1
-	27 	1350.000000 -91.400002 1450.000000 	2	-1
-	27 	1400.000000 -90.050003 1825.000000 	2	-1
-	23 	375.000000 7.240000 -1375.000000 	2	-1
-	101 	950.000000 57.000000 475.000000 	2	-1
-	26 	150.000000 -57.000000 1950.000000 	2	-1
-	17 	400.000000 -57.000000 1600.000000 	2	-1
-	17 	750.000000 -57.000000 1350.000000 	2	-1
-	24 	550.000000 17.690001 -1000.000000 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	0 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+24 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+11 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/smc3.txt
+++ b/assets/files/presets/at/smc3.txt
@@ -101,50 +101,42 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-17 	# num enemy spawns
-	17 	-950.000000 6.250000 -150.000000 	1	-1
-	0 	-480.000000 89.010002 -1115.000000 	1	-1
-	0 	-666.000000 89.010002 -800.000000 	1	-1
-	0 	-375.000000 89.010002 -800.000000 	1	-1
-	23 	-650.000000 52.889999 -1800.000000 	1	-1
-	26 	-400.000000 -57.000000 -2950.000000 	1	-1
-	55 	0.000000 -57.000000 -3000.000000 	1	-1
-	14 	-25.000000 0.000000 -75.000000 	1	-1
-	14 	275.000000 16.480000 -275.000000 	1	-1
-	27 	1350.000000 -91.400002 1450.000000 	2	-1
-	27 	1400.000000 -90.050003 1825.000000 	2	-1
-	23 	375.000000 7.240000 -1375.000000 	2	-1
-	101 	950.000000 57.000000 475.000000 	2	-1
-	26 	150.000000 -57.000000 1950.000000 	2	-1
-	17 	400.000000 -57.000000 1600.000000 	2	-1
-	17 	750.000000 -57.000000 1350.000000 	2	-1
-	24 	550.000000 17.690001 -1000.000000 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	0 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+24 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+11 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/smc4.txt
+++ b/assets/files/presets/at/smc4.txt
@@ -101,50 +101,42 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-17 	# num enemy spawns
-	17 	-950.000000 6.250000 -150.000000 	1	-1
-	0 	-480.000000 89.010002 -1115.000000 	1	-1
-	0 	-666.000000 89.010002 -800.000000 	1	-1
-	0 	-375.000000 89.010002 -800.000000 	1	-1
-	23 	-650.000000 52.889999 -1800.000000 	1	-1
-	26 	-400.000000 -57.000000 -2950.000000 	1	-1
-	55 	0.000000 -57.000000 -3000.000000 	1	-1
-	14 	-25.000000 0.000000 -75.000000 	1	-1
-	14 	275.000000 16.480000 -275.000000 	1	-1
-	27 	1350.000000 -91.400002 1450.000000 	2	-1
-	27 	1400.000000 -90.050003 1825.000000 	2	-1
-	23 	375.000000 7.240000 -1375.000000 	2	-1
-	101 	950.000000 57.000000 475.000000 	2	-1
-	26 	150.000000 -57.000000 1950.000000 	2	-1
-	17 	400.000000 -57.000000 1600.000000 	2	-1
-	17 	750.000000 -57.000000 1350.000000 	2	-1
-	24 	550.000000 17.690001 -1000.000000 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	0 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+24 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+11 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/smc5.txt
+++ b/assets/files/presets/at/smc5.txt
@@ -101,50 +101,42 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-17 	# num enemy spawns
-	17 	-950.000000 6.250000 -150.000000 	1	-1
-	0 	-480.000000 89.010002 -1115.000000 	1	-1
-	0 	-666.000000 89.010002 -800.000000 	1	-1
-	0 	-375.000000 89.010002 -800.000000 	1	-1
-	23 	-650.000000 52.889999 -1800.000000 	1	-1
-	26 	-400.000000 -57.000000 -2950.000000 	1	-1
-	55 	0.000000 -57.000000 -3000.000000 	1	-1
-	14 	-25.000000 0.000000 -75.000000 	1	-1
-	14 	275.000000 16.480000 -275.000000 	1	-1
-	27 	1350.000000 -91.400002 1450.000000 	2	-1
-	27 	1400.000000 -90.050003 1825.000000 	2	-1
-	23 	375.000000 7.240000 -1375.000000 	2	-1
-	101 	950.000000 57.000000 475.000000 	2	-1
-	26 	150.000000 -57.000000 1950.000000 	2	-1
-	17 	400.000000 -57.000000 1600.000000 	2	-1
-	17 	750.000000 -57.000000 1350.000000 	2	-1
-	24 	550.000000 17.690001 -1000.000000 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	0 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+24 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+11 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/sr1-4.txt
+++ b/assets/files/presets/at/sr1-4.txt
@@ -107,43 +107,50 @@ AT 	# category
 2	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
 	2	1408.7	1625.2				0	# SR plug
-10 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	2	-1
-	84 	-899.460022 -20.000000 1109.540039 	2	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	10 	-347.220001 -20.000000 4107.390137 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	15 	-383.959991 30.000000 575.849976 	2	-1
-	15 	-71.489998 -20.000000 1117.589966 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	1 	# Onion Replica
-	72 	1 	# Aquatic Mine
-	77 	1 	# Impediment Scourge
-	118 	1 	# Massage Girdle
-	140 	1 	# Optical Illustration
-	152 	1 	# Fortified Delicacy
-	172 	1 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+25 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+	2	101	950.000000 -57.000000 475.000000	8	# PP Toady Bloyster
+18 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
+	2	53	0	# PP Onion Replica
+	2	72	0	# PP Aquatic Mine
+	2	77	0	# PP Impediment Scourge
+	2	118	0	# PP Massage Girdle
+	2	140	0	# PP Optical Illustration
+	2	152	0	# PP Fortified Delicacy
+	2	172	0	# PP Gherkin Gate
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/sr5.txt
+++ b/assets/files/presets/at/sr5.txt
@@ -107,43 +107,50 @@ AT 	# category
 2	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
 	2	1408.7	1625.2				0	# SR plug
-10 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	2	-1
-	84 	-899.460022 -20.000000 1109.540039 	2	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	10 	-347.220001 -20.000000 4107.390137 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	15 	-383.959991 30.000000 575.849976 	2	-1
-	15 	-71.489998 -20.000000 1117.589966 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	1 	# Onion Replica
-	72 	1 	# Aquatic Mine
-	77 	1 	# Impediment Scourge
-	118 	1 	# Massage Girdle
-	140 	1 	# Optical Illustration
-	152 	1 	# Fortified Delicacy
-	172 	1 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+25 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+	2	101	950.000000 -57.000000 475.000000	8	# PP Toady Bloyster
+18 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
+	2	53	0	# PP Onion Replica
+	2	72	0	# PP Aquatic Mine
+	2	77	0	# PP Impediment Scourge
+	2	118	0	# PP Massage Girdle
+	2	140	0	# PP Optical Illustration
+	2	152	0	# PP Fortified Delicacy
+	2	172	0	# PP Gherkin Gate
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/sr6.txt
+++ b/assets/files/presets/at/sr6.txt
@@ -107,43 +107,50 @@ AT 	# category
 2	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
 	2	1408.7	1625.2				0	# SR plug
-10 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	2	-1
-	84 	-899.460022 -20.000000 1109.540039 	2	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	10 	-347.220001 -20.000000 4107.390137 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	15 	-383.959991 30.000000 575.849976 	2	-1
-	15 	-71.489998 -20.000000 1117.589966 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	1 	# Onion Replica
-	72 	1 	# Aquatic Mine
-	77 	1 	# Impediment Scourge
-	118 	1 	# Massage Girdle
-	140 	1 	# Optical Illustration
-	152 	1 	# Fortified Delicacy
-	172 	1 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+25 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+	2	101	950.000000 -57.000000 475.000000	8	# PP Toady Bloyster
+18 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
+	2	53	0	# PP Onion Replica
+	2	72	0	# PP Aquatic Mine
+	2	77	0	# PP Impediment Scourge
+	2	118	0	# PP Massage Girdle
+	2	140	0	# PP Optical Illustration
+	2	152	0	# PP Fortified Delicacy
+	2	172	0	# PP Gherkin Gate
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/sr7.txt
+++ b/assets/files/presets/at/sr7.txt
@@ -107,43 +107,50 @@ AT 	# category
 2	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
 	2	1408.7	1625.2				0	# SR plug
-10 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	2	-1
-	84 	-899.460022 -20.000000 1109.540039 	2	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	10 	-347.220001 -20.000000 4107.390137 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	15 	-383.959991 30.000000 575.849976 	2	-1
-	15 	-71.489998 -20.000000 1117.589966 	2	-1
-26 	# num treasure spawn overrides
-	47 	1 	# Fossilized Ursidae
-	62 	1 	# Pink Menace
-	71 	1 	# Unspeakable Wonder
-	73 	1 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	1 	# Courage Reactor
-	157 	1 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	1 	# Onion Replica
-	72 	1 	# Aquatic Mine
-	77 	1 	# Impediment Scourge
-	118 	1 	# Massage Girdle
-	140 	1 	# Optical Illustration
-	152 	1 	# Fortified Delicacy
-	172 	1 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+25 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	24	300.905426 100.000000 361.603760	7	# VoR Fiery Blowhog
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	0	33	-616.059265 100.000000 -778.380981	7	# VoR Fiery Bulblax
+	0	26	-679.412659 60.000000 -24.931995	7	# VoR Water Dumple x2
+	0	26	-810.081970 60.000000 -378.640717	7	# VoR Water Dumple (near bulblax)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	2	17	-950.000000 6.250000 -150.000000	8	# PP Yellow Wollywog (near CoS)
+	2	0	-480.000000 89.010002 -1115.000000	8	# PP Pellet Posy (YO)
+	2	0	-666.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	0	-375.000000 89.010002 -800.000000	8	# PP Pellet Posy (YO)
+	2	23	-650.000000 52.889999 -1800.000000	8	# PP Swooping Snitchbug
+	2	26	-400.000000 -57.000000 -2950.000000	8	# PP Water Dumple x2
+	2	55	0.000000 -57.000000 -3000.000000	8	# PP Withering Blowhog
+	2	14	-25.000000 0.000000 -75.000000	8	# PP Shearwig
+	2	14	275.000000 16.480000 -275.000000	8	# PP Shearwig
+	2	101	950.000000 -57.000000 475.000000	8	# PP Toady Bloyster
+18 	# num treasure spawn overrides
+	0	47	0	# VoR Fossilized Ursidae
+	0	62	0	# VoR Pink Menace
+	0	71	0	# VoR Unspeakable Wonder
+	0	73	0	# VoR Temporal Mechanism
+	0	87	0	# VoR Utter Scrap
+	0	142	0	# VoR Courage Reactor
+	0	157	0	# VoR Spiny Alien Treat
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
+	2	53	0	# PP Onion Replica
+	2	72	0	# PP Aquatic Mine
+	2	77	0	# PP Impediment Scourge
+	2	118	0	# PP Massage Girdle
+	2	140	0	# PP Optical Illustration
+	2	152	0	# PP Fortified Delicacy
+	2	172	0	# PP Gherkin Gate
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/vor_cleanup.txt
+++ b/assets/files/presets/at/vor_cleanup.txt
@@ -90,52 +90,23 @@ AT 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-19 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	1	-1
-	24 	548.539978 100.000000 546.479980 	1	-1
-	24 	300.910004 100.000000 361.600006 	2	-1
-	26 	340.790009 15.000000 868.559998 	2	-1
-	26 	145.539993 18.870001 618.030029 	2	-1
-	95 	-244.220001 100.000000 326.779999 	2	-1
-	95 	302.179993 100.000000 -177.910004 	1	-1
-	96 	182.160004 210.000000 -1559.790039 	1	-1
-	55 	-271.089996 114.000000 -1387.319946 	1	-1
-	26 	-679.409973 60.000000 -24.930000 	2	-1
-	26 	-810.080017 60.000000 -378.640015 	2	-1
-	33 	-616.059998 100.000000 -778.380005 	2	-1
-	0 	-259.880005 50.000000 2476.479980 	2	-1
-	0 	52.869999 9.170000 3055.310059 	2	-1
-	0 	-1342.390015 4.200000 2825.760010 	2	-1
-	0 	-1340.810059 0.000000 2606.399902 	2	-1
-	0 	-584.419983 0.000000 3160.870117 	2	-1
-	0 	-21.920000 0.000000 2870.729980 	2	-1
-	0 	-400.920013 0.000000 2646.800049 	2	-1
-26 	# num treasure spawn overrides
-	47 	2 	# Fossilized Ursidae
-	62 	2 	# Pink Menace
-	71 	2 	# Unspeakable Wonder
-	73 	2 	# Temporal Mechanism
-	87 	1 	# Utter Scrap
-	142 	2 	# Courage Reactor
-	157 	2 	# Spiny Alien Treat
-	11 	1 	# Geographic Projection
-	42 	1 	# Sunseed Berry
-	43 	0
-	130 	1 	# Pilgrim Bulb
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	0 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+11 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	24	548.539978 100.000000 546.479980	6	# VoR Fiery Blowhog (bridge)
+	0	95	302.179993 100.000000 -177.910004	6	# VoR Decorated Cannon Beetle
+	0	96	182.160004 210.000000 -1559.790039	6	# VoR Armored Cannon Beetle Larva
+	0	55	-271.089996 114.000000 -1387.319946	6	# VoR Withering Blowhog
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	9	518.905334 -75.000000 3719.976562	5	# AW Iridescent Flint Beetle
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+5 	# num treasure spawn overrides
+	0	87	0	# VoR Utter Scrap
+	1	11	0	# AW Geographic Projection
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/wfg1.txt
+++ b/assets/files/presets/at/wfg1.txt
@@ -46,45 +46,10 @@ AT 	# category
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 0	# num plugs destroyed
-12 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	1	-1
-	84 	-899.460022 -20.000000 1109.540039 	2	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	0 	13.000000 15.000000 211.000000 	2	-1
-	0 	209.000000 10.000000 -206.000000 	2	-1
-	0 	14.000000 15.000000 -263.000000 	2	-1
-	0 	-258.000000 15.000000 -133.000000 	2	-1
-	27 	-36.439999 15.000000 -104.839996 	2	-1
-26 	# num treasure spawn overrides
-	47 	2 	# Fossilized Ursidae
-	62 	2 	# Pink Menace
-	71 	2 	# Unspeakable Wonder
-	73 	2 	# Temporal Mechanism
-	87 	2 	# Utter Scrap
-	142 	2 	# Courage Reactor
-	157 	2 	# Spiny Alien Treat
-	11 	2 	# Geographic Projection
-	42 	2 	# Sunseed Berry
-	43 	2
-	130 	2 	# Pilgrim Bulb
-	155 	2 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	2 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+3 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/wfg2-3.txt
+++ b/assets/files/presets/at/wfg2-3.txt
@@ -50,45 +50,10 @@ AT 	# category
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 0	# num plugs destroyed
-12 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	1	-1
-	84 	-899.460022 -20.000000 1109.540039 	2	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	0 	13.000000 15.000000 211.000000 	2	-1
-	0 	209.000000 10.000000 -206.000000 	2	-1
-	0 	14.000000 15.000000 -263.000000 	2	-1
-	0 	-258.000000 15.000000 -133.000000 	2	-1
-	27 	-36.439999 15.000000 -104.839996 	2	-1
-26 	# num treasure spawn overrides
-	47 	2 	# Fossilized Ursidae
-	62 	2 	# Pink Menace
-	71 	2 	# Unspeakable Wonder
-	73 	2 	# Temporal Mechanism
-	87 	2 	# Utter Scrap
-	142 	2 	# Courage Reactor
-	157 	2 	# Spiny Alien Treat
-	11 	2 	# Geographic Projection
-	42 	2 	# Sunseed Berry
-	43 	2
-	130 	2 	# Pilgrim Bulb
-	155 	2 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	2 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+3 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/at/wfg4-5.txt
+++ b/assets/files/presets/at/wfg4-5.txt
@@ -53,45 +53,10 @@ AT 	# category
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 0	# num plugs destroyed
-12 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	1	-1
-	84 	-899.460022 -20.000000 1109.540039 	2	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	0 	13.000000 15.000000 211.000000 	2	-1
-	0 	209.000000 10.000000 -206.000000 	2	-1
-	0 	14.000000 15.000000 -263.000000 	2	-1
-	0 	-258.000000 15.000000 -133.000000 	2	-1
-	27 	-36.439999 15.000000 -104.839996 	2	-1
-26 	# num treasure spawn overrides
-	47 	2 	# Fossilized Ursidae
-	62 	2 	# Pink Menace
-	71 	2 	# Unspeakable Wonder
-	73 	2 	# Temporal Mechanism
-	87 	2 	# Utter Scrap
-	142 	2 	# Courage Reactor
-	157 	2 	# Spiny Alien Treat
-	11 	2 	# Geographic Projection
-	42 	2 	# Sunseed Berry
-	43 	2
-	130 	2 	# Pilgrim Bulb
-	155 	2 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	2 	# Air Brake
-	53 	2 	# Onion Replica
-	72 	2 	# Aquatic Mine
-	77 	2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	2 	# Armored Nut
-	45 	2 	# Anti-hiccup Fungus
-	50 	2 	# Conifer Spire
-	76 	2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+3 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/general/everything.txt
+++ b/assets/files/presets/general/everything.txt
@@ -125,53 +125,7 @@ General 	# category
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 0	# num plugs destroyed
-20 	# num enemy spawns
-	78 	-1576.150024 20.000000 1320.489990 	2	-1
-	1 	-3232.669922 0.000000 -123.870003 	2	-1
-	1 	-2245.250000 50.000000 676.880005 	2	-1
-	23 	-2781.399902 -30.000000 162.669998 	2	-1
-	95 	-3007.169922 -30.000000 574.859985 	2	-1
-	15 	-1340.170044 30.000000 491.329987 	2	-1
-	24 	-1310.869995 30.000000 346.839996 	2	-1
-	21 	-1218.459961 23.950001 766.489990 	2	-1
-	21 	-1220.699951 22.190001 679.390015 	2	-1
-	17 	-1500.079956 -10.000000 1002.669983 	2	-1
-	55 	-342.399994 0.000000 1391.130005 	2	-1
-	55 	-92.239998 0.000000 1681.890015 	2	-1
-	84 	-145.679993 0.000000 1537.790039 	2	-1
-	84 	-467.910004 0.000000 1477.599976 	2	-1
-	84 	-241.839996 0.000000 1716.819946 	2	-1
-	63 	-3538.899902 -30.000000 1044.170044 	2	-1
-	14 	-2976.199951 0.000000 2237.370117 	2	-1
-	75 	-2172.050049 30.000000 2714.399902 	2	-1
-	24 	-2992.959961 0.000000 1651.540039 	2	-1
-	25 	-3244.419922 0.000000 2052.760010 	2	-1
-26 	# num treasure spawn overrides
-	47 	    2 	# Fossilized Ursidae
-	62 	    2 	# Pink Menace
-	71 	    2 	# Unspeakable Wonder
-	73 	    2 	# Temporal Mechanism
-	87 	    2 	# Utter Scrap
-	142 	2 	# Courage Reactor
-	157 	2 	# Spiny Alien Treat
-	11 	    2 	# Geographic Projection
-	42 	    2 	# Sunseed Berry
-	43 	    2
-	130 	2 	# Pilgrim Bulb
-	155 	2 	# Chance Totem
-	173 	2 	# Healing Cask
-	185 	2 	# Air Brake
-	53 	    2 	# Onion Replica
-	72 	    2 	# Aquatic Mine
-	77 	    2 	# Impediment Scourge
-	118 	2 	# Massage Girdle
-	140 	2 	# Optical Illustration
-	152 	2 	# Fortified Delicacy
-	172 	2 	# Gherkin Gate
-	27 	    2 	# Armored Nut
-	45 	    2 	# Anti-hiccup Fungus
-	50 	    2 	# Conifer Spire
-	76 	    2 	# Doomsday Apparatus
-	183 	2 	# Seed of Greed
+0 	# num enemy spawns
+0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/bk.txt
+++ b/assets/files/presets/pod/bk.txt
@@ -71,17 +71,18 @@ PoD 	# category
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 0	# num plugs destroyed
-0 	# num enemy spawns
-10 	# num treasure spawn overrides
-	42 	1 	# Sunseed Berry
-	130 	1 	# Pilgrim Bulb
-	11 	1 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	142 	2 	# Courage Reactor
-	62 	2 	# Pink Menace
-	87 	2 	# Utter Scrap
-	157 	2 	# Spiny Alien Treat
-	47 	2 	# Fossilized Ursidae
+6 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+5 	# num treasure spawn overrides
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	11	0	# AW Geographic Projection
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
 1	# bridge glitch active
 4	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/bk_25w.txt
+++ b/assets/files/presets/pod/bk_25w.txt
@@ -71,17 +71,18 @@ PoD 	# category
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 0	# num plugs destroyed
-0 	# num enemy spawns
-10 	# num treasure spawn overrides
-	42 	1 	# Sunseed Berry
-	130 	1 	# Pilgrim Bulb
-	11 	1 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	142 	2 	# Courage Reactor
-	62 	2 	# Pink Menace
-	87 	2 	# Utter Scrap
-	157 	2 	# Spiny Alien Treat
-	47 	2 	# Fossilized Ursidae
+6 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+5 	# num treasure spawn overrides
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	11	0	# AW Geographic Projection
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
 1	# bridge glitch active
 4	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/cos.txt
+++ b/assets/files/presets/pod/cos.txt
@@ -86,17 +86,24 @@ PoD 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-0 	# num enemy spawns
+7 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	55	-271.092255 114.000000 -1387.317261	7	# VoR Withering Blowhog
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
 10 	# num treasure spawn overrides
-	42 	1 	# Sunseed Berry
-	130 	1 	# Pilgrim Bulb
-	11 	1 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	142 	1 	# Courage Reactor
-	62 	1 	# Pink Menace
-	87 	1 	# Utter Scrap
-	157 	1 	# Spiny Alien Treat
-	47 	1 	# Fossilized Ursidae
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	11	0	# AW Geographic Projection
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	0	142	0	# VoR Courage Reactor
+	0	62	0	# VoR Pink Menace
+	0	87	0	# VoR Utter Scrap
+	0	157	0	# VoR Spiny Alien Treat
+	0	47	0	# VoR Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/cos_40w.txt
+++ b/assets/files/presets/pod/cos_40w.txt
@@ -86,17 +86,24 @@ PoD 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-0 	# num enemy spawns
+7 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	55	-271.092255 114.000000 -1387.317261	7	# VoR Withering Blowhog
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
 10 	# num treasure spawn overrides
-	42 	1 	# Sunseed Berry
-	130 	1 	# Pilgrim Bulb
-	11 	1 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	142 	1 	# Courage Reactor
-	62 	1 	# Pink Menace
-	87 	1 	# Utter Scrap
-	157 	1 	# Spiny Alien Treat
-	47 	1 	# Fossilized Ursidae
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	11	0	# AW Geographic Projection
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	0	142	0	# VoR Courage Reactor
+	0	62	0	# VoR Pink Menace
+	0	87	0	# VoR Utter Scrap
+	0	157	0	# VoR Spiny Alien Treat
+	0	47	0	# VoR Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/day1.txt
+++ b/assets/files/presets/pod/day1.txt
@@ -18,32 +18,7 @@ PoD 	# category
 0 	# num finished bridges
 0 	# num flattened bags
 0	# num plugs destroyed
-15 	# num enemy spawns
-	1 	-1153.00 	47.00 		2231.00  2	-1	# dwarf bulborb on manhole cover
-	1	-585.96		0.00		2782.99  2	-1	# dwarf bulborb in landing site
-	0	52.87 		9.17 		3055.3 	 1	-1	# 5 pellet behind ship
-	0	-21.92 		0.00 		2870.73	 1	-1	# 1 pellets behind red onion
-	37	424.30		125.00 		2897.12	 1	-1	# eggs behind ship
-	0	-400.92  	0.00 		2646.80	 1	-1	# 1 pellet next to red onion
-	0	-259.88 	50.00 		2476.48	 1	-1	# 10 pellet on ledge
-	0	-584.42 	0.00 		3160.87	 1	-1	# 1 pellet near blue onion spot
-	0	-1342.39 	4.20 	   	2825.76	 1	-1	# left 5 pellet in bag area
-	0	-1340.81 	0.00 	   	2606.4	 1	-1	# right 5 pellet in bag area
-    0  -524.84     	60.00    	3718.10  2	-1	# left 1 pellet in louie area
-    0  -113.63     	60.00    	3915.37  2	-1	# middle 1 pellet in louie area
-    0  -221.42     	60.00    	4188.80  2	-1	# right 1 pellet in louie area
-    0  -14.46       100.00   	3721.81  2	-1	# left ledge 1 pellet in louie area
-    0  62.66        100.00   	3768.90  2	-1	# right ledge 1 pellet in louie area
-10 	# num treasure spawn overrides
-    42 		2 	# Sunseed Berry
-	130 	2 	# Pilgrim Bulb
-	11 		2 	# Geographic Projection
-	155 	2 	# Chance Totem
-	173 	2 	# Healing Cask
-	142 	2 	# Courage Reactor
-	62 		2 	# Pink Menace
-	87 		2 	# Utter Scrap
-	157 	2 	# Spiny Alien Treat
-	47 		2 	# Fossilized Ursidae
+0 	# num enemy spawns
+0 	# num treasure spawn overrides
 0	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/day2.txt
+++ b/assets/files/presets/pod/day2.txt
@@ -21,27 +21,7 @@ PoD 	# category
 0 	# num finished bridges
 0 	# num flattened bags
 0	# num plugs destroyed
-10 	# num enemy spawns
-	1 	-1153.00	47.00	2231.00 2	-1	# dwarf bulborb on manhole cover
-	1	-585.96		0.00	2782.99	2	-1	# dwarf bulborb in landing site
-	0	52.87		9.17	3055.3 	1	-1	# 5 pellet behind ship
-	0	-21.92		0.00	2870.73	2	-1	# 1 pellets behind red onion
-	37	424.30		125.00	2897.12	1	-1	# eggs behind ship
-	0	-400.92		0.00	2646.80	1	-1	# 1 pellet next to red onion
-	0	-259.88		50.00	2476.48	1	-1	# 10 pellet on ledge
-	0	-584.42		0.00	3160.87	1	-1	# 1 pellet near blue onion spot
-	0	-1342.39	4.20	2825.76	1	-1	# left 5 pellet in bag area
-	0	-1340.81	0.00	2606.4	1	-1	# right 5 pellet in bag area
-10 	# num treasure spawn overrides
-	42 		2 	# Sunseed Berry
-	130 	2 	# Pilgrim Bulb
-	11 		2 	# Geographic Projection
-	155 	2 	# Chance Totem
-	173 	2 	# Healing Cask
-	142 	2 	# Courage Reactor
-	62 		2 	# Pink Menace
-	87 		2 	# Utter Scrap
-	157 	2 	# Spiny Alien Treat
-	47 		2 	# Fossilized Ursidae
+0 	# num enemy spawns
+0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/day3.txt
+++ b/assets/files/presets/pod/day3.txt
@@ -26,27 +26,7 @@ PoD 	# category
 0 	# num finished bridges
 0 	# num flattened bags
 0	# num plugs destroyed
-10 	# num enemy spawns
-	1 	-1153.00	47.00	2231.00 2	-1	# dwarf bulborb on manhole cover
-	1	-585.96		0.00	2782.99	1	-1	# dwarf bulborb in landing site
-	0	52.87		9.17	3055.3 	1	-1	# 5 pellet behind ship
-	0	-21.92		0.00	2870.73	2	-1	# 1 pellets behind red onion
-	37	424.30		125.00	2897.12	1	-1	# eggs behind ship
-	0	-400.92		0.00	2646.80	2	-1	# 1 pellet next to red onion
-	0	-259.88		50.00	2476.48	1	-1	# 10 pellet on ledge
-	0	-584.42		0.00	3160.87	1	-1	# 1 pellet near blue onion spot
-	0	-1342.39	4.20	2825.76	1	-1	# left 5 pellet in bag area
-	0	-1340.81	0.00	2606.4	1	-1	# right 5 pellet in bag area
-10 	# num treasure spawn overrides
-	42 		2 	# Sunseed Berry
-	130 	2 	# Pilgrim Bulb
-	11 		2 	# Geographic Projection
-	155 	2 	# Chance Totem
-	173 	2 	# Healing Cask
-	142 	2 	# Courage Reactor
-	62 		2 	# Pink Menace
-	87 		2 	# Utter Scrap
-	157 	2 	# Spiny Alien Treat
-	47 		2 	# Fossilized Ursidae
+0 	# num enemy spawns
+0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/day4.txt
+++ b/assets/files/presets/pod/day4.txt
@@ -28,27 +28,7 @@ PoD 	# category
 0 	# num finished bridges
 0 	# num flattened bags
 0	# num plugs destroyed
-10 	# num enemy spawns
-	1 	-1153.00	47.00	2231.00 2	-1	# dwarf bulborb on manhole cover
-	1	-585.96		0.00	2782.99	1	-1	# dwarf bulborb in landing site
-	0	52.87		9.17	3055.30	2	-1	# 5 pellet behind ship
-	0	-21.92		0.00	2870.73	2	-1	# 1 pellets behind red onion
-	37	424.30		125.00	2897.12	2	-1	# eggs behind ship
-	0	-400.92		0.00	2646.80	2	-1	# 1 pellet next to red onion
-	0	-259.88		50.00	2476.48	2	-1	# 10 pellet on ledge
-	0	-584.42		0.00	3160.87	2	-1	# 1 pellet near blue onion spot
-	0	-1342.39	4.20	2825.76	2	-1	# left 5 pellet in bag area
-	0	-1340.81	0.00	2606.40	2	-1	# right 5 pellet in bag area
-10 	# num treasure spawn overrides
-	42 		2 	# Sunseed Berry
-	130 	2 	# Pilgrim Bulb
-	11 		2 	# Geographic Projection
-	155 	2 	# Chance Totem
-	173 	2 	# Healing Cask
-	142 	2 	# Courage Reactor
-	62 		2 	# Pink Menace
-	87 		2 	# Utter Scrap
-	157 	2 	# Spiny Alien Treat
-	47 		2 	# Fossilized Ursidae
+0 	# num enemy spawns
+0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/day6_cr.txt
+++ b/assets/files/presets/pod/day6_cr.txt
@@ -74,21 +74,16 @@ PoD 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 0	# num plugs destroyed
 5 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	2	-1
-	24 	548.54 100.0 546.48 	2	-1	# fiery blowhog
-    24  300.91 100.0 361.60     2	-1	# fiery blowhog
-    95  302.18 100.0 -177.91    2	-1	# cannon beetle larvae
-    55  -271.09 114.0 -1387.32  2	-1	# withering blowhog
-10 	# num treasure spawn overrides
-	42 	1 	# Sunseed Berry
-	130 	1 	# Pilgrim Bulb
-	11 	1 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	142 	2 	# Courage Reactor
-	62 	2 	# Pink Menace
-	87 	2 	# Utter Scrap
-	157 	2 	# Spiny Alien Treat
-	47 	2 	# Fossilized Ursidae
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+5 	# num treasure spawn overrides
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	11	0	# AW Geographic Projection
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/day6_cr_25w.txt
+++ b/assets/files/presets/pod/day6_cr_25w.txt
@@ -74,21 +74,16 @@ PoD 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 0	# num plugs destroyed
 5 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	2	-1
-	24 	548.54 100.0 546.48 	2	-1	# fiery blowhog
-    24  300.91 100.0 361.60     2	-1	# fiery blowhog
-    95  302.18 100.0 -177.91    2	-1	# cannon beetle larvae
-    55  -271.09 114.0 -1387.32  2	-1	# withering blowhog
-10 	# num treasure spawn overrides
-	42 	1 	# Sunseed Berry
-	130 	1 	# Pilgrim Bulb
-	11 	1 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	142 	2 	# Courage Reactor
-	62 	2 	# Pink Menace
-	87 	2 	# Utter Scrap
-	157 	2 	# Spiny Alien Treat
-	47 	2 	# Fossilized Ursidae
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+5 	# num treasure spawn overrides
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	11	0	# AW Geographic Projection
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/ec1.txt
+++ b/assets/files/presets/pod/ec1.txt
@@ -36,7 +36,8 @@ PoD 	# category
 	0 	-910.700012 2769.199951 	0 	# landing area bag (15)
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 0	# num plugs destroyed
-0 	# num enemy spawns
+1 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
 0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/ec2.txt
+++ b/assets/files/presets/pod/ec2.txt
@@ -38,28 +38,8 @@ PoD 	# category
 	0 	-910.700012 2769.199951 	0 	# landing area bag (15)
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 0	# num plugs destroyed
-11 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	2	-1
-	15 	-672.000000 -20.000000 1392.000000 	2	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	0 	13.000000 15.000000 211.000000 	2	-1
-	0 	209.000000 10.000000 -206.000000 	2	-1
-	0 	14.000000 15.000000 -263.000000 	2	-1
-	0 	-258.000000 15.000000 -133.000000 	2	-1
-	27 	-36.439999 15.000000 -104.839996 	2	-1
-10 	# num treasure spawn overrides
-	42 	2 	# Sunseed Berry
-	130 	2 	# Pilgrim Bulb
-	11 	2 	# Geographic Projection
-	155 	2 	# Chance Totem
-	173 	2 	# Healing Cask
-	142 	2 	# Courage Reactor
-	62 	2 	# Pink Menace
-	87 	2 	# Utter Scrap
-	157 	2 	# Spiny Alien Treat
-	47 	2 	# Fossilized Ursidae
+1 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/enter_bk_15_5w.txt
+++ b/assets/files/presets/pod/enter_bk_15_5w.txt
@@ -67,28 +67,11 @@ PoD 	# category
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 0	# num plugs destroyed
-11 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	1	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	0 	13.000000 15.000000 211.000000 	2	-1
-	0 	209.000000 10.000000 -206.000000 	2	-1
-	0 	14.000000 15.000000 -263.000000 	2	-1
-	0 	-258.000000 15.000000 -133.000000 	2	-1
-	27 	-36.439999 15.000000 -104.839996 	2	-1
-10 	# num treasure spawn overrides
-	42 	2 	# Sunseed Berry
-	130 	2 	# Pilgrim Bulb
-	11 	2 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	142 	2 	# Courage Reactor
-	62 	2 	# Pink Menace
-	87 	2 	# Utter Scrap
-	157 	2 	# Spiny Alien Treat
-	47 	2 	# Fossilized Ursidae
+3 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+1 	# num treasure spawn overrides
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/enter_bk_20w.txt
+++ b/assets/files/presets/pod/enter_bk_20w.txt
@@ -67,28 +67,11 @@ PoD 	# category
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 0	# num plugs destroyed
-11 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	1	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	0 	13.000000 15.000000 211.000000 	2	-1
-	0 	209.000000 10.000000 -206.000000 	2	-1
-	0 	14.000000 15.000000 -263.000000 	2	-1
-	0 	-258.000000 15.000000 -133.000000 	2	-1
-	27 	-36.439999 15.000000 -104.839996 	2	-1
-10 	# num treasure spawn overrides
-	42 	2 	# Sunseed Berry
-	130 	2 	# Pilgrim Bulb
-	11 	2 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	142 	2 	# Courage Reactor
-	62 	2 	# Pink Menace
-	87 	2 	# Utter Scrap
-	157 	2 	# Spiny Alien Treat
-	47 	2 	# Fossilized Ursidae
+3 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+1 	# num treasure spawn overrides
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/enter_bk_25w.txt
+++ b/assets/files/presets/pod/enter_bk_25w.txt
@@ -67,28 +67,11 @@ PoD 	# category
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 0	# num plugs destroyed
-11 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	1	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	0 	13.000000 15.000000 211.000000 	2	-1
-	0 	209.000000 10.000000 -206.000000 	2	-1
-	0 	14.000000 15.000000 -263.000000 	2	-1
-	0 	-258.000000 15.000000 -133.000000 	2	-1
-	27 	-36.439999 15.000000 -104.839996 	2	-1
-10 	# num treasure spawn overrides
-	42 	2 	# Sunseed Berry
-	130 	2 	# Pilgrim Bulb
-	11 	2 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	142 	2 	# Courage Reactor
-	62 	2 	# Pink Menace
-	87 	2 	# Utter Scrap
-	157 	2 	# Spiny Alien Treat
-	47 	2 	# Fossilized Ursidae
+3 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+1 	# num treasure spawn overrides
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/enter_cos.txt
+++ b/assets/files/presets/pod/enter_cos.txt
@@ -84,17 +84,24 @@ PoD 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-0 	# num enemy spawns
+7 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	55	-271.092255 114.000000 -1387.317261	7	# VoR Withering Blowhog
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
 10 	# num treasure spawn overrides
-	42 	1 	# Sunseed Berry
-	130 	1 	# Pilgrim Bulb
-	11 	1 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	142 	1 	# Courage Reactor
-	62 	1 	# Pink Menace
-	87 	1 	# Utter Scrap
-	157 	1 	# Spiny Alien Treat
-	47 	1 	# Fossilized Ursidae
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	11	0	# AW Geographic Projection
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	0	142	0	# VoR Courage Reactor
+	0	62	0	# VoR Pink Menace
+	0	87	0	# VoR Utter Scrap
+	0	157	0	# VoR Spiny Alien Treat
+	0	47	0	# VoR Fossilized Ursidae
 0	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/enter_cos_40w.txt
+++ b/assets/files/presets/pod/enter_cos_40w.txt
@@ -84,17 +84,24 @@ PoD 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-0 	# num enemy spawns
+7 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	55	-271.092255 114.000000 -1387.317261	7	# VoR Withering Blowhog
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
 10 	# num treasure spawn overrides
-	42 	1 	# Sunseed Berry
-	130 	1 	# Pilgrim Bulb
-	11 	1 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	142 	1 	# Courage Reactor
-	62 	1 	# Pink Menace
-	87 	1 	# Utter Scrap
-	157 	1 	# Spiny Alien Treat
-	47 	1 	# Fossilized Ursidae
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	11	0	# AW Geographic Projection
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	0	142	0	# VoR Courage Reactor
+	0	62	0	# VoR Pink Menace
+	0	87	0	# VoR Utter Scrap
+	0	157	0	# VoR Spiny Alien Treat
+	0	47	0	# VoR Fossilized Ursidae
 0	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/enter_fc.txt
+++ b/assets/files/presets/pod/enter_fc.txt
@@ -79,22 +79,23 @@ PoD 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-5 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	1	-1	# dwarf bulborb
-	24 	548.54 100.0 546.48 	2	-1	# fiery blowhog
-    24  300.91 100.0 361.60     2	-1	# fiery blowhog
-    95  302.18 100.0 -177.91    2	-1	# cannon beetle larvae
-    55  -271.09 114.0 -1387.32  2	-1	# withering blowhog
+6 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
 10 	# num treasure spawn overrides
-	42 	    1 	# Sunseed Berry
-	130 	1 	# Pilgrim Bulb
-	11 	    1 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	142 	1 	# Courage Reactor
-	62 	    1 	# Pink Menace
-	87 	    1 	# Utter Scrap
-	157 	1 	# Spiny Alien Treat
-	47 	    3   -973.11 80.24 1721.64 	# Fossilized Ursidae
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	11	0	# AW Geographic Projection
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	0	142	0	# VoR Courage Reactor
+	0	62	0	# VoR Pink Menace
+	0	87	0	# VoR Utter Scrap
+	0	157	0	# VoR Spiny Alien Treat
+	0	47	1	-973.11 80.24 1721.64	# VoR Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/enter_fc_40w.txt
+++ b/assets/files/presets/pod/enter_fc_40w.txt
@@ -79,22 +79,23 @@ PoD 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-5 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	1	-1	# dwarf bulborb
-	24 	548.54 100.0 546.48 	2	-1	# fiery blowhog
-    24  300.91 100.0 361.60     2	-1	# fiery blowhog
-    95  302.18 100.0 -177.91    2	-1	# cannon beetle larvae
-    55  -271.09 114.0 -1387.32  2	-1	# withering blowhog
+6 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
 10 	# num treasure spawn overrides
-	42 	    1 	# Sunseed Berry
-	130 	1 	# Pilgrim Bulb
-	11 	    1 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	142 	1 	# Courage Reactor
-	62 	    1 	# Pink Menace
-	87 	    1 	# Utter Scrap
-	157 	1 	# Spiny Alien Treat
-	47 	    3   -973.11 80.24 1721.64 	# Fossilized Ursidae
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	11	0	# AW Geographic Projection
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	0	142	0	# VoR Courage Reactor
+	0	62	0	# VoR Pink Menace
+	0	87	0	# VoR Utter Scrap
+	0	157	0	# VoR Spiny Alien Treat
+	0	47	1	-973.11 80.24 1721.64	# VoR Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/enter_gk.txt
+++ b/assets/files/presets/pod/enter_gk.txt
@@ -86,17 +86,24 @@ PoD 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-0 	# num enemy spawns
+7 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	55	-271.092255 114.000000 -1387.317261	7	# VoR Withering Blowhog
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
 10 	# num treasure spawn overrides
-	42 	1 	# Sunseed Berry
-	130 	1 	# Pilgrim Bulb
-	11 	1 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	142 	1 	# Courage Reactor
-	62 	1 	# Pink Menace
-	87 	1 	# Utter Scrap
-	157 	1 	# Spiny Alien Treat
-	47 	1 	# Fossilized Ursidae
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	11	0	# AW Geographic Projection
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	0	142	0	# VoR Courage Reactor
+	0	62	0	# VoR Pink Menace
+	0	87	0	# VoR Utter Scrap
+	0	157	0	# VoR Spiny Alien Treat
+	0	47	0	# VoR Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/enter_gk_40w.txt
+++ b/assets/files/presets/pod/enter_gk_40w.txt
@@ -86,17 +86,24 @@ PoD 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-0 	# num enemy spawns
+7 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	55	-271.092255 114.000000 -1387.317261	7	# VoR Withering Blowhog
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
 10 	# num treasure spawn overrides
-	42 	1 	# Sunseed Berry
-	130 	1 	# Pilgrim Bulb
-	11 	1 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	142 	1 	# Courage Reactor
-	62 	1 	# Pink Menace
-	87 	1 	# Utter Scrap
-	157 	1 	# Spiny Alien Treat
-	47 	1 	# Fossilized Ursidae
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	11	0	# AW Geographic Projection
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	0	142	0	# VoR Courage Reactor
+	0	62	0	# VoR Pink Menace
+	0	87	0	# VoR Utter Scrap
+	0	157	0	# VoR Spiny Alien Treat
+	0	47	0	# VoR Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/enter_hob.txt
+++ b/assets/files/presets/pod/enter_hob.txt
@@ -45,28 +45,8 @@ PoD 	# category
 	0 	-910.700012 2769.199951 	0 	# landing area bag (15)
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 0	# num plugs destroyed
-11 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	2	-1
-	15 	-672.000000 -20.000000 1392.000000 	2	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	0 	13.000000 15.000000 211.000000 	2	-1
-	0 	209.000000 10.000000 -206.000000 	2	-1
-	0 	14.000000 15.000000 -263.000000 	2	-1
-	0 	-258.000000 15.000000 -133.000000 	2	-1
-	27 	-36.439999 15.000000 -104.839996 	2	-1
-10 	# num treasure spawn overrides
-	42 	2 	# Sunseed Berry
-	130 	2 	# Pilgrim Bulb
-	11 	2 	# Geographic Projection
-	155 	2 	# Chance Totem
-	173 	2 	# Healing Cask
-	142 	2 	# Courage Reactor
-	62 	2 	# Pink Menace
-	87 	2 	# Utter Scrap
-	157 	2 	# Spiny Alien Treat
-	47 	2 	# Fossilized Ursidae
+1 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+0 	# num treasure spawn overrides
 0	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/enter_scx.txt
+++ b/assets/files/presets/pod/enter_scx.txt
@@ -75,22 +75,19 @@ PoD 	# category
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 0	# num plugs destroyed
-5 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	1	-1
-	24 	548.54 100.0 546.48 	2	-1	# fiery blowhog
-    24  300.91 100.0 361.60     2	-1	# fiery blowhog
-    95  302.18 100.0 -177.91    2	-1	# cannon beetle larvae
-    55  -271.09 114.0 -1387.32  2	-1	# withering blowhog
-10 	# num treasure spawn overrides
-	42 	1 	# Sunseed Berry
-	130 	1 	# Pilgrim Bulb
-	11 	1 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	142 	1 	# Courage Reactor
-	62 	2 	# Pink Menace
-	87 	2 	# Utter Scrap
-	157 	2 	# Spiny Alien Treat
-	47 	2 	# Fossilized Ursidae
+6 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+6 	# num treasure spawn overrides
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	11	0	# AW Geographic Projection
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	0	142	0	# VoR Courage Reactor
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/enter_scx_25w.txt
+++ b/assets/files/presets/pod/enter_scx_25w.txt
@@ -75,22 +75,19 @@ PoD 	# category
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 0	# num plugs destroyed
-5 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	1	-1
-	24 	548.54 100.0 546.48 	2	-1	# fiery blowhog
-    24  300.91 100.0 361.60     2	-1	# fiery blowhog
-    95  302.18 100.0 -177.91    2	-1	# cannon beetle larvae
-    55  -271.09 114.0 -1387.32  2	-1	# withering blowhog
-10 	# num treasure spawn overrides
-	42 	1 	# Sunseed Berry
-	130 	1 	# Pilgrim Bulb
-	11 	1 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	142 	1 	# Courage Reactor
-	62 	2 	# Pink Menace
-	87 	2 	# Utter Scrap
-	157 	2 	# Spiny Alien Treat
-	47 	2 	# Fossilized Ursidae
+6 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+6 	# num treasure spawn overrides
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	11	0	# AW Geographic Projection
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	0	142	0	# VoR Courage Reactor
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/enter_sh.txt
+++ b/assets/files/presets/pod/enter_sh.txt
@@ -60,28 +60,10 @@ PoD 	# category
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 0	# num plugs destroyed
-11 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	1	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	0 	13.000000 15.000000 211.000000 	2	-1
-	0 	209.000000 10.000000 -206.000000 	2	-1
-	0 	14.000000 15.000000 -263.000000 	2	-1
-	0 	-258.000000 15.000000 -133.000000 	2	-1
-	27 	-36.439999 15.000000 -104.839996 	2	-1
-10 	# num treasure spawn overrides
-	42 	2 	# Sunseed Berry
-	130 	2 	# Pilgrim Bulb
-	11 	2 	# Geographic Projection
-	155 	2 	# Chance Totem
-	173 	2 	# Healing Cask
-	142 	2 	# Courage Reactor
-	62 	2 	# Pink Menace
-	87 	2 	# Utter Scrap
-	157 	2 	# Spiny Alien Treat
-	47 	2 	# Fossilized Ursidae
+3 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/enter_wfg.txt
+++ b/assets/files/presets/pod/enter_wfg.txt
@@ -53,28 +53,10 @@ PoD 	# category
 	0 	-910.700012 2769.199951 	0 	# landing area bag (15)
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 0	# num plugs destroyed
-11 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	1	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	0 	13.000000 15.000000 211.000000 	2	-1
-	0 	209.000000 10.000000 -206.000000 	2	-1
-	0 	14.000000 15.000000 -263.000000 	2	-1
-	0 	-258.000000 15.000000 -133.000000 	2	-1
-	27 	-36.439999 15.000000 -104.839996 	2	-1
-10 	# num treasure spawn overrides
-	42 	2 	# Sunseed Berry
-	130 	2 	# Pilgrim Bulb
-	11 	2 	# Geographic Projection
-	155 	2 	# Chance Totem
-	173 	2 	# Healing Cask
-	142 	2 	# Courage Reactor
-	62 	2 	# Pink Menace
-	87 	2 	# Utter Scrap
-	157 	2 	# Spiny Alien Treat
-	47 	2 	# Fossilized Ursidae
+3 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/fc1-5.txt
+++ b/assets/files/presets/pod/fc1-5.txt
@@ -81,22 +81,23 @@ PoD 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-5 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	1	-1
-	24 	548.54 100.0 546.48 	2	-1	# fiery blowhog
-    24  300.91 100.0 361.60     2	-1	# fiery blowhog
-    95  302.18 100.0 -177.91    2	-1	# cannon beetle larvae
-    55  -271.09 114.0 -1387.32  1	-1	# withering blowhog
-10 	# num treasure spawn overrides
-	42 	1 	# Sunseed Berry
-	130 	1 	# Pilgrim Bulb
-	11 	1 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	142 	1 	# Courage Reactor
-	62 	1 	# Pink Menace
-	87 	1 	# Utter Scrap
-	157 	1 	# Spiny Alien Treat
-	47 	0 	# Fossilized Ursidae
+7 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	55	-271.092255 114.000000 -1387.317261	7	# VoR Withering Blowhog
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+9 	# num treasure spawn overrides
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	11	0	# AW Geographic Projection
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	0	142	0	# VoR Courage Reactor
+	0	62	0	# VoR Pink Menace
+	0	87	0	# VoR Utter Scrap
+	0	157	0	# VoR Spiny Alien Treat
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/fc1-5_40w.txt
+++ b/assets/files/presets/pod/fc1-5_40w.txt
@@ -81,22 +81,24 @@ PoD 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-5 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	1	-1
-	24 	548.54 100.0 546.48 	2	-1	# fiery blowhog
-    24  300.91 100.0 361.60     2	-1	# fiery blowhog
-    95  302.18 100.0 -177.91    2	-1	# cannon beetle larvae
-    55  -271.09 114.0 -1387.32  1	-1	# withering blowhog
+7 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	55	-271.092255 114.000000 -1387.317261	7	# VoR Withering Blowhog
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
 10 	# num treasure spawn overrides
-	42 	1 	# Sunseed Berry
-	130 	1 	# Pilgrim Bulb
-	11 	1 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	142 	1 	# Courage Reactor
-	62 	1 	# Pink Menace
-	87 	1 	# Utter Scrap
-	157 	1 	# Spiny Alien Treat
-	47 	1 	# Fossilized Ursidae
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	11	0	# AW Geographic Projection
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	0	142	0	# VoR Courage Reactor
+	0	62	0	# VoR Pink Menace
+	0	87	0	# VoR Utter Scrap
+	0	157	0	# VoR Spiny Alien Treat
+	0	47	0	# VoR Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/fc6-7.txt
+++ b/assets/files/presets/pod/fc6-7.txt
@@ -83,22 +83,24 @@ PoD 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-5 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	1	-1
-	24 	548.54 100.0 546.48 	2	-1	# fiery blowhog
-    24  300.91 100.0 361.60     2	-1	# fiery blowhog
-    95  302.18 100.0 -177.91    2	-1	# cannon beetle larvae
-    55  -271.09 114.0 -1387.32  1	-1	# withering blowhog
+7 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	55	-271.092255 114.000000 -1387.317261	7	# VoR Withering Blowhog
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
 10 	# num treasure spawn overrides
-	42 	1 	# Sunseed Berry
-	130 	1 	# Pilgrim Bulb
-	11 	1 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	142 	1 	# Courage Reactor
-	62 	1 	# Pink Menace
-	87 	1 	# Utter Scrap
-	157 	1 	# Spiny Alien Treat
-	47 	1 	# Fossilized Ursidae
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	11	0	# AW Geographic Projection
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	0	142	0	# VoR Courage Reactor
+	0	62	0	# VoR Pink Menace
+	0	87	0	# VoR Utter Scrap
+	0	157	0	# VoR Spiny Alien Treat
+	0	47	0	# VoR Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/fc6-7_40w.txt
+++ b/assets/files/presets/pod/fc6-7_40w.txt
@@ -83,22 +83,24 @@ PoD 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-5 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	1	-1
-	24 	548.54 100.0 546.48 	2	-1	# fiery blowhog
-    24  300.91 100.0 361.60     2	-1	# fiery blowhog
-    95  302.18 100.0 -177.91    2	-1	# cannon beetle larvae
-    55  -271.09 114.0 -1387.32  1	-1	# withering blowhog
+7 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	55	-271.092255 114.000000 -1387.317261	7	# VoR Withering Blowhog
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
 10 	# num treasure spawn overrides
-	42 	1 	# Sunseed Berry
-	130 	1 	# Pilgrim Bulb
-	11 	1 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	142 	1 	# Courage Reactor
-	62 	1 	# Pink Menace
-	87 	1 	# Utter Scrap
-	157 	1 	# Spiny Alien Treat
-	47 	1 	# Fossilized Ursidae
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	11	0	# AW Geographic Projection
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	0	142	0	# VoR Courage Reactor
+	0	62	0	# VoR Pink Menace
+	0	87	0	# VoR Utter Scrap
+	0	157	0	# VoR Spiny Alien Treat
+	0	47	0	# VoR Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/gk.txt
+++ b/assets/files/presets/pod/gk.txt
@@ -89,17 +89,25 @@ PoD 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-0 	# num enemy spawns
+8 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	55	-271.092255 114.000000 -1387.317261	7	# VoR Withering Blowhog
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	2	101	950.000000 -57.000000 475.000000	8	# PP Toady Bloyster
 10 	# num treasure spawn overrides
-	42 	1 	# Sunseed Berry
-	130 	1 	# Pilgrim Bulb
-	11 	1 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	142 	1 	# Courage Reactor
-	62 	1 	# Pink Menace
-	87 	1 	# Utter Scrap
-	157 	1 	# Spiny Alien Treat
-	47 	1 	# Fossilized Ursidae
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	11	0	# AW Geographic Projection
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	0	142	0	# VoR Courage Reactor
+	0	62	0	# VoR Pink Menace
+	0	87	0	# VoR Utter Scrap
+	0	157	0	# VoR Spiny Alien Treat
+	0	47	0	# VoR Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/gk_40w.txt
+++ b/assets/files/presets/pod/gk_40w.txt
@@ -89,17 +89,25 @@ PoD 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-0 	# num enemy spawns
+8 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	0	55	-271.092255 114.000000 -1387.317261	7	# VoR Withering Blowhog
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+	2	101	950.000000 -57.000000 475.000000	8	# PP Toady Bloyster
 10 	# num treasure spawn overrides
-	42 	1 	# Sunseed Berry
-	130 	1 	# Pilgrim Bulb
-	11 	1 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	142 	1 	# Courage Reactor
-	62 	1 	# Pink Menace
-	87 	1 	# Utter Scrap
-	157 	1 	# Spiny Alien Treat
-	47 	1 	# Fossilized Ursidae
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	11	0	# AW Geographic Projection
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	0	142	0	# VoR Courage Reactor
+	0	62	0	# VoR Pink Menace
+	0	87	0	# VoR Utter Scrap
+	0	157	0	# VoR Spiny Alien Treat
+	0	47	0	# VoR Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/hob1-2.txt
+++ b/assets/files/presets/pod/hob1-2.txt
@@ -51,28 +51,10 @@ PoD 	# category
 	0 	-910.700012 2769.199951 	0 	# landing area bag (15)
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 0	# num plugs destroyed
-11 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	1	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	0 	13.000000 15.000000 211.000000 	2	-1
-	0 	209.000000 10.000000 -206.000000 	2	-1
-	0 	14.000000 15.000000 -263.000000 	2	-1
-	0 	-258.000000 15.000000 -133.000000 	2	-1
-	27 	-36.439999 15.000000 -104.839996 	2	-1
-10 	# num treasure spawn overrides
-	42 	2 	# Sunseed Berry
-	130 	2 	# Pilgrim Bulb
-	11 	2 	# Geographic Projection
-	155 	2 	# Chance Totem
-	173 	2 	# Healing Cask
-	142 	2 	# Courage Reactor
-	62 	2 	# Pink Menace
-	87 	2 	# Utter Scrap
-	157 	2 	# Spiny Alien Treat
-	47 	2 	# Fossilized Ursidae
+3 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/hob3-4.txt
+++ b/assets/files/presets/pod/hob3-4.txt
@@ -51,28 +51,10 @@ PoD 	# category
 	0 	-910.700012 2769.199951 	0 	# landing area bag (15)
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 0	# num plugs destroyed
-11 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	1	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	0 	13.000000 15.000000 211.000000 	2	-1
-	0 	209.000000 10.000000 -206.000000 	2	-1
-	0 	14.000000 15.000000 -263.000000 	2	-1
-	0 	-258.000000 15.000000 -133.000000 	2	-1
-	27 	-36.439999 15.000000 -104.839996 	2	-1
-10 	# num treasure spawn overrides
-	42 	2 	# Sunseed Berry
-	130 	2 	# Pilgrim Bulb
-	11 	2 	# Geographic Projection
-	155 	2 	# Chance Totem
-	173 	2 	# Healing Cask
-	142 	2 	# Courage Reactor
-	62 	2 	# Pink Menace
-	87 	2 	# Utter Scrap
-	157 	2 	# Spiny Alien Treat
-	47 	2 	# Fossilized Ursidae
+3 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/hob5.txt
+++ b/assets/files/presets/pod/hob5.txt
@@ -51,28 +51,10 @@ PoD 	# category
 	0 	-910.700012 2769.199951 	0 	# landing area bag (15)
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 0	# num plugs destroyed
-11 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	1	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	0 	13.000000 15.000000 211.000000 	2	-1
-	0 	209.000000 10.000000 -206.000000 	2	-1
-	0 	14.000000 15.000000 -263.000000 	2	-1
-	0 	-258.000000 15.000000 -133.000000 	2	-1
-	27 	-36.439999 15.000000 -104.839996 	2	-1
-10 	# num treasure spawn overrides
-	42 	2 	# Sunseed Berry
-	130 	2 	# Pilgrim Bulb
-	11 	2 	# Geographic Projection
-	155 	2 	# Chance Totem
-	173 	2 	# Healing Cask
-	142 	2 	# Courage Reactor
-	62 	2 	# Pink Menace
-	87 	2 	# Utter Scrap
-	157 	2 	# Spiny Alien Treat
-	47 	2 	# Fossilized Ursidae
+3 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/scx1-4.txt
+++ b/assets/files/presets/pod/scx1-4.txt
@@ -79,22 +79,22 @@ PoD 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-5 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	1	-1
-	24 	548.54 100.0 546.48 	2	-1	# fiery blowhog
-    24  300.91 100.0 361.60     2	-1	# fiery blowhog
-    95  302.18 100.0 -177.91    2	-1	# cannon beetle larvae
-    55  -271.09 114.0 -1387.32  2	-1	# withering blowhog
-10 	# num treasure spawn overrides
-	42 	1 	# Sunseed Berry
-	130 	1 	# Pilgrim Bulb
-	11 	1 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	142 	1 	# Courage Reactor
-	62 	1 	# Pink Menace
-	87 	1 	# Utter Scrap
-	157 	1 	# Spiny Alien Treat
-	47 	0 	# Fossilized Ursidae
+6 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+9 	# num treasure spawn overrides
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	11	0	# AW Geographic Projection
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	0	142	0	# VoR Courage Reactor
+	0	62	0	# VoR Pink Menace
+	0	87	0	# VoR Utter Scrap
+	0	157	0	# VoR Spiny Alien Treat
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/scx1-4_25w.txt
+++ b/assets/files/presets/pod/scx1-4_25w.txt
@@ -79,22 +79,22 @@ PoD 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-5 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	1	-1
-	24 	548.54 100.0 546.48 	2	-1	# fiery blowhog
-    24  300.91 100.0 361.60     2	-1	# fiery blowhog
-    95  302.18 100.0 -177.91    2	-1	# cannon beetle larvae
-    55  -271.09 114.0 -1387.32  2	-1	# withering blowhog
-10 	# num treasure spawn overrides
-	42 	1 	# Sunseed Berry
-	130 	1 	# Pilgrim Bulb
-	11 	1 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	142 	1 	# Courage Reactor
-	62 	1 	# Pink Menace
-	87 	1 	# Utter Scrap
-	157 	1 	# Spiny Alien Treat
-	47 	0 	# Fossilized Ursidae
+6 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+9 	# num treasure spawn overrides
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	11	0	# AW Geographic Projection
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	0	142	0	# VoR Courage Reactor
+	0	62	0	# VoR Pink Menace
+	0	87	0	# VoR Utter Scrap
+	0	157	0	# VoR Spiny Alien Treat
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/scx5-8.txt
+++ b/assets/files/presets/pod/scx5-8.txt
@@ -79,22 +79,22 @@ PoD 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-5 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	1	-1
-	24 	548.54 100.0 546.48 	2	-1	# fiery blowhog
-    24  300.91 100.0 361.60     2	-1	# fiery blowhog
-    95  302.18 100.0 -177.91    2	-1	# cannon beetle larvae
-    55  -271.09 114.0 -1387.32  2	-1	# withering blowhog
-10 	# num treasure spawn overrides
-	42 	1 	# Sunseed Berry
-	130 	1 	# Pilgrim Bulb
-	11 	1 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	142 	1 	# Courage Reactor
-	62 	1 	# Pink Menace
-	87 	1 	# Utter Scrap
-	157 	1 	# Spiny Alien Treat
-	47 	0 	# Fossilized Ursidae
+6 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+9 	# num treasure spawn overrides
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	11	0	# AW Geographic Projection
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	0	142	0	# VoR Courage Reactor
+	0	62	0	# VoR Pink Menace
+	0	87	0	# VoR Utter Scrap
+	0	157	0	# VoR Spiny Alien Treat
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/scx5-8_40w.txt
+++ b/assets/files/presets/pod/scx5-8_40w.txt
@@ -79,22 +79,22 @@ PoD 	# category
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 1	# num plugs destroyed
 	0	800.0	1380.0				0	# bridge plug
-5 	# num enemy spawns
-	1 	-1153.000000 47.000000 2231.000000 	1	-1
-	24 	548.54 100.0 546.48 	2	-1	# fiery blowhog
-    24  300.91 100.0 361.60     2	-1	# fiery blowhog
-    95  302.18 100.0 -177.91    2	-1	# cannon beetle larvae
-    55  -271.09 114.0 -1387.32  2	-1	# withering blowhog
-10 	# num treasure spawn overrides
-	42 	1 	# Sunseed Berry
-	130 	1 	# Pilgrim Bulb
-	11 	1 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	1 	# Healing Cask
-	142 	1 	# Courage Reactor
-	62 	1 	# Pink Menace
-	87 	1 	# Utter Scrap
-	157 	1 	# Spiny Alien Treat
-	47 	0 	# Fossilized Ursidae
+6 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	6	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+	1	1	-179.685318 -70.000000 2909.942139	5	# AW Dwarf Red Bulborb x2
+	1	2	-486.161591 -70.000000 3058.214355	5	# AW Red Bulborb
+	1	10	-738.448914 -28.741590 2354.096924	5	# AW Iridescent Glint Beetle (flowerpot)
+9 	# num treasure spawn overrides
+	1	42	0	# AW Sunseed Berry
+	1	130	0	# AW Pilgrim Bulb
+	1	11	0	# AW Geographic Projection
+	1	155	0	# AW Chance Totem
+	1	173	0	# AW Healing Cask
+	0	142	0	# VoR Courage Reactor
+	0	62	0	# VoR Pink Menace
+	0	87	0	# VoR Utter Scrap
+	0	157	0	# VoR Spiny Alien Treat
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/sh1-2.txt
+++ b/assets/files/presets/pod/sh1-2.txt
@@ -65,28 +65,11 @@ PoD 	# category
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 0	# num plugs destroyed
-11 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	1	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	0 	13.000000 15.000000 211.000000 	2	-1
-	0 	209.000000 10.000000 -206.000000 	2	-1
-	0 	14.000000 15.000000 -263.000000 	2	-1
-	0 	-258.000000 15.000000 -133.000000 	2	-1
-	27 	-36.439999 15.000000 -104.839996 	2	-1
-10 	# num treasure spawn overrides
-	42 	2 	# Sunseed Berry
-	130 	2 	# Pilgrim Bulb
-	11 	2 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	142 	2 	# Courage Reactor
-	62 	2 	# Pink Menace
-	87 	2 	# Utter Scrap
-	157 	2 	# Spiny Alien Treat
-	47 	2 	# Fossilized Ursidae
+3 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+1 	# num treasure spawn overrides
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/sh3-7.txt
+++ b/assets/files/presets/pod/sh3-7.txt
@@ -65,28 +65,11 @@ PoD 	# category
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 0	# num plugs destroyed
-11 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	1	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	0 	13.000000 15.000000 211.000000 	2	-1
-	0 	209.000000 10.000000 -206.000000 	2	-1
-	0 	14.000000 15.000000 -263.000000 	2	-1
-	0 	-258.000000 15.000000 -133.000000 	2	-1
-	27 	-36.439999 15.000000 -104.839996 	2	-1
-10 	# num treasure spawn overrides
-	42 	2 	# Sunseed Berry
-	130 	2 	# Pilgrim Bulb
-	11 	2 	# Geographic Projection
-	155 	1 	# Chance Totem
-	173 	2 	# Healing Cask
-	142 	2 	# Courage Reactor
-	62 	2 	# Pink Menace
-	87 	2 	# Utter Scrap
-	157 	2 	# Spiny Alien Treat
-	47 	2 	# Fossilized Ursidae
+3 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+1 	# num treasure spawn overrides
+	1	155	0	# AW Chance Totem
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/wfg1-3.txt
+++ b/assets/files/presets/pod/wfg1-3.txt
@@ -55,28 +55,10 @@ PoD 	# category
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 0	# num plugs destroyed
-11 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	1	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	0 	13.000000 15.000000 211.000000 	2	-1
-	0 	209.000000 10.000000 -206.000000 	2	-1
-	0 	14.000000 15.000000 -263.000000 	2	-1
-	0 	-258.000000 15.000000 -133.000000 	2	-1
-	27 	-36.439999 15.000000 -104.839996 	2	-1
-10 	# num treasure spawn overrides
-	42 	2 	# Sunseed Berry
-	130 	2 	# Pilgrim Bulb
-	11 	2 	# Geographic Projection
-	155 	2 	# Chance Totem
-	173 	2 	# Healing Cask
-	142 	2 	# Courage Reactor
-	62 	2 	# Pink Menace
-	87 	2 	# Utter Scrap
-	157 	2 	# Spiny Alien Treat
-	47 	2 	# Fossilized Ursidae
+3 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/assets/files/presets/pod/wfg4-5.txt
+++ b/assets/files/presets/pod/wfg4-5.txt
@@ -58,28 +58,10 @@ PoD 	# category
 	0 	-1150.000000 2455.000000 	0 	# hubcap bag (35)
 	1 	-395.000000 1115.000000 	0 	# WFG bag (200)
 0	# num plugs destroyed
-11 	# num enemy spawns
-	1 	-179.690002 -70.000000 2909.939941 	2	-1
-	2 	-486.160004 -70.000000 3058.209961 	2	-1
-	16 	-544.000000 -38.000000 1804.000000 	1	-1
-	15 	-672.000000 -20.000000 1392.000000 	1	-1
-	10 	-738.000000 -28.000000 2354.000000 	2	-1
-	9 	518.000000 -75.000000 3719.000000 	2	-1
-	0 	13.000000 15.000000 211.000000 	2	-1
-	0 	209.000000 10.000000 -206.000000 	2	-1
-	0 	14.000000 15.000000 -263.000000 	2	-1
-	0 	-258.000000 15.000000 -133.000000 	2	-1
-	27 	-36.439999 15.000000 -104.839996 	2	-1
-10 	# num treasure spawn overrides
-	42 	2 	# Sunseed Berry
-	130 	2 	# Pilgrim Bulb
-	11 	2 	# Geographic Projection
-	155 	2 	# Chance Totem
-	173 	2 	# Healing Cask
-	142 	2 	# Courage Reactor
-	62 	2 	# Pink Menace
-	87 	2 	# Utter Scrap
-	157 	2 	# Spiny Alien Treat
-	47 	2 	# Fossilized Ursidae
+3 	# num enemy spawns
+	0	1	-1153.361206 47.871529 2231.686035	4	# VoR Dwarf Red Bulborb (hubcap)
+	1	15	-672.000000 -20.000000 1392.000000	5	# AW Cloaking Burrow-nit
+	1	16	-544.000000 -38.000000 1804.000000	5	# AW Honeywisp
+0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)

--- a/include/p2gz/Preset.h
+++ b/include/p2gz/Preset.h
@@ -21,8 +21,6 @@ enum PresetOrigin { PO_File, PO_Memcard, PO_Generated };
 
 enum EnterAreaKind { PEK_FromCave = 0, PEK_FromMap = 1 };
 
-enum GenSpawnOverride { PSO_Ignore = 0, PSO_DontSpawn = 1, PSO_Spawn = 2, PSO_SpawnAndMove = 3 };
-
 struct TreasureAreaMap {
 	u8 id;
 	u8 course_idx;
@@ -61,35 +59,39 @@ struct Preset {
 		bool plug_destroyed;
 	};
 
-	struct EnemyGenSpawnOverride {
-		EnemyGenSpawnOverride()
+	// enemy (above ground) to be tracked as killed
+	struct KilledEnemy {
+		KilledEnemy()
 		{
-			spawn_override = PSO_Ignore;
-			kill_day       = -1;
+			course   = 0xFF; // invalid unless set
+			kill_day = -1;   // default = use day from preset
 		}
 
 		void read(Stream& input);
 		void write(Stream& output);
 
+		u8 course;
 		Game::EnemyTypeID::EEnemyTypeID enemy_id;
 		Vector3f gen_pos;
-		GenSpawnOverride spawn_override;
-		int kill_day; // day enemy should've been killed, to set respawn day correctly (-1 = killed on day we're warping to)
+		int kill_day; // day enemy (should've been) killed, to set respawn day correctly (-1 = killed on day we're warping to)
 	};
 
-	struct TreasureGenSpawnOverride {
-		TreasureGenSpawnOverride()
+	// treasure removed from its fresh state, either collected or carried part-way
+	struct CarriedTreasure {
+		CarriedTreasure()
 		{
-			id             = 255;
-			spawn_override = PSO_Ignore;
+			course = 0xFF; // invalid unless set
+			id     = 255;  // invalid unless set
+			moved  = false;
 		}
 
 		void read(Stream& input);
 		void write(Stream& output);
 
+		u8 course;
 		u8 id;
-		GenSpawnOverride spawn_override;
-		Vector3f position_override; // only used if spawn_override is PSO_SpawnAndMove
+		bool moved;                 // true = spawn at position_override (moved part-way)
+		Vector3f position_override; // only used if moved
 	};
 
 	struct Sprout {
@@ -143,8 +145,8 @@ public:
 	void apply();
 	void apply_post_load();
 
-	EnemyGenSpawnOverride get_enemy_gen_override(Game::Generator* gen);
-	TreasureGenSpawnOverride get_treasure_gen_override(int treasure_id, u8 pellet_type = 0);
+	KilledEnemy get_killed_enemy(int course, Game::Generator* gen);
+	CarriedTreasure get_treasure_override(int course, int treasure_id, u8 pellet_type = 0);
 
 	PresetPreview* preview;
 	PresetCategory category;
@@ -170,8 +172,8 @@ public:
 	int pokos;
 	bool apply_pokos;
 	u8 day;
-	Vec<EnemyGenSpawnOverride> enemy_spawn_overrides;
-	Vec<TreasureGenSpawnOverride> treasure_spawn_overrides;
+	Vec<KilledEnemy> killed_enemies;
+	Vec<CarriedTreasure> carried_treasures;
 	bool bridge_glitch_active;
 	BitFlag<u16> new_area_zoom;        // bit per course: VoR=1 AW=2 PP=4 WW=8; set = allow zoom on next world-map visit
 	AreaStructureState area_states[4]; // per-area structure state, indexed by CourseIndex (0=VoR…3=WW)

--- a/src/p2gz/preset.cpp
+++ b/src/p2gz/preset.cpp
@@ -129,39 +129,55 @@ bool Preset::AreaStructureState::is_bag_flattened(const char* name) const
 	return false;
 }
 
-Preset::EnemyGenSpawnOverride Preset::get_enemy_gen_override(Game::Generator* gen)
+Preset::KilledEnemy Preset::get_killed_enemy(int course, Game::Generator* gen)
 {
 	if (gen->mObject->mTypeID == 'teki') {
 		Game::GenObjectEnemy* gen_obj_enemy = static_cast<Game::GenObjectEnemy*>(gen->mObject);
-		for (u32 i = 0; i < enemy_spawn_overrides.len(); i++) {
-			EnemyGenSpawnOverride& oride = enemy_spawn_overrides[i];
-			if (oride.enemy_id == gen_obj_enemy->mEnemyID && absF(oride.gen_pos.sqrDistance(gen->mPosition)) < 25.0f) {
-				return oride;
+		for (u32 i = 0; i < killed_enemies.len(); i++) {
+			KilledEnemy& kill = killed_enemies[i];
+			if (kill.course != course) {
+				continue; // belongs to a different area
+			}
+			if (kill.enemy_id == gen_obj_enemy->mEnemyID && kill.gen_pos.sqrDistance(gen->mPosition) < 25.0f) {
+				return kill;
 			}
 		}
 	}
-	return EnemyGenSpawnOverride();
+	return KilledEnemy(); // course == 0xFF => not killed
 }
 
-Preset::TreasureGenSpawnOverride Preset::get_treasure_gen_override(int treasure_id, u8 pellet_type)
+Preset::CarriedTreasure Preset::get_treasure_override(int course, int treasure_id, u8 pellet_type)
 {
-	for (u32 i = 0; i < treasure_spawn_overrides.len(); i++) {
-		TreasureGenSpawnOverride& oride = treasure_spawn_overrides[i];
-		if (treasure_id == oride.id) {
-			return oride;
+	for (u32 i = 0; i < carried_treasures.len(); i++) {
+		CarriedTreasure& treasure = carried_treasures[i];
+		if (treasure.course != course) {
+			continue; // belongs to a different area
+		}
+		if (treasure_id == treasure.id) {
+			return treasure;
 		}
 	}
-	return TreasureGenSpawnOverride();
+	return CarriedTreasure(); // course == 0xFF => spawns as normal
 }
 
 bool Preset::is_area_visited(int course) const
 {
+	// only rebuild this area if it actually has gen edits tagged for it
+	// (structures, enemies, treasures)
 	if (area_states[course].has_any_state()) {
 		return true;
 	}
-	// conservative: rebuild all areas when any gen overrides exist,
-	// since overrides don't carry per-area indexing
-	return enemy_spawn_overrides.len() > 0 || treasure_spawn_overrides.len() > 0;
+	for (u32 i = 0; i < killed_enemies.len(); i++) {
+		if (killed_enemies[i].course == course) {
+			return true;
+		}
+	}
+	for (u32 i = 0; i < carried_treasures.len(); i++) {
+		if (carried_treasures[i].course == course) {
+			return true;
+		}
+	}
+	return false;
 }
 
 Game::ItemPikihead::Item* birth_sprout(u8 kind, u8 stage)
@@ -276,13 +292,13 @@ void Preset::apply()
 	u8 treasure_counts[4];
 	treasure_counts[COURSE_VoR] = treasure_counts[COURSE_AW] = treasure_counts[COURSE_PP] = treasure_counts[COURSE_WW] = 0;
 
-	for (u32 i = 0; i < treasure_spawn_overrides.len(); i++) {
-		// only interested in treasures we've "collected"
-		if (treasure_spawn_overrides[i].spawn_override != PSO_DontSpawn) {
+	for (u32 i = 0; i < carried_treasures.len(); i++) {
+		// moved treasures = not collected
+		if (carried_treasures[i].moved) {
 			continue;
 		}
 
-		u32 id = treasure_spawn_overrides[i].id;
+		u32 id = carried_treasures[i].id;
 		for (u8 i = 0; i < AG_treasure_count; i++) {
 			if (AG_treasure_IDs[i].id == id) {
 				treasure_counts[AG_treasure_IDs[i].course_idx]++;

--- a/src/p2gz/presetSerde.cpp
+++ b/src/p2gz/presetSerde.cpp
@@ -106,6 +106,8 @@ static const char* CAVE_NAMES[] = {
 	"Above ground", "EC", "SCx", "FC", "HoB", "WFG", "BK", "SH", "CoS", "GK", "SR", "SmC", "CoC", "HoH", "DD",
 };
 
+static const char* COURSE_NAMES[] = { "VoR", "AW", "PP", "WW" }; // indexed by CourseIndex
+
 struct TreasureNameMap {
 	const int treasure_id;
 	const char* name;
@@ -275,8 +277,8 @@ void Preset::read(Stream& input)
 	READ_LIST_T(input, StructureOverride, bags_flattened);
 	READ_LIST_T(input, StructureOverride, plugs_destroyed);
 
-	READ_LIST_T(input, EnemyGenSpawnOverride, enemy_spawn_overrides);
-	READ_LIST_T(input, TreasureGenSpawnOverride, treasure_spawn_overrides);
+	READ_LIST_T(input, KilledEnemy, killed_enemies);
+	READ_LIST_T(input, CarriedTreasure, carried_treasures);
 
 	bridge_glitch_active = input.readInt() > 0;
 
@@ -431,25 +433,26 @@ void Preset::write(Stream& output)
 		}
 	}
 
-	write_vec(enemy_spawn_overrides, output, "num enemy spawns");
+	write_vec(killed_enemies, output, "num enemy spawns");
 
-	output.writeInt(treasure_spawn_overrides.len());
+	output.writeInt(carried_treasures.len());
 	output.textWriteText("\t# num treasure spawn overrides\n");
-	FOREACH_VEC(treasure_spawn_overrides)
+	FOREACH_VEC(carried_treasures)
 	{
 		output.textWriteTab(1);
-		treasure_spawn_overrides[i].write(output);
+		carried_treasures[i].write(output);
 
 		if (output.mMode == STREAM_MODE_TEXT) {
 			const char* treasure_name = nullptr;
 			for (u32 j = 0; j < ARRAY_SIZE(AG_TREASURE_NAMES); j++) {
-				if (AG_TREASURE_NAMES[j].treasure_id == treasure_spawn_overrides[i].id) {
+				if (AG_TREASURE_NAMES[j].treasure_id == carried_treasures[i].id) {
 					treasure_name = AG_TREASURE_NAMES[j].name;
 					break;
 				}
 			}
+			const u8 course = carried_treasures[i].course;
 			if (treasure_name) {
-				output.textWriteText("\t# %s", treasure_name);
+				output.textWriteText("\t# %s %s", course < 4 ? COURSE_NAMES[course] : "?", treasure_name);
 			}
 			output.textWriteText("\n");
 		}
@@ -558,23 +561,26 @@ void Preset::Sprout::write(Stream& output)
 	}
 }
 
-void Preset::TreasureGenSpawnOverride::read(Stream& input)
+void Preset::CarriedTreasure::read(Stream& input)
 {
-	id             = input.readInt();
-	spawn_override = static_cast<GenSpawnOverride>(input.readInt());
-	if (spawn_override == PSO_SpawnAndMove) {
+	course = input.readInt();
+	id     = input.readInt();
+	moved  = input.readInt() > 0;
+	if (moved) {
 		position_override.x = input.readFloat();
 		position_override.y = input.readFloat();
 		position_override.z = input.readFloat();
 	}
 }
 
-void Preset::TreasureGenSpawnOverride::write(Stream& output)
+void Preset::CarriedTreasure::write(Stream& output)
 {
+	output.writeInt(course);
+	output.textWriteTab(1);
 	output.writeInt(id);
 	output.textWriteTab(1);
-	output.writeInt(spawn_override);
-	if (spawn_override == PSO_SpawnAndMove) {
+	output.writeInt(moved ? 1 : 0);
+	if (moved) {
 		output.textWriteTab(1);
 		output.writeFloat(position_override.x);
 		output.writeFloat(position_override.y);
@@ -582,25 +588,25 @@ void Preset::TreasureGenSpawnOverride::write(Stream& output)
 	}
 }
 
-void Preset::EnemyGenSpawnOverride::read(Stream& input)
+void Preset::KilledEnemy::read(Stream& input)
 {
-	enemy_id       = static_cast<Game::EnemyTypeID::EEnemyTypeID>(input.readInt());
-	gen_pos.x      = input.readFloat();
-	gen_pos.y      = input.readFloat();
-	gen_pos.z      = input.readFloat();
-	spawn_override = static_cast<GenSpawnOverride>(input.readInt());
-	kill_day       = input.readInt();
+	course    = input.readInt();
+	enemy_id  = static_cast<Game::EnemyTypeID::EEnemyTypeID>(input.readInt());
+	gen_pos.x = input.readFloat();
+	gen_pos.y = input.readFloat();
+	gen_pos.z = input.readFloat();
+	kill_day  = input.readInt();
 }
 
-void Preset::EnemyGenSpawnOverride::write(Stream& output)
+void Preset::KilledEnemy::write(Stream& output)
 {
+	output.writeInt(course);
+	output.textWriteTab(1);
 	output.writeInt(enemy_id);
 	output.textWriteTab(1);
 	output.writeFloat(gen_pos.x);
 	output.writeFloat(gen_pos.y);
 	output.writeFloat(gen_pos.z);
-	output.textWriteTab(1);
-	output.writeInt(spawn_override);
 	output.textWriteTab(1);
 	output.writeInt(kill_day);
 }

--- a/src/p2gz/warp.cpp
+++ b/src/p2gz/warp.cpp
@@ -389,8 +389,9 @@ void Warp::warp_to_cave(Game::SingleGameSection* game)
 	Game::playData->mCaveSaveData.mCourseIdx     = dst_course_info->mCourseIndex;
 	Game::playData->mCaveSaveData.mCurrentCaveID = caveID;
 
-	// Save changes to world state if we're above-ground currently
-	if (in_above_ground_play() && !already_saved_generators) {
+	// save changes to world state if we're above-ground AND are not warping to a preset
+	// (preset will set the above-ground state itself)
+	if (in_above_ground_play() && !already_saved_generators && !has_next_preset()) {
 		game->saveToGeneratorCache(game->mCurrentCourseInfo);
 	}
 
@@ -446,8 +447,9 @@ void Warp::warp_to_area(Game::SingleGameSection* game)
 		}
 	}
 
-	// Save changes to world state if we're above-ground currently
-	if (in_above_ground_play() && !already_saved_generators) {
+	// save changes to world state if we're above-ground AND are not warping to a preset
+	// (preset will set the above-ground state itself)
+	if (in_above_ground_play() && !already_saved_generators && !has_next_preset()) {
 		game->saveToGeneratorCache(game->mCurrentCourseInfo);
 	}
 
@@ -537,9 +539,9 @@ void Warp::do_post_warp()
 		preset_during_warp->del();
 	}
 
-	// Clear both pointers so a stale next_preset can't dangle or report a phantom pending preset
-	next_preset   = nullptr;
-	next_preset_p = nullptr;
+	// null-out next_preset to avoid dangling
+	// NB: we DON'T want to null-out next_preset_p though, otherwise warp menu will fall out of sync
+	next_preset = nullptr;
 
 	if (use_set_seed) {
 		set_random_seed();

--- a/src/plugProjectKandoU/baseGameSection.cpp
+++ b/src/plugProjectKandoU/baseGameSection.cpp
@@ -3516,20 +3516,18 @@ void BaseGameSection::reconstruct_generator_cache()
 			}
 		}
 
-		// apply enemy spawn overrides: record death state in lieu of live kills/spawns
+		// apply killed enemies: record death (unaltered = alive)
 		FOREACH_NODE(Generator, generatorCache->getFirstGenerator(), gen)
 		{
 			if (!gen->mObject || gen->mObject->mTypeID != 'teki') {
 				continue;
 			}
-			gz::Preset::EnemyGenSpawnOverride oride = preset->get_enemy_gen_override(gen);
-			if (oride.spawn_override == gz::PSO_DontSpawn) {
+			gz::Preset::KilledEnemy kill = preset->get_killed_enemy(course, gen); // @P2GZ - per-area lookup
+			if (kill.course != 0xFF) {
 				gen->mDeathCount = static_cast<GenObjectEnemy*>(gen->mObject)->mTekiNum;
-				// killed on the authored day (clamped to a valid past day); -1/out-of-range -> warp day
-				gen->mDayNum = (oride.kill_day >= 0 && oride.kill_day <= today) ? oride.kill_day : today;
-			} else if (oride.spawn_override >= gz::PSO_Spawn) {
-				gen->mDeathCount = 0;
-				gen->mDayNum     = today;
+				// killed on day according to preset, clamped to a valid past day
+				// -1 or out of range = use day of preset we're warping with
+				gen->mDayNum = (kill.kill_day >= 0 && kill.kill_day <= today) ? kill.kill_day : today;
 			}
 		}
 
@@ -3549,11 +3547,12 @@ void BaseGameSection::reconstruct_generator_cache()
 			    || !node->isReservedFlag(Generator::Reserved_doSaveCreature)) {
 				continue;
 			}
-			// no record for collected pellets: absent record = absent on visit
 			if (node->mObject->mTypeID == 'pelt') {
-				Game::GenPellet* genPellet                 = static_cast<Game::GenPellet*>(node->mObject);
-				gz::Preset::TreasureGenSpawnOverride oride = preset->get_treasure_gen_override(genPellet->mGenParm->mIndex);
-				if (oride.spawn_override == gz::PSO_DontSpawn) {
+				// no record for collected pellets, but need one for ones we've moved
+				Game::GenPellet* genPellet = static_cast<Game::GenPellet*>(node->mObject);
+				gz::Preset::CarriedTreasure treasure
+				    = preset->get_treasure_override(course, genPellet->mGenParm->mIndex); // @P2GZ - per-area lookup
+				if (treasure.course != 0xFF && !treasure.moved) {
 					continue;
 				}
 			} else if (node->mObject->mTypeID == 'item') {

--- a/src/plugProjectKandoU/gameGenerator.cpp
+++ b/src/plugProjectKandoU/gameGenerator.cpp
@@ -9,6 +9,7 @@
 #include "nans.h"
 #include "Parameters.h"
 #include <p2gz/p2gz.h>
+#include <p2gz/Utility.h>
 
 u32 GeneratorCurrentVersion = 'v0.3';
 
@@ -290,16 +291,19 @@ void Generator::saveCreature(Stream& output)
 		const int kind              = gen_pellet->mPelType;
 		const bool buried = Game::PelletList::Mgr::mInstance->getConfig(kind)->getPelletConfig(treasure_id)->mParams.mDepth.mData > 0.0f;
 
-		if (preset) {
-			gz::Preset::TreasureGenSpawnOverride oride = preset->get_treasure_gen_override(treasure_id, kind);
-			if (oride.spawn_override == gz::PSO_SpawnAndMove) {
-				oride.position_override.write(output);
-				output.writeByte(static_cast<u8>(0)); // never buried when moved, though this is unrealistic
+		// treasure overrides are per-area
+		Game::SingleGameSection* sgs = gz::get_SGS();
+		if (preset && sgs && sgs->mCurrentCourseInfo) {
+			const int course                     = sgs->mCurrentCourseInfo->mCourseIndex;
+			gz::Preset::CarriedTreasure treasure = preset->get_treasure_override(course, treasure_id, kind);
+			if (treasure.course != 0xFF && treasure.moved) {
+				treasure.position_override.write(output);
+				output.writeByte(static_cast<u8>(0));
 				return;
 			}
 		}
 
-		// PSO_Spawn pellets and all other pellets still need to be saved to be respawned
+		// uncollected treasures still need to be saved at their original position
 		mPosition.write(output);                           // save at original position of the generator
 		output.writeByte(static_cast<u8>(buried ? 1 : 0)); // mIsCaptured
 		return;


### PR DESCRIPTION
Updates all enemy and treasure presets to work better with the new generator cache system. Since the generator cache is restored fresh before presets are applied, enemies and treasures only need to be specified if they should not appear/should have been killed (or should be moved from their starting positions in the case of treasures). This updates all PoD and AT presets to keep only these enemies and treasures.

Additionally, all enemies and treasures in presets now require the area they spawn in to be specified, so only the required caches are touched, rather than all four.

Also, fixed the bug with the warp menu where, after warping, the displayed preset wouldn't match what would be applied if you just hit warp - fixes #265 .