### PR TITLE
Fix race mode timer + save prompt crash

### DIFF
--- a/include/p2gz/RaceMode.h
+++ b/include/p2gz/RaceMode.h
@@ -45,10 +45,12 @@ public:
 	void start_run();
 
 	// hooks called from game code
-	void on_ending(bool is_all_treasures); // run-end detection
-	void request_reset();                  // X+B+Start = floor retry override
-	void notify_enemy_defeated();          // fun stats counter
-	void notify_pikmin_thrown();           // fun stats counter
+	void on_ending(bool is_all_treasures);        // run-end detection
+	void request_reset();                         // X+B+Start = floor retry override
+	void notify_cutscene_skipped(u32 skipped_ms); // advance the run clock by skipped vanilla cutscene time
+	void notify_save_skipped(f32 offset_seconds); // advance the run clock by a skipped save-prompt's vanilla time
+	void notify_enemy_defeated();                 // fun stats counter
+	void notify_pikmin_thrown();                  // fun stats counter
 
 private:
 	void begin_fresh_file();
@@ -57,6 +59,9 @@ private:
 	void do_reset();
 	void abort_run();
 	void capture_stats();
+
+	u32 rta_ms();
+	void add_skipped_time(u32 ms); // advance the run clock by p2gz-skipped vanilla time (cutscenes, save prompts)
 
 	void draw_timers();
 	void draw_timer_line(J2DPrint& j2d, f32 decimal_x, f32 z, const char* label, u32 ms); // one decimal-aligned RTA/IGT row
@@ -87,6 +92,9 @@ private:
 	bool was_loading;      // edge-detect in_load() for load_ms accounting
 	u32 load_enter_ms;     // wall-clock ms when the current load began
 	u32 abort_hold_frames; // frames the abort combo has been held
+
+	u32 run_start_ms; // wall-clock ms when the run started
+	bool timer_started;
 
 	bool pending_reset; // set by request_reset(), consumed in update()
 

--- a/include/p2gz/timer.h
+++ b/include/p2gz/timer.h
@@ -60,15 +60,12 @@ public:
 	void offset_sub_timer(f32 offset_seconds);
 
 	void reset_skip_timer();
-	void stop_skip_timer(Game::MovieConfig* config);
+	u32 stop_skip_timer(Game::MovieConfig* config); // returns the unwatched cutscene time it compensated for (ms)
 	void cancel_skip_timer();
 
 	void pause();
 	void unpause();
 	u32 get_elapsed_time() { return ((get_cur_time() - sub_timer) / 1000); } // this returns time since last loaded section in seconds
-
-	// elapsed RTA in ms (for race mode)
-	u32 get_main_elapsed_ms();
 
 	void reset_navi_swap_timer();
 	f32 stop_navi_swap_timer();

--- a/src/p2gz/RaceMode.cpp
+++ b/src/p2gz/RaceMode.cpp
@@ -40,6 +40,8 @@ RaceMode::RaceMode()
 	was_loading            = false;
 	load_enter_ms          = 0;
 	abort_hold_frames      = 0;
+	run_start_ms           = 0;
+	timer_started          = false;
 	pending_reset          = false;
 	final_rta_ms           = 0;
 	final_igt_ms           = 0;
@@ -55,6 +57,13 @@ RaceMode::RaceMode()
 u32 RaceMode::cur_ms()
 {
 	return (u32)OSTicksToMilliseconds(OSGetTime());
+}
+
+// race mode has its own timer, so it doesn't get wiped by cave exits etc (woops)
+u32 RaceMode::rta_ms()
+{
+	// time since run start (or 0 if we haven't started yet)
+	return timer_started ? cur_ms() - run_start_ms : 0;
 }
 
 void RaceMode::ms_to_clock(u32 ms, u32& hours, u32& minutes, u32& seconds, u32& tenths)
@@ -135,12 +144,16 @@ void RaceMode::start_run()
 	enemies_defeated  = 0;
 	pikmin_thrown     = 0;
 
+	// start the timer
+	timer_started = true;
+	run_start_ms  = cur_ms();
+
 	// treasure region is bound straight into the region change stuff, so it'll auto-apply
 
 	// close menu first, otherwise we mess up the timer lol
 	p2gz->menu->close();
 
