### PR TITLE
Implement poko % cutscenes to relevant PoD abovegrounds

### DIFF
--- a/assets/files/presets/at/bk1-4.txt
+++ b/assets/files/presets/at/bk1-4.txt
@@ -154,3 +154,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/bk5-6.txt
+++ b/assets/files/presets/at/bk5-6.txt
@@ -154,3 +154,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/bk7.txt
+++ b/assets/files/presets/at/bk7.txt
@@ -154,3 +154,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/coc1-10.txt
+++ b/assets/files/presets/at/coc1-10.txt
@@ -170,3 +170,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/cos1-2.txt
+++ b/assets/files/presets/at/cos1-2.txt
@@ -128,3 +128,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/cos3-5.txt
+++ b/assets/files/presets/at/cos3-5.txt
@@ -128,3 +128,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/day1.txt
+++ b/assets/files/presets/at/day1.txt
@@ -22,3 +22,4 @@ AT 	# category
 0 	# num treasure spawn overrides
 0	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/day2.txt
+++ b/assets/files/presets/at/day2.txt
@@ -45,3 +45,4 @@ AT 	# category
 	47 		2 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/day3.txt
+++ b/assets/files/presets/at/day3.txt
@@ -29,3 +29,4 @@ AT 	# category
 0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/day4.txt
+++ b/assets/files/presets/at/day4.txt
@@ -32,3 +32,4 @@ AT 	# category
 0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/day_5_cleanup.txt
+++ b/assets/files/presets/at/day_5_cleanup.txt
@@ -105,3 +105,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+1   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/dd1-9.txt
+++ b/assets/files/presets/at/dd1-9.txt
@@ -172,3 +172,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/dd10-14.txt
+++ b/assets/files/presets/at/dd10-14.txt
@@ -172,3 +172,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/ec1-2_2nd_visit.txt
+++ b/assets/files/presets/at/ec1-2_2nd_visit.txt
@@ -45,3 +45,4 @@ AT 	# category
 0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/ec1_1st_visit.txt
+++ b/assets/files/presets/at/ec1_1st_visit.txt
@@ -39,3 +39,4 @@ AT 	# category
 0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/ec2_1st_visit.txt
+++ b/assets/files/presets/at/ec2_1st_visit.txt
@@ -41,3 +41,4 @@ AT 	# category
 0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/enter_bk.txt
+++ b/assets/files/presets/at/enter_bk.txt
@@ -149,3 +149,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/enter_coc.txt
+++ b/assets/files/presets/at/enter_coc.txt
@@ -168,3 +168,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 0	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/enter_cos.txt
+++ b/assets/files/presets/at/enter_cos.txt
@@ -124,3 +124,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 0	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/enter_dd.txt
+++ b/assets/files/presets/at/enter_dd.txt
@@ -170,3 +170,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/enter_fc.txt
+++ b/assets/files/presets/at/enter_fc.txt
@@ -121,3 +121,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+1   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/enter_gk.txt
+++ b/assets/files/presets/at/enter_gk.txt
@@ -129,3 +129,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/enter_hob.txt
+++ b/assets/files/presets/at/enter_hob.txt
@@ -97,3 +97,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/enter_hoh.txt
+++ b/assets/files/presets/at/enter_hoh.txt
@@ -174,3 +174,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/enter_scx.txt
+++ b/assets/files/presets/at/enter_scx.txt
@@ -109,3 +109,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/enter_sh.txt
+++ b/assets/files/presets/at/enter_sh.txt
@@ -156,3 +156,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/enter_smc.txt
+++ b/assets/files/presets/at/enter_smc.txt
@@ -140,3 +140,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+1   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/enter_sr.txt
+++ b/assets/files/presets/at/enter_sr.txt
@@ -150,3 +150,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/enter_wfg.txt
+++ b/assets/files/presets/at/enter_wfg.txt
@@ -85,3 +85,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 0	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/fc1.txt
+++ b/assets/files/presets/at/fc1.txt
@@ -133,3 +133,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/fc2-3.txt
+++ b/assets/files/presets/at/fc2-3.txt
@@ -134,3 +134,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/fc4.txt
+++ b/assets/files/presets/at/fc4.txt
@@ -134,3 +134,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/fc5.txt
+++ b/assets/files/presets/at/fc5.txt
@@ -135,3 +135,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/fc6.txt
+++ b/assets/files/presets/at/fc6.txt
@@ -137,3 +137,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/fc7.txt
+++ b/assets/files/presets/at/fc7.txt
@@ -137,3 +137,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/fc8.txt
+++ b/assets/files/presets/at/fc8.txt
@@ -137,3 +137,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/gk1-5.txt
+++ b/assets/files/presets/at/gk1-5.txt
@@ -138,3 +138,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/gk6.txt
+++ b/assets/files/presets/at/gk6.txt
@@ -138,3 +138,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/hob1-2.txt
+++ b/assets/files/presets/at/hob1-2.txt
@@ -101,3 +101,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/hob3.txt
+++ b/assets/files/presets/at/hob3.txt
@@ -101,3 +101,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/hob4.txt
+++ b/assets/files/presets/at/hob4.txt
@@ -102,3 +102,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/hob5.txt
+++ b/assets/files/presets/at/hob5.txt
@@ -102,3 +102,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/hoh1-5.txt
+++ b/assets/files/presets/at/hoh1-5.txt
@@ -178,3 +178,4 @@ AT 	# category
 	183 	1 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/hoh6-8.txt
