### PR TITLE
Disable skipping breadbug cutscenes until it's been damaged

### DIFF
--- a/include/p2gz/SkippableCS.h
+++ b/include/p2gz/SkippableCS.h
@@ -1,9 +1,12 @@
 #ifndef _GZ_SKIPPABLECS_H
 #define _GZ_SKIPPABLECS_H
 
+#include <types.h>
+
 // predeclarations
 namespace Game {
 struct Creature;
+struct EnemyBase;
 struct MovieConfig;
 } // namespace Game
 
@@ -15,6 +18,8 @@ public:
 	    : enabled(true)
 	    , is_treasure_collected(false)
 	    , start_press_reason(nullptr)
+	    , breadbug(nullptr)
+	    , breadbug_start_health(0.0f)
 	{
 	}
 
@@ -31,6 +36,9 @@ public:
 	// if we're in the right cutscene, make cutscene skippable
 	void prime_skip(Game::Creature* cutscene_target, Game::MovieConfig* config);
 
+	// check when we can skip a cutscene that involves a breadbug
+	void update_breadbug_lockout();
+
 	// keep track of why we hit start/"paused" the game, so we know when we're skipping a cutscene
 	void record_start_press(char* start_press_reason_) { start_press_reason = start_press_reason_; }
 
@@ -38,6 +46,9 @@ private:
 	bool enabled;
 	bool is_treasure_collected;
 	char* start_press_reason; // to know when we're Actually Skipping
+
+	Game::EnemyBase* breadbug; // breadbug attached to treasure in this cutscene
+	f32 breadbug_start_health; // breadbug reference health (from cutscene start)
 };
 
 }; // namespace gz

--- a/src/p2gz/skippableCS.cpp
+++ b/src/p2gz/skippableCS.cpp
@@ -79,8 +79,8 @@ void SkippableCutscenes::update_breadbug_lockout()
 		return;
 	}
 