-	// start RTA (main) and IGT (load-removed) timers
+	// the normal per-segment timer is hidden during a race, but keep it in a sane state for when the race ends
 	p2gz->timer->set_enabled(true);
 	p2gz->timer->set_sub_timer_enabled(false);
 	p2gz->timer->reset_main_timer();
@@ -173,6 +186,9 @@ void RaceMode::begin_fresh_file()
 	Game::playData->reset();
 	Game::playData->mLoadType             = Game::STORYSAVE_NewFile;
 	Game::gameSystem->mTimeMgr->mDayCount = 0;
+
+	// no save slot was ever chosen, so flag this like a menu warp does
+	p2gz->in_save_file = false;
 
 	Game::SingleGame::MovieArg arg(Game::THPPlayer::OPENING_GameStart);
 	game->mFsm->transit(game, Game::SingleGame::SGS_Movie, &arg);
@@ -225,7 +241,8 @@ void RaceMode::do_reset()
 
 	const f32 penalty = use_set_seed ? RESET_PENALTY_SET_SEED : RESET_PENALTY_RANDOM;
 	if (penalty > 0.0f) {
-		p2gz->timer->offset_main_timer(penalty); // also penalises IGT, since IGT = RTA - loads
+		// move the run-clock origin earlier so the penalty is "added" to both RTA and IGT
+		run_start_ms -= (u32)(penalty * 1000.0f);
 	}
 
 	// day 1 has to be difficult every single time. account for it if someone resets the day
@@ -269,18 +286,41 @@ void RaceMode::on_ending(bool is_all_treasures)
 
 	capture_stats();
 	final_is_all_treasures = is_all_treasures;
-	p2gz->timer->pause(); // stop the timer!
+
 	finished = true;
 }
 
 void RaceMode::capture_stats()
 {
-	const u32 rta      = p2gz->timer->get_main_elapsed_ms();
+	const u32 rta      = rta_ms();
 	const u32 eff_load = load_ms + (was_loading ? cur_ms() - load_enter_ms : 0);
 
 	final_rta_ms      = rta;
 	final_igt_ms      = (rta > eff_load) ? rta - eff_load : 0;
 	final_pikmin_lost = Game::DeathMgr::get_total(Game::DeathCounter::COD_All) + Game::DeathMgr::get_today(Game::DeathCounter::COD_All);
+}
+
+void RaceMode::add_skipped_time(u32 ms)
+{
+	// correct the race timer for skipped cutscenes/save prompts/etc
+	if (!timer_started || finished || ms == 0) {
+		return;
+	}
+	run_start_ms -= ms;
+}
+
+void RaceMode::notify_cutscene_skipped(u32 skipped_ms)
+{
+	add_skipped_time(skipped_ms);
+}
+
+void RaceMode::notify_save_skipped(f32 offset_seconds)
+{
+	// no underflows for me, thanks - i'm driving
+	if (offset_seconds <= 0.0f) {
+		return;
+	}
+	add_skipped_time((u32)(offset_seconds * 1000.0f));
 }
 
 void RaceMode::notify_enemy_defeated()
@@ -400,7 +440,7 @@ void RaceMode::draw_timers()
 	j2d.mCharColor.set(color);
 	j2d.mGradientColor.set(color);
 
-	const u32 rta      = finished ? final_rta_ms : p2gz->timer->get_main_elapsed_ms();
+	const u32 rta      = finished ? final_rta_ms : rta_ms();
 	const u32 eff_load = load_ms + (was_loading ? cur_ms() - load_enter_ms : 0);
 	const u32 igt      = finished ? final_igt_ms : ((rta > eff_load) ? rta - eff_load : 0);
 

--- a/src/p2gz/timer.cpp
+++ b/src/p2gz/timer.cpp
@@ -63,13 +63,6 @@ void Timer::init()
 	timer_menu = static_cast<ListMenu*>(p2gz->menu->get_option("timer")->get_sub_menu());
 }
 