+++ b/assets/files/presets/at/hoh6-8.txt
@@ -178,3 +178,4 @@ AT 	# category
 	183 	1 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/hoh9-15.txt
+++ b/assets/files/presets/at/hoh9-15.txt
@@ -178,3 +178,4 @@ AT 	# category
 	183 	1 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/purple_farm.txt
+++ b/assets/files/presets/at/purple_farm.txt
@@ -168,3 +168,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/scx1-3.txt
+++ b/assets/files/presets/at/scx1-3.txt
@@ -118,3 +118,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/scx4.txt
+++ b/assets/files/presets/at/scx4.txt
@@ -118,3 +118,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/scx5-8.txt
+++ b/assets/files/presets/at/scx5-8.txt
@@ -118,3 +118,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/scx9.txt
+++ b/assets/files/presets/at/scx9.txt
@@ -118,3 +118,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/sh1-3.txt
+++ b/assets/files/presets/at/sh1-3.txt
@@ -166,3 +166,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/sh4-7.txt
+++ b/assets/files/presets/at/sh4-7.txt
@@ -166,3 +166,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/smc1-2.txt
+++ b/assets/files/presets/at/smc1-2.txt
@@ -148,3 +148,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/smc3.txt
+++ b/assets/files/presets/at/smc3.txt
@@ -148,3 +148,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/smc4.txt
+++ b/assets/files/presets/at/smc4.txt
@@ -148,3 +148,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/smc5.txt
+++ b/assets/files/presets/at/smc5.txt
@@ -148,3 +148,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/sr1-4.txt
+++ b/assets/files/presets/at/sr1-4.txt
@@ -147,3 +147,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/sr5.txt
+++ b/assets/files/presets/at/sr5.txt
@@ -147,3 +147,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/sr6.txt
+++ b/assets/files/presets/at/sr6.txt
@@ -147,3 +147,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/sr7.txt
+++ b/assets/files/presets/at/sr7.txt
@@ -147,3 +147,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/vor_cleanup.txt
+++ b/assets/files/presets/at/vor_cleanup.txt
@@ -139,3 +139,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+1   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/wfg1.txt
+++ b/assets/files/presets/at/wfg1.txt
@@ -88,3 +88,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/wfg2-3.txt
+++ b/assets/files/presets/at/wfg2-3.txt
@@ -92,3 +92,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/at/wfg4-5.txt
+++ b/assets/files/presets/at/wfg4-5.txt
@@ -95,3 +95,4 @@ AT 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/general/everything.txt
+++ b/assets/files/presets/general/everything.txt
@@ -175,3 +175,4 @@ General 	# category
 	183 	2 	# Seed of Greed
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/bk.txt
+++ b/assets/files/presets/pod/bk.txt
@@ -85,3 +85,4 @@ PoD 	# category
 	47 	2 	# Fossilized Ursidae
 1	# bridge glitch active
 4	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/bk_25w.txt
