### PR TITLE
Fix frame-perfect empress trainer crash

### DIFF
--- a/include/p2gz/Trainers.h
+++ b/include/p2gz/Trainers.h
@@ -29,6 +29,8 @@ public:
 
 	void stop() { enabled = false; }
 
+	bool is_fading() { return enabled && fade_out_frames >= 30; }
+
 	void draw();
 	void start();
 	void update();

--- a/src/p2gz/empressTrainer.cpp
+++ b/src/p2gz/empressTrainer.cpp
@@ -3,6 +3,7 @@
 #include <P2JME/P2JME.h>
 #include <Game/generalEnemyMgr.h>
 #include <Game/Entities/Queen.h>
+#include <Screen/Game2DMgr.h>
 #include <p2gz/SegmentHistory.h>
 #include <p2gz/p2gz.h>
 
@@ -120,7 +121,13 @@ void EmpressTrainer::update()
 		Game::gameSystem->startFadeout(1.0f);
 	}
 
-	if (fade_out_frames == 60) {
+	if (fade_out_frames >= 60) {
+		// make doubly sure no screen is loading before we reload
+		// (otherwise we can hit a lockout skip crash)
+		if (Screen::gGame2DMgr && Screen::gGame2DMgr->mScreenMgr && Screen::gGame2DMgr->mScreenMgr->isCurrentSceneLoading()) {
+			return;
+		}
+
 		fade_out_frames    = 0;
 		first_damage_frame = -1;
 		polling            = true;

--- a/src/plugProjectKandoU/singleGS_CaveGame.cpp
+++ b/src/plugProjectKandoU/singleGS_CaveGame.cpp
@@ -284,8 +284,11 @@ void CaveState::check_SMenu(SingleGameSection* game)
 		return;
 	case Screen::Game2DMgr::CHECK2D_SMenu_Error:
 		// Conditions to open pause menu
-		if (!(gameSystem->isFlag(GAMESYS_DisablePause)) && moviePlayer->mDemoState == DEMOSTATE_Inactive && !gameSystem->paused()
-		    && game->mControllerP1->getButtonDown() & Controller::PRESS_START) {
+		if (!(gameSystem->isFlag(GAMESYS_DisablePause)) && moviePlayer->mDemoState == DEMOSTATE_Inactive
+		    && !gameSystem->paused()
+		    // @P2GZ: fix pause-during-fadeout empress trainer crash
+		    // && game->mControllerP1->getButtonDown() & Controller::PRESS_START) {
+		    && !p2gz->empress_trainer->is_fading() && game->mControllerP1->getButtonDown() & Controller::PRESS_START) {
 			og::Screen::DispMemberSMenuAll disp;
 			game->setDispMemberSMenu(disp);
 			if (!Screen::gGame2DMgr->open_SMenu(disp)) {


### PR DESCRIPTION
Currently, if you pause frame-perfectly during the auto-load-out for the fast empress trainer, such that the map on the pause screen is initialising just as the load transition fires, the game crashes (the vanilla ScreenMgr does not handle unexpected things gracefully). This fixes the crash by preventing pausing during that auto-fadeout, and puts in some guards to not trigger the auto-load transition if any screen is loading.