-u32 Timer::get_main_elapsed_ms()
-{
-	// while paused, the timer is frozen at pause_timer
-	const u32 end = pause_timer_set ? pause_timer : get_cur_time();
-	return end - main_timer;
-}
-
 void Timer::draw()
 {
 	if (!enabled) {
@@ -307,10 +300,10 @@ void Timer::reset_skip_timer()
 	skip_timer_set = true;
 }
 
-void Timer::stop_skip_timer(Game::MovieConfig* config)
+u32 Timer::stop_skip_timer(Game::MovieConfig* config)
 {
 	if (!skip_timer_set || !config) {
-		return;
+		return 0;
 	}
 
 	f32 max_cutscene_time = 0.0f;
@@ -331,7 +324,7 @@ void Timer::stop_skip_timer(Game::MovieConfig* config)
 		// we have a skip timer going during the wrong cutscene, something is Wrong
 		OSReport("[P2GZ WARN] stop_skip_timer: unhandled config name\n");
 		OSReport("[P2GZ WARN] >> config: %s\n", config->mMovieNameBuffer2);
-		return;
+		return 0;
 	}
 
 	int remaining = skip_timer + (max_cutscene_time * 1000.0f) - get_cur_time();
@@ -342,6 +335,10 @@ void Timer::stop_skip_timer(Game::MovieConfig* config)
 	main_timer -= remaining;
 	sub_timer -= remaining;
 	skip_timer_set = false;
+
+	// hand back the unwatched vanilla cutscene time we just compensated for, so timers that run on
+	// their own clock (e.g. race mode) can apply the same offset
+	return (u32)remaining;
 }
 
 void Timer::cancel_skip_timer()

--- a/src/plugProjectKandoU/singleGS_CaveGame.cpp
+++ b/src/plugProjectKandoU/singleGS_CaveGame.cpp
@@ -611,6 +611,11 @@ void CaveState::onMovieDone(Game::SingleGameSection* game, Game::MovieConfig* co
 			// @P2GZ - timer
 			// add offset for save prompt (to both timers!)
 			p2gz->timer->offset_main_timer(NEXT_SUBLEVEL_SAVE_OFFSET_TIME);
+
+			// the race timer runs on its own clock, so feed it the same skip compensation
+			if (p2gz->race_mode && p2gz->race_mode->is_active()) {
+				p2gz->race_mode->notify_save_skipped(NEXT_SUBLEVEL_SAVE_OFFSET_TIME);
+			}
 		}
 		mDrawSave = true;
 

--- a/src/plugProjectKandoU/singleGS_MainGame.cpp
+++ b/src/plugProjectKandoU/singleGS_MainGame.cpp
@@ -863,6 +863,11 @@ void GameState::onMovieDone(SingleGameSection* game, MovieConfig* config, u32, u
 			// @P2GZ - timer
 			// add offset for save prompt
 			p2gz->timer->offset_main_timer(CAVE_ENTER_SAVE_OFFSET_TIME);
+
+			// the race timer runs on its own clock, so feed it the same skip compensation
+			if (p2gz->race_mode && p2gz->race_mode->is_active()) {
+				p2gz->race_mode->notify_save_skipped(CAVE_ENTER_SAVE_OFFSET_TIME);
+			}
 		}
 		mInSaveScreen = true;
 

--- a/src/sysGCU/moviePlayer.cpp
+++ b/src/sysGCU/moviePlayer.cpp
@@ -921,7 +921,12 @@ void MoviePlayer::skip()
 	// update the timer if we skip the cutscene
 	// (+ handle weird intro cutscene skip sound stuff)
 	if (p2gz->skippable_cutscenes->is_skippable()) {
-		p2gz->timer->stop_skip_timer(mCurrentConfig);
+		u32 skipped_ms = p2gz->timer->stop_skip_timer(mCurrentConfig);
+
+		// the race timer runs on its own clock, so feed it the same skip compensation
+		if (p2gz->race_mode && p2gz->race_mode->is_active()) {
+			p2gz->race_mode->notify_cutscene_skipped(skipped_ms);
+		}
 
 		// re-enable pikmin sounds for intro skip
 		// this normally happens on the first textbox of the cutscene, but we skipped it


### PR DESCRIPTION
Fixes a bug with the race mode timer where it resets on cave exit/day end (like the main non-race-mode timer) - it now goes from beginning to end properly. Also fixes a crash in race mode when starting the run with save prompts on and entering a cave - it now uses the work-around when warping from file select as expected.