+++ b/assets/files/presets/pod/bk_25w.txt
@@ -85,3 +85,4 @@ PoD 	# category
 	47 	2 	# Fossilized Ursidae
 1	# bridge glitch active
 4	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/cos.txt
+++ b/assets/files/presets/pod/cos.txt
@@ -100,3 +100,4 @@ PoD 	# category
 	47 	1 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/cos_40w.txt
+++ b/assets/files/presets/pod/cos_40w.txt
@@ -100,3 +100,4 @@ PoD 	# category
 	47 	1 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/day1.txt
+++ b/assets/files/presets/pod/day1.txt
@@ -47,3 +47,4 @@ PoD 	# category
 	47 		2 	# Fossilized Ursidae
 0	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/day2.txt
+++ b/assets/files/presets/pod/day2.txt
@@ -45,3 +45,4 @@ PoD 	# category
 	47 		2 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/day3.txt
+++ b/assets/files/presets/pod/day3.txt
@@ -50,3 +50,4 @@ PoD 	# category
 	47 		2 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/day4.txt
+++ b/assets/files/presets/pod/day4.txt
@@ -52,3 +52,4 @@ PoD 	# category
 	47 		2 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/day6_cr.txt
+++ b/assets/files/presets/pod/day6_cr.txt
@@ -92,3 +92,4 @@ PoD 	# category
 	47 	2 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/day6_cr_25w.txt
+++ b/assets/files/presets/pod/day6_cr_25w.txt
@@ -92,3 +92,4 @@ PoD 	# category
 	47 	2 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/ec1.txt
+++ b/assets/files/presets/pod/ec1.txt
@@ -40,3 +40,4 @@ PoD 	# category
 0 	# num treasure spawn overrides
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/ec2.txt
+++ b/assets/files/presets/pod/ec2.txt
@@ -63,3 +63,4 @@ PoD 	# category
 	47 	2 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/enter_bk_15_5w.txt
+++ b/assets/files/presets/pod/enter_bk_15_5w.txt
@@ -92,3 +92,4 @@ PoD 	# category
 	47 	2 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+1   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/enter_bk_20w.txt
+++ b/assets/files/presets/pod/enter_bk_20w.txt
@@ -92,3 +92,4 @@ PoD 	# category
 	47 	2 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+1   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/enter_bk_25w.txt
+++ b/assets/files/presets/pod/enter_bk_25w.txt
@@ -92,3 +92,4 @@ PoD 	# category
 	47 	2 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+1   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/enter_cos.txt
+++ b/assets/files/presets/pod/enter_cos.txt
@@ -98,3 +98,4 @@ PoD 	# category
 	47 	1 	# Fossilized Ursidae
 0	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/enter_cos_40w.txt
+++ b/assets/files/presets/pod/enter_cos_40w.txt
@@ -98,3 +98,4 @@ PoD 	# category
 	47 	1 	# Fossilized Ursidae
 0	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/enter_fc.txt
+++ b/assets/files/presets/pod/enter_fc.txt
@@ -98,3 +98,4 @@ PoD 	# category
 	47 	    3   -973.11 80.24 1721.64 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+1   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/enter_fc_40w.txt
+++ b/assets/files/presets/pod/enter_fc_40w.txt
@@ -98,3 +98,4 @@ PoD 	# category
 	47 	    3   -973.11 80.24 1721.64 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+1   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/enter_gk.txt
+++ b/assets/files/presets/pod/enter_gk.txt
@@ -9,7 +9,7 @@ PoD 	# category
 7.000000 	# time of day
 8 	# day number
 -1 	# pokos (-1 if not applied)
-1 	# enter kind (FromCave = 0, FromMap = 1)
+0 	# enter kind (FromCave = 0, FromMap = 1)
 7 	# num upgrades
 	0 	# ODII_BruteKnuckles
 	5 	# ODII_JusticeAlloy
