### PR TITLE
Game no longer crashes on soft reset

### DIFF
--- a/config/GPVE01/splits.txt
+++ b/config/GPVE01/splits.txt
@@ -4,7 +4,7 @@ Sections:
 	extabindex  type:rodata align:32
 	.text       type:code align:8
 	.ctors      type:rodata align:32
-	.dtors      type:rodata align:4
+	.dtors      type:rodata align:32
 	.rodata     type:rodata align:32
 	.data       type:data align:16
 	.bss        type:bss align:32

--- a/include/p2gz/DismissPositions.h
+++ b/include/p2gz/DismissPositions.h
@@ -8,7 +8,12 @@
 namespace gz {
 struct DismissPositions {
 public:
-	DismissPositions() { }
+	DismissPositions()
+	    : enabled(false)
+	    , draw_circles(false)
+	    , draw_lines(false)
+	{
+	}
 	~DismissPositions() { }
 
 	void toggle(bool enabled_) { enabled = enabled_; }

--- a/include/p2gz/Trainers.h
+++ b/include/p2gz/Trainers.h
@@ -10,7 +10,9 @@ public:
 	{
 		enabled            = false;
 		polling            = false;
+		last_flick_count   = 0;
 		first_damage_frame = -1;
+		fade_out_frames    = 0;
 	}
 	~EmpressTrainer() { }
 

--- a/include/p2gz/TreasureEditor.h
+++ b/include/p2gz/TreasureEditor.h
@@ -8,7 +8,12 @@ namespace gz {
 
 struct TreasureEditor {
 public:
-	TreasureEditor() { }
+	TreasureEditor()
+	    : treasures(nullptr)
+	    , active_treasure(nullptr)
+	    , enabled(false)
+	{
+	}
 	~TreasureEditor() { }
 
 	void init();

--- a/include/p2gz/gzmenu.h
+++ b/include/p2gz/gzmenu.h
@@ -251,7 +251,12 @@ private:
 /// Base class for different types of menus
 struct MenuLayer {
 public:
-	MenuLayer(IDelegate* on_opened_ = nullptr) { on_opened = on_opened_; }
+	MenuLayer(IDelegate* on_opened_ = nullptr)
+	    : title(nullptr)
+	    , parent(nullptr)
+	    , on_opened(on_opened_)
+	{
+	}
 	virtual ~MenuLayer();
 
 	virtual void update()                            = 0;

--- a/src/Dolphin/os/__ppc_eabi_init.cpp
+++ b/src/Dolphin/os/__ppc_eabi_init.cpp
@@ -11,6 +11,11 @@ DECL_SECT(".dtors") extern voidfunctionptr _dtors[];
 
 static void __init_cpp();
 
+// @P2GZ: soft-reset crash fix
+// see __init_cpp
+extern void __destroy_global_chain(void);
+extern void __fini_cpp_exceptions(void);
+
 DECL_SECT(".init")
 ASM void __init_hardware() {
 #ifdef __MWERKS__ // clang-format off
@@ -68,6 +73,15 @@ static void __init_cpp()
 	 *	call static initializers
 	 */
 	for (constructor = _ctors; *constructor; constructor++) {
+		// @P2GZ: soft-reset crash fix
+		// if a soft reset reloads with the .ctors/.dtors boundary corrupted, the end of the ctor list
+		// reads back as pointers to program teardown functions lmao. this makes real sure we don't do that again
+		// NB: the real fix for the soft reset crashes was aligning the .dtors section to 32-bytes in splits.txt
+		// this is just being extra careful
+		if (*constructor == (voidfunctionptr)__destroy_global_chain || *constructor == (voidfunctionptr)__fini_cpp_exceptions) {
+			OSReport("[__init_cpp] .ctors corrupted (teardown ptr %08x) - stopping ctor walk\n", (u32)*constructor);
+			break;
+		}
 		(*constructor)();
 	}
 }

--- a/src/plugProjectKandoU/baseGameSection.cpp
+++ b/src/plugProjectKandoU/baseGameSection.cpp
@@ -3560,12 +3560,11 @@ void BaseGameSection::reconstruct_generator_cache()
 				// apply structure state: absent record = absent on load
 				GenItem* genItem = static_cast<GenItem*>(node->mObject);
 				u32 structId     = genItem->mItemMgr ? genItem->mItemMgr->generatorGetID() : 0;
-				const f32 gx     = node->mPosition.x;
+				const f32 gx_    = node->mPosition.x;
 				const f32 gz_    = node->mPosition.z;
-				bool dummy_gen   = false;
 
 				if (structId == 'gate' || structId == 'dgat') {
-					const char* name = p2gz->structure_editor->get_gate_name(gx, gz_, dummy_gen);
+					const char* name = p2gz->structure_editor->find_gate_name(Vector2f(gx_, gz_), course);
 					if (name && astate.is_gate_destroyed(name)) {
 						Game::GeneratorCache::CreatureRecordState state;
 						state.gate_destroyed = true;
@@ -3573,7 +3572,7 @@ void BaseGameSection::reconstruct_generator_cache()
 						continue;
 					}
 				} else if (structId == 'brdg') {
-					const char* name = p2gz->structure_editor->get_bridge_name(gx, gz_);
+					const char* name = p2gz->structure_editor->find_bridge_name(Vector2f(gx_, gz_), course);
 					if (name && astate.is_bridge_finished(name)) {
 						Game::GeneratorCache::CreatureRecordState state;
 						state.bridge_finished = true;
@@ -3581,7 +3580,7 @@ void BaseGameSection::reconstruct_generator_cache()
 						continue;
 					}
 				} else if (structId == 'dwfl') {
-					const char* name = p2gz->structure_editor->get_bag_name(gx, gz_);
+					const char* name = p2gz->structure_editor->find_bag_name(Vector2f(gx_, gz_), course);
 					if (name && astate.is_bag_flattened(name)) {
 						Game::GeneratorCache::CreatureRecordState state;
 						state.bag_pressed = true;
@@ -3589,7 +3588,7 @@ void BaseGameSection::reconstruct_generator_cache()
 						continue;
 					}
 				} else if (structId == 'barl') {
-					const char* name = p2gz->structure_editor->find_plug_name(Vector2f(gx, gz_), course);
+					const char* name = p2gz->structure_editor->find_plug_name(Vector2f(gx_, gz_), course);
 					if (name && astate.plug_destroyed) {
 						Game::GeneratorCache::CreatureRecordState state;
 						state.plug_alive = false;


### PR DESCRIPTION
Currently the game can crash in weird ways on soft reset, usually when trying to warp to areas. This was due to a bug in how the constructor/destructor alignments were set by decomp, meaning sometimes static destructors would get re-called on soft reset alongside the static constructors, clearing some static initialised data. This fixes that issue, and also adds in a couple other guards to make similar crashes less likely. 