-	// unlock skipping once the breadbug has taken damage in the cutscene
-	if (breadbug->mHealth < breadbug_start_health) {
+	// unlock skipping once the breadbug has taken damage in the cutscene (or has died)
+	if (!breadbug->isEvent(0, EB_Alive) || breadbug->isDead() || breadbug->mHealth < breadbug_start_health) {
 		if (moviePlayer->mCurrentConfig) {
 			moviePlayer->mCurrentConfig->enableSkippableWithStart();
 		}
@@ -123,11 +123,11 @@ void SkippableCutscenes::prime_skip(Creature* cutscene_target, MovieConfig* conf
 			p2gz->timer->reset_skip_timer();
 
 			// prevent a cutscene from being skippable if it has a breadbug in it, until the breadbug has been damaged properly
-			EnemyBase* breadbug = find_attached_breadbug(cutscene_target);
-			if (breadbug) {
+			EnemyBase* attached = find_attached_breadbug(cutscene_target);
+			if (attached) {
 				config->disableSkippable();
-				breadbug              = breadbug;
-				breadbug_start_health = breadbug->mHealth;
+				breadbug              = attached;
+				breadbug_start_health = attached->mHealth;
 			} else {
 				config->enableSkippableWithStart();
 			}

--- a/src/p2gz/skippableCS.cpp
+++ b/src/p2gz/skippableCS.cpp
@@ -3,9 +3,38 @@
 #include <Game/pelletMgr.h>
 #include <Game/Interaction.h>
 #include <Game/Entities/ItemOnyon.h>
+#include <Game/EnemyBase.h>
+#include <Game/enemyInfo.h>
 
 using namespace gz;
 using namespace Game;
+
+// find the breadbug attached to this treasure, if any
+static EnemyBase* find_attached_breadbug(Creature* treasure)
+{
+	if (!treasure) {
+		return nullptr;
+	}
+
+	for (Creature* sticker = treasure->mSticked; sticker; sticker = sticker->mCaptured) {
+		if (sticker->isTeki()) {
+			EnemyBase* enemy = static_cast<EnemyBase*>(sticker);
+			if (enemy->getEnemyTypeID() == EnemyTypeID::EnemyID_PanModoki || enemy->getEnemyTypeID() == EnemyTypeID::EnemyID_OoPanModoki) {
+				return enemy;
+			}
+		}
+	}
+
+	return nullptr;
+}
+
+// are we currently in one of the treasure/item collection cutscenes?
+static bool is_suck_movie_playing()
+{
+	return moviePlayer
+	    && (moviePlayer->isPlaying("s22_cv_suck_treasure") || moviePlayer->isPlaying("s22_cv_suck_equipment")
+	        || moviePlayer->isPlaying("s10_suck_treasure") || moviePlayer->isPlaying("s17_suck_equipment"));
+}
 
 void SkippableCutscenes::force_collect(Game::Creature* cutscene_target)
 {
@@ -38,6 +67,27 @@ void SkippableCutscenes::force_collect(Game::Creature* cutscene_target)
 	}
 }
 
+void SkippableCutscenes::update_breadbug_lockout()
+{
+	if (!enabled || !breadbug) {
+		return;
+	}
+
+	// if the cutscene is no longer running, unlock it so we don't end up with stale shit
+	if (!is_suck_movie_playing()) {
+		breadbug = nullptr;
+		return;
+	}
+
+	// unlock skipping once the breadbug has taken damage in the cutscene
+	if (breadbug->mHealth < breadbug_start_health) {
+		if (moviePlayer->mCurrentConfig) {
+			moviePlayer->mCurrentConfig->enableSkippableWithStart();
+		}
+		breadbug = nullptr;
+	}
+}
+
 void SkippableCutscenes::prime_skip(Creature* cutscene_target, MovieConfig* config)
 {
 	if (!config) {
@@ -65,12 +115,22 @@ void SkippableCutscenes::prime_skip(Creature* cutscene_target, MovieConfig* conf
 	// toggle cave and above ground treasure cutscenes skippable
 	if (config->is("s22_cv_suck_treasure") || config->is("s22_cv_suck_equipment") || config->is("s10_suck_treasure")
 	    || config->is("s17_suck_equipment")) {
+		breadbug = nullptr;
 		if (enabled) {
 			is_treasure_collected = false;
-			config->enableSkippableWithStart();
 
 			// set skip timer
 			p2gz->timer->reset_skip_timer();
+
+			// prevent a cutscene from being skippable if it has a breadbug in it, until the breadbug has been damaged properly
+			EnemyBase* breadbug = find_attached_breadbug(cutscene_target);
+			if (breadbug) {
+				config->disableSkippable();
+				breadbug              = breadbug;
+				breadbug_start_health = breadbug->mHealth;
+			} else {
+				config->enableSkippableWithStart();
+			}
 
 			// TODO: this is where we'd also record the treasure being collected for the purposes of collection statistics
 		} else {

--- a/src/plugProjectKandoU/singleGS_CaveGame.cpp
+++ b/src/plugProjectKandoU/singleGS_CaveGame.cpp
@@ -145,6 +145,8 @@ void CaveState::exec(SingleGameSection* game)
 	// @P2GZ: skippable treasure cutscenes
 	// force collect treasure during cutscene if conditions are met
 	p2gz->skippable_cutscenes->force_collect(game->mDraw2DCreature);
+	// open a breadbug treasure cutscene to skipping once the breadbug has been damaged
+	p2gz->skippable_cutscenes->update_breadbug_lockout();
 
 	// the saving between cave floors is part of this state
 	if (mDrawSave) {

--- a/src/plugProjectKandoU/singleGS_MainGame.cpp
+++ b/src/plugProjectKandoU/singleGS_MainGame.cpp
@@ -436,6 +436,8 @@ void GameState::exec(SingleGameSection* game)
 	// @P2GZ: skippable treasure cutscenes
 	// force collect treasure during cutscene if conditions are met
 	p2gz->skippable_cutscenes->force_collect(game->mDraw2DCreature);
+	// open a breadbug treasure cutscene to skipping once the breadbug has been damaged
+	p2gz->skippable_cutscenes->update_breadbug_lockout();
 
 	// when you enter a cave from above ground, this state is still technically active until after the game saves
 	if (mInSaveScreen) {


### PR DESCRIPTION
If "skippable cutscenes" is turned on in settings, players can get in the habit of mashing start to skip the cutscene during gameplay. However, doing so for cutscenes involving a breadbug results in them not being damaged successfully. This makes it so cutscenes involving breadbugs attached the the target treasure are locked from skipping, with the lock being removed once the damage is applied to the breadbug successfully (when it hits the ground).

This does cause some deviation from vanilla behaviour if skipped, since the breadbug would normally be active during the cutscene, and would start seeking out a new target - skipping interrupts this. This only really matters on GK6 during PoD, so the decision is just left up to the player on whether to skip and deviate from the new pathfinding behaviour, or not - it just prevents them from accidentally doing so before they can think it through. I think this is a good balance between preventing mistakes and not taking away player agency.