@@ -18,7 +18,7 @@ PoD 	# category
 	9 	# ODII_FiveManNapsack
 	10 	# ODII_SphericalAtlas
 	11 	# ODII_GeographicProjection
-34 	# num demo flags
+35 	# num demo flags
 	0 	# DEMO_Pluck_First_Pikmin
 	1 	# DEMO_Discover_Treasure
 	3 	# DEMO_Find_Cave_Deeper_Hole
@@ -38,6 +38,7 @@ PoD 	# category
 	26 	# DEMO_Purple_Candypop
 	31 	# DEMO_Day_One_Start
 	32 	# DEMO_Enter_Awakening_Wood
+	33 	# DEMO_Enter_Perplexing_Pool
 	35 	# DEMO_Meet_Red_Pikmin
 	36 	# DEMO_Louie_Finds_Red_Onion
 	37 	# DEMO_Unlock_Captain_Switch
@@ -53,7 +54,7 @@ PoD 	# category
 	49 	# DEMO_First_Number_Pellet
 	51 	# DEMO_Pikmin_In_Danger_Water
 	52 	# DEMO_Pikmin_In_Danger_Poison
-7 	# num EK cutscenes
+8 	# num EK cutscenes
 	0 	# ODII_BruteKnuckles
 	5 	# ODII_JusticeAlloy
 	6 	# ODII_ForgedCourage
@@ -62,7 +63,7 @@ PoD 	# category
 	10 	# ODII_SphericalAtlas
 	11 	# ODII_GeographicProjection
 	12 	# ODII_TheKey
-7 	# num cave cutscene flags
+8 	# num cave cutscene flags
 	1 	# EC
 	2 	# SCx
 	3 	# FC

--- a/assets/files/presets/pod/enter_gk.txt
+++ b/assets/files/presets/pod/enter_gk.txt
@@ -100,3 +100,4 @@ PoD 	# category
 	47 	1 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/enter_gk_40w.txt
+++ b/assets/files/presets/pod/enter_gk_40w.txt
@@ -9,7 +9,7 @@ PoD 	# category
 7.000000 	# time of day
 8 	# day number
 -1 	# pokos (-1 if not applied)
-1 	# enter kind (FromCave = 0, FromMap = 1)
+0 	# enter kind (FromCave = 0, FromMap = 1)
 7 	# num upgrades
 	0 	# ODII_BruteKnuckles
 	5 	# ODII_JusticeAlloy
@@ -18,7 +18,7 @@ PoD 	# category
 	9 	# ODII_FiveManNapsack
 	10 	# ODII_SphericalAtlas
 	11 	# ODII_GeographicProjection
-34 	# num demo flags
+35 	# num demo flags
 	0 	# DEMO_Pluck_First_Pikmin
 	1 	# DEMO_Discover_Treasure
 	3 	# DEMO_Find_Cave_Deeper_Hole
@@ -38,6 +38,7 @@ PoD 	# category
 	26 	# DEMO_Purple_Candypop
 	31 	# DEMO_Day_One_Start
 	32 	# DEMO_Enter_Awakening_Wood
+	33 	# DEMO_Enter_Perplexing_Pool
 	35 	# DEMO_Meet_Red_Pikmin
 	36 	# DEMO_Louie_Finds_Red_Onion
 	37 	# DEMO_Unlock_Captain_Switch
@@ -53,7 +54,7 @@ PoD 	# category
 	49 	# DEMO_First_Number_Pellet
 	51 	# DEMO_Pikmin_In_Danger_Water
 	52 	# DEMO_Pikmin_In_Danger_Poison
-7 	# num EK cutscenes
+8 	# num EK cutscenes
 	0 	# ODII_BruteKnuckles
 	5 	# ODII_JusticeAlloy
 	6 	# ODII_ForgedCourage
@@ -62,7 +63,7 @@ PoD 	# category
 	10 	# ODII_SphericalAtlas
 	11 	# ODII_GeographicProjection
 	12 	# ODII_TheKey
-7 	# num cave cutscene flags
+8 	# num cave cutscene flags
 	1 	# EC
 	2 	# SCx
 	3 	# FC

