### PR TITLE
Misc preset bug + crash fixes

### DIFF
--- a/include/p2gz/SegmentHistory.h
+++ b/include/p2gz/SegmentHistory.h
@@ -57,7 +57,7 @@ private:
 	void draw_cur_seed();
 	void draw_reset_controls();
 
-	RingBuffer<32, Segment*> segments;
+	RingBuffer<16, Segment*> segments;
 	Preset* cave_floor0_preset;       // The current cave's floor-0 preset, ref'd so it survives ring buffer clearing
 	WarpDestination cave_floor0_dest; // area+cave the pinned preset belongs to
 };

--- a/include/p2gz/gzCollections.h
+++ b/include/p2gz/gzCollections.h
@@ -71,7 +71,8 @@ private:
 
 template <typename T>
 struct Vec {
-	Vec(size_t capacity = 8)
+	// doesn't allocate space until we need it
+	Vec(size_t capacity = 0)
 	{
 		mCapacity = capacity;
 		mLen      = 0;
@@ -97,7 +98,7 @@ struct Vec {
 	void push(T val)
 	{
 		if (mLen >= mCapacity) {
-			_grow(mCapacity * 2);
+			_grow(mCapacity == 0 ? 8 : mCapacity * 2);
 		}
 		GZASSERTLINE(mBuf);
 		mBuf[mLen] = val;
@@ -106,12 +107,12 @@ struct Vec {
 
 	int find(T val)
 	{
-		GZASSERTLINE(mBuf);
 		for (size_t i = 0; i < mLen; i++) {
 			if (mBuf[i] == val) {
 				return i;
 			}
 		}
+		// mBuf may be null for a never-pushed Vec
 		return -1;
 	}
 
@@ -159,7 +160,6 @@ struct Vec {
 	void extend(Vec<T>& other)
 	{
 		expandCapacityTo(len() + other.len());
-		GZASSERTLINE(mBuf);
 		for (size_t i = 0; i < other.len(); i++) {
 			push(other[i]);
 		}

--- a/include/p2gz/warp.h
+++ b/include/p2gz/warp.h
@@ -66,6 +66,8 @@ public:
 	bool using_set_seed() { return use_set_seed; }
 	u32 get_seed() { return seed; }
 
+	Game::PikiContainer preview_warp_squad();
+
 	void set_preset(PresetPreview* preset, int preset_status);
 	void set_preset(Preset* preset, int preset_status);
 	Preset* get_preset_during_warp()
@@ -107,6 +109,7 @@ private:
 	void warp_to_cave(Game::SingleGameSection* game);
 	void warp_to_area(Game::SingleGameSection* game);
 	void save_pikmin();
+	bool piki_warps_to_dest(Game::Piki* piki);
 	void reset_cave_treasure_collections(Game::SingleGameSection* game);
 
 	bool has_next_preset() { return next_preset_p != nullptr || next_preset != nullptr; }

--- a/src/p2gz/ekEditor.cpp
+++ b/src/p2gz/ekEditor.cpp
@@ -74,7 +74,7 @@ void EKEditor::check_upgrades()
 BitFlag<u16> EKEditor::get_upgrades_bitfield()
 {
 	BitFlag<u16> bitfield;
-	for (size_t i = Game::OlimarData::ODII_FIRST_EXPLORATION_KIT_ITEM; i < Game::OlimarData::ODII_LAST_EXPLORATION_KIT_ITEM; i++) {
+	for (size_t i = Game::OlimarData::ODII_FIRST_EXPLORATION_KIT_ITEM; i <= Game::OlimarData::ODII_LAST_EXPLORATION_KIT_ITEM; i++) {
 		const u16 mask = 1 << i;
 		if (playData->mOlimarData->hasItem(i)) {
 			bitfield.set(mask);
@@ -95,8 +95,8 @@ void EKEditor::set_upgrade(OlimarData::ItemIndex item, bool enabled)
 	} else {
 		bool validItem = item >= OlimarData::ODII_BruteKnuckles && item <= OlimarData::ODII_LAST_EXPLORATION_KIT_ITEM;
 		GZASSERTLINE(validItem);
-		int data_idx = item < 8 ? 0 : 1;
-		playData->mOlimarData->mFlags[data_idx] &= ~(1 << (item - (data_idx * 8)));
+		int data_idx = item >> 3;
+		playData->mOlimarData->mFlags[1 - data_idx] &= ~(1 << (item - (data_idx << 3)));
 
 		if (item == OlimarData::ODII_PrototypeDetector) {
 			Game::playData->mDemoFlags.resetFlag(Game::DEMO_RADAR_ENABLED);
@@ -106,7 +106,7 @@ void EKEditor::set_upgrade(OlimarData::ItemIndex item, bool enabled)
 
 void EKEditor::reset_all()
 {
-	for (int item = OlimarData::ODII_FIRST_EXPLORATION_KIT_ITEM; item < OlimarData::ODII_LAST_EXPLORATION_KIT_ITEM; item++) {
+	for (int item = OlimarData::ODII_FIRST_EXPLORATION_KIT_ITEM; item <= OlimarData::ODII_LAST_EXPLORATION_KIT_ITEM; item++) {
 		set_upgrade(static_cast<OlimarData::ItemIndex>(item), false);
 	}
 }

--- a/src/p2gz/preset.cpp
+++ b/src/p2gz/preset.cpp
@@ -335,7 +335,14 @@ void Preset::apply()
 	}
 
 	// Convert position-based StructureOverride data into per-area name-based state
-	// for use by reconstruct_generator_cache() during the upcoming load
+	// for use by reconstruct_generator_cache() during the upcoming load.
+	// clear area_states so it doesn't accumulate incorrectly across loads
+	for (int i = 0; i < 4; i++) {
+		area_states[i].destroyed_gates.clear();
+		area_states[i].finished_bridges.clear();
+		area_states[i].bags_flattened.clear();
+		area_states[i].plug_destroyed = false;
+	}
 	for (u32 i = 0; i < destroyed_gates.len(); i++) {
 		const StructureOverride& o = destroyed_gates[i];
 		const char* name           = p2gz->structure_editor->find_gate_name(o.position, o.area);

--- a/src/p2gz/presetMenu.cpp
+++ b/src/p2gz/presetMenu.cpp
@@ -182,7 +182,8 @@ void PresetMenuOption::draw(J2DPrint& j2d, f32& x, f32& z, bool selected)
 		draw_icon_row(j2d, icon_indent, z, current_preview->squad, current_preview->onion_pikis);
 	} else {
 		x += j2d.print(x, z, "current squad ");
-		Game::PikiContainer current_squad = p2gz->squad_editor->get_squad();
+		// only show pikmin that will actually warp (i.e. not wild pikmin, bulbmin, non-blues to SmC)
+		Game::PikiContainer current_squad = p2gz->warp->preview_warp_squad();
 		draw_icon_row(j2d, icon_indent, z, current_squad, Game::playData->mPikiContainer);
 	}
 

--- a/src/p2gz/presetMgr.cpp
+++ b/src/p2gz/presetMgr.cpp
@@ -224,7 +224,8 @@ Preset* PresetMgr::load_preset(PresetPreview* preview)
 	}
 
 	for (u32 i = 0; i < presets.len(); i++) {
-		if (presets[i]->name == preview->name) {
+		if (presets[i]->category == preview->category && strcmp(presets[i]->name, preview->name) == 0) {
+			presets[i]->ref();
 			return presets[i];
 		}
 	}
@@ -236,6 +237,7 @@ Preset* PresetMgr::load_preset(PresetPreview* preview)
 	preset->read_file(preview->filename);
 	preset->preview = preview;
 	presets.push(preset);
+	preset->ref();
 
 	prev_heap->becomeCurrentHeap();
 	return preset;

--- a/src/p2gz/warp.cpp
+++ b/src/p2gz/warp.cpp
@@ -447,6 +447,20 @@ void Warp::reset_cave_treasure_collections(Game::SingleGameSection* game)
 	}
 }
 
+// would this piki actually warp to the current destination?
+bool Warp::piki_warps_to_dest(Game::Piki* piki)
+{
+	// no dead pikmin, wild pikmin, wild bulbmin, tamed bulbmin
+	if (!piki->isAlive() || piki->isZikatu() || !piki->isPikmin() || piki->getKind() == Game::Bulbmin) {
+		return false;
+	}
+	// only blues allowed in SmC
+	if (dest.area == 2 && dest.cave == 4 && piki->getKind() != Game::Blue) {
+		return false;
+	}
+	return true;
+}
+
 void Warp::save_pikmin()
 {
 	// clear cave piki container so we don't double up
@@ -462,16 +476,33 @@ void Warp::save_pikmin()
 			Game::PikiKillArg killArg(Game::CKILL_DontCountAsDeath);
 			piki->kill(&killArg);
 		}
-		//                      vvvvvvvvvvvvvvvv <- make sure we don't bring wild pikmin
-		if (piki->isAlive() && !piki->isZikatu() && piki->isPikmin()) {
-			// Don't bring non-blues into SmC
-			if (!(dest.area == 2 && dest.cave == 4) || piki->getKind() == Game::Blue) {
-				Game::playData->mCaveSaveData.mCavePikis(piki)++;
-				Game::PikiKillArg arg(Game::CKILL_DontCountAsDeath);
-				piki->kill(&arg);
-			}
+		if (piki_warps_to_dest(piki)) {
+			Game::playData->mCaveSaveData.mCavePikis(piki)++;
+			Game::PikiKillArg arg(Game::CKILL_DontCountAsDeath);
+			piki->kill(&arg);
 		}
 	}
+}
+
+// get the pikmin that would warp to the current destination, for the menu's squad preview
+Game::PikiContainer Warp::preview_warp_squad()
+{
+	Game::PikiContainer squad;
+
+	// managers don't exist until a level loads (e.g. menu opened from file-select)
+	if (!Game::pikiMgr) {
+		return squad;
+	}
+
+	Iterator<Game::Piki> iterator(Game::pikiMgr);
+	CI_LOOP(iterator)
+	{
+		Game::Piki* piki = *iterator;
+		if (piki_warps_to_dest(piki)) {
+			squad.getCount(piki->mPikiKind, piki->mHappaKind)++;
+		}
+	}
+	return squad;
 }
 
 void Warp::warp_to_cave(Game::SingleGameSection* game)


### PR DESCRIPTION
Fixes a few bugs with presets and warping:
- Fixes a memory crash after playing and warping for a certain amount of time by reducing preset and segment history ring buffer size
- Fixes a bug where wild pikmin and bulbmin would incorrectly show up in the squad preview when selecting "no preset"
- Fixes a bug where warping to a preset with a lot of upgrades, then warping back to an earlier preset did not disable the upgrades correctly