--- a/assets/files/presets/pod/enter_gk_40w.txt
+++ b/assets/files/presets/pod/enter_gk_40w.txt
@@ -100,3 +100,4 @@ PoD 	# category
 	47 	1 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/enter_hob.txt
+++ b/assets/files/presets/pod/enter_hob.txt
@@ -70,3 +70,4 @@ PoD 	# category
 	47 	2 	# Fossilized Ursidae
 0	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/enter_scx.txt
+++ b/assets/files/presets/pod/enter_scx.txt
@@ -94,3 +94,4 @@ PoD 	# category
 	47 	2 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+1   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/enter_scx_25w.txt
+++ b/assets/files/presets/pod/enter_scx_25w.txt
@@ -94,3 +94,4 @@ PoD 	# category
 	47 	2 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+1   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/enter_sh.txt
+++ b/assets/files/presets/pod/enter_sh.txt
@@ -85,3 +85,4 @@ PoD 	# category
 	47 	2 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+1   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/enter_wfg.txt
+++ b/assets/files/presets/pod/enter_wfg.txt
@@ -78,3 +78,4 @@ PoD 	# category
 	47 	2 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+1   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/fc1-5.txt
+++ b/assets/files/presets/pod/fc1-5.txt
@@ -100,3 +100,4 @@ PoD 	# category
 	47 	0 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/fc1-5_40w.txt
+++ b/assets/files/presets/pod/fc1-5_40w.txt
@@ -100,3 +100,4 @@ PoD 	# category
 	47 	1 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/fc6-7.txt
+++ b/assets/files/presets/pod/fc6-7.txt
@@ -102,3 +102,4 @@ PoD 	# category
 	47 	1 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/fc6-7_40w.txt
+++ b/assets/files/presets/pod/fc6-7_40w.txt
@@ -102,3 +102,4 @@ PoD 	# category
 	47 	1 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/gk.txt
+++ b/assets/files/presets/pod/gk.txt
@@ -103,3 +103,4 @@ PoD 	# category
 	47 	1 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/gk_40w.txt
+++ b/assets/files/presets/pod/gk_40w.txt
@@ -103,3 +103,4 @@ PoD 	# category
 	47 	1 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/hob1-2.txt
+++ b/assets/files/presets/pod/hob1-2.txt
@@ -76,3 +76,4 @@ PoD 	# category
 	47 	2 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/hob3-4.txt
+++ b/assets/files/presets/pod/hob3-4.txt
@@ -76,3 +76,4 @@ PoD 	# category
 	47 	2 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/hob5.txt
+++ b/assets/files/presets/pod/hob5.txt
@@ -76,3 +76,4 @@ PoD 	# category
 	47 	2 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/scx1-4.txt
+++ b/assets/files/presets/pod/scx1-4.txt
@@ -98,3 +98,4 @@ PoD 	# category
 	47 	0 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/scx1-4_25w.txt
+++ b/assets/files/presets/pod/scx1-4_25w.txt
@@ -98,3 +98,4 @@ PoD 	# category
 	47 	0 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/scx5-8.txt
+++ b/assets/files/presets/pod/scx5-8.txt
@@ -98,3 +98,4 @@ PoD 	# category
 	47 	0 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/scx5-8_40w.txt
+++ b/assets/files/presets/pod/scx5-8_40w.txt
@@ -98,3 +98,4 @@ PoD 	# category
 	47 	0 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/sh1-2.txt
+++ b/assets/files/presets/pod/sh1-2.txt
@@ -90,3 +90,4 @@ PoD 	# category
 	47 	2 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/sh3-7.txt
+++ b/assets/files/presets/pod/sh3-7.txt
@@ -90,3 +90,4 @@ PoD 	# category
 	47 	2 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/wfg1-3.txt
+++ b/assets/files/presets/pod/wfg1-3.txt
@@ -80,3 +80,4 @@ PoD 	# category
 	47 	2 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/assets/files/presets/pod/wfg4-5.txt
+++ b/assets/files/presets/pod/wfg4-5.txt
@@ -83,3 +83,4 @@ PoD 	# category
 	47 	2 	# Fossilized Ursidae
 1	# bridge glitch active
 0	# new area zoom (bit per course: VoR=1 AW=2 PP=4 WW=8)
+0   # percent cutscene (> 0 if one should play)

--- a/include/p2gz/PokoEditor.h
+++ b/include/p2gz/PokoEditor.h
@@ -7,7 +7,10 @@
 namespace gz {
 struct PokoEditor {
 public:
-	PokoEditor() { }
+	PokoEditor()
+	    : repay_demo_enabled(false)
+	{
+	}
 	~PokoEditor() { }
 
 	void init();
@@ -16,9 +19,9 @@ public:
 	void set_pokos(u32 pokos);
 	void apply_cave_pokos();
 
-	// variable which tracks whether a % CS will play next warp. 
+	// variable which tracks whether a % CS will play next warp.
 	// set on warp by play_repay_demo, which is read from the presets
-	bool repay_demo_enabled = false;
+	bool repay_demo_enabled;
 
 private:
 	gz::DecimalInputOption* poko_menu;

--- a/include/p2gz/PokoEditor.h
+++ b/include/p2gz/PokoEditor.h
@@ -16,6 +16,10 @@ public:
 	void set_pokos(u32 pokos);
 	void apply_cave_pokos();
 
+	// variable which tracks whether a % CS will play next warp. 
+	// set on warp by play_repay_demo, which is read from the presets
+	bool repay_demo_enabled = false;
+
 private:
 	gz::DecimalInputOption* poko_menu;
 };

--- a/include/p2gz/Preset.h
+++ b/include/p2gz/Preset.h
@@ -174,6 +174,7 @@ public:
 	Vec<TreasureGenSpawnOverride> treasure_spawn_overrides;
 	bool bridge_glitch_active;
 	BitFlag<u16> new_area_zoom;        // bit per course: VoR=1 AW=2 PP=4 WW=8; set = allow zoom on next world-map visit
+	bool play_repay_demo; // tracks whether or not to play a % cutscene
 	AreaStructureState area_states[4]; // per-area structure state, indexed by CourseIndex (0=VoR…3=WW)
 
 	bool is_area_visited(int course) const;

--- a/src/p2gz/preset.cpp
+++ b/src/p2gz/preset.cpp
@@ -301,7 +301,6 @@ void Preset::apply()
 	p2gz->warp->set_enter_area_type(enter_kind);
 
 	// set whether %cutscene should be forced to play or not
-	OSReport("right before setting enable percent cutscenes \n"); 
 	if (play_repay_demo){
 		p2gz->poko_editor->repay_demo_enabled = true; 
 	}

--- a/src/p2gz/preset.cpp
+++ b/src/p2gz/preset.cpp
@@ -69,6 +69,7 @@ Preset::Preset()
 	bridge_glitch_active = true;
 	category             = PoD;  // default to pod so we don't get errors for null presets
 	time                 = 7.0f; // default to start of day
+	play_repay_demo      = false; // default to no percent cutscene
 	squad.clear();
 	onion_pikis.clear();
 }
@@ -298,6 +299,12 @@ void Preset::apply()
 	}
 
 	p2gz->warp->set_enter_area_type(enter_kind);
+
+	// set whether %cutscene should be forced to play or not
+	OSReport("right before setting enable percent cutscenes \n"); 
+	if (play_repay_demo){
+		p2gz->poko_editor->repay_demo_enabled = true; 
+	}
 
 	if (apply_pokos) {
 		p2gz->poko_editor->set_pokos(pokos);

--- a/src/p2gz/presetSerde.cpp
+++ b/src/p2gz/presetSerde.cpp
@@ -288,7 +288,7 @@ void Preset::read(Stream& input)
 	new_area_zoom.clear();
 	new_area_zoom.typeView = static_cast<u16>(input.readInt());
 	OSReport("Right before reading play_repay_demo \n");
-	play_repay_demo = input.readInt() > 0; // read % cutscene on the next line from pokos
+	play_repay_demo = input.readInt() > 0; 
 }
 
 void Preset::write(Stream& output)

--- a/src/p2gz/presetSerde.cpp
+++ b/src/p2gz/presetSerde.cpp
@@ -4,17 +4,22 @@
 
 using namespace gz;
 
-#define READ_LIST(stream)          \
-	list_count = stream.readInt(); \
+// clearer guard against corrupt preset list counts
+static const u32 PRESET_LIST_MAX = 256;
+
+#define READ_LIST(stream)                                                                          \
+	list_count = stream.readInt();                                                                 \
+	GZEXPECT((u32)list_count <= PRESET_LIST_MAX, "preset list count %d out of range", list_count); \
 	for (u32 i = 0; i < list_count; i++)
 
-#define READ_LIST_T(stream, Type, dest)    \
-	list_count = stream.readInt();         \
-	dest.expandCapacityTo(list_count);     \
-	for (u32 i = 0; i < list_count; i++) { \
-		Type container;                    \
-		container.read(stream);            \
-		dest.push(container);              \
+#define READ_LIST_T(stream, Type, dest)                                                            \
+	list_count = stream.readInt();                                                                 \
+	GZEXPECT((u32)list_count <= PRESET_LIST_MAX, "preset list count %d out of range", list_count); \
+	dest.expandCapacityTo(list_count);                                                             \
+	for (u32 i = 0; i < list_count; i++) {                                                         \
+		Type container;                                                                            \
+		container.read(stream);                                                                    \
+		dest.push(container);                                                                      \
 	}
 
 #define READ_BITFLAG(stream, bitfield)        \
@@ -282,8 +287,8 @@ void Preset::read(Stream& input)
 
 	new_area_zoom.clear();
 	new_area_zoom.typeView = static_cast<u16>(input.readInt());
-	OSReport("Right before reading play_repay_demo \n"); 
-	play_repay_demo  = input.readInt() > 0; // read % cutscene on the next line from pokos
+	OSReport("Right before reading play_repay_demo \n");
+	play_repay_demo = input.readInt() > 0; // read % cutscene on the next line from pokos
 }
 
 void Preset::write(Stream& output)

--- a/src/p2gz/presetSerde.cpp
+++ b/src/p2gz/presetSerde.cpp
@@ -287,7 +287,6 @@ void Preset::read(Stream& input)
 
 	new_area_zoom.clear();
 	new_area_zoom.typeView = static_cast<u16>(input.readInt());
-	OSReport("Right before reading play_repay_demo \n");
 	play_repay_demo = input.readInt() > 0; 
 }
 

--- a/src/p2gz/presetSerde.cpp
+++ b/src/p2gz/presetSerde.cpp
@@ -282,6 +282,8 @@ void Preset::read(Stream& input)
 
 	new_area_zoom.clear();
 	new_area_zoom.typeView = static_cast<u16>(input.readInt());
+	OSReport("Right before reading play_repay_demo \n"); 
+	play_repay_demo  = input.readInt() > 0; // read % cutscene on the next line from pokos
 }
 
 void Preset::write(Stream& output)

--- a/src/plugProjectKandoU/singleGS_MainGame.cpp
+++ b/src/plugProjectKandoU/singleGS_MainGame.cpp
@@ -472,6 +472,12 @@ void GameState::exec(SingleGameSection* game)
 	if (moviePlayer->mDemoState == DEMOSTATE_Inactive && needRepayDemo()) {
 		startRepayDemo();
 	}
+	else if (moviePlayer->mDemoState == DEMOSTATE_Inactive && p2gz->poko_editor->repay_demo_enabled){ 
+		// @ P2GZ: alternate way to force % cutscenes to play. I'm not disturbing usual game logic if we want
+		// the hack to be playable more normally. 
+		startRepayDemo();
+		p2gz->poko_editor->repay_demo_enabled = false; 
+	}
 
 	// Check if anything needs to be done following a % of debt cutscene
 	int repaystate = updateRepayDemo();


### PR DESCRIPTION
Percent cutscenes now play properly on every segment where they are expected to in Pay off Debt. 

Percent cutscenes are not yet implemented for AT, and it would probably be useful to make a menu option to turn them all off forcefully for segments in which they may or may not play (enter scx). 