### PR TITLE
Make crash log appear much faster

### DIFF
--- a/build.py
+++ b/build.py
@@ -168,6 +168,9 @@ if args.map:
     with open("root/files/pikmin2UP.map", "w") as f:
         f.writelines(lines)
 
+    # build the custom compact crash-handler symbol table from the map
+    subprocess.run("python3 tools/gen_crash_symbols.py", shell=True)
+
 
 print(f"Done! Build took {round(time.time() - start_time, 2)}s")
 

--- a/include/p2gz/crashSymbols.h
+++ b/include/p2gz/crashSymbols.h
@@ -1,0 +1,19 @@
+#ifndef _GZ_CRASH_SYMBOLS_H
+#define _GZ_CRASH_SYMBOLS_H
+
+#include <types.h>
+
+struct JUTConsole;
+
+namespace gz {
+
+/// Resolve a code/data address to a symbol using the precomputed ``/pikmin2UP.sym``
+/// table (built by tools/gen_crash_symbols.py) and print it to `console`.
+/// @return  1 = address resolved and printed
+///          0 = .sym is available but no symbol contains `address` (fast miss)
+///         -1 = .sym unavailable (caller should fall back to the legacy .map scan)
+int crashSymbolsTryPrint(JUTConsole* console, u32 address, bool beginWithNewline);
+
+} // namespace gz
+
+#endif

--- a/include/p2gz/crashSymbols.h
+++ b/include/p2gz/crashSymbols.h
@@ -7,11 +7,7 @@ struct JUTConsole;
 
 namespace gz {
 
-/// Resolve a code/data address to a symbol using the precomputed ``/pikmin2UP.sym``
-/// table (built by tools/gen_crash_symbols.py) and print it to `console`.
-/// @return  1 = address resolved and printed
-///          0 = .sym is available but no symbol contains `address` (fast miss)
-///         -1 = .sym unavailable (caller should fall back to the legacy .map scan)
+// resolve a code/data address to a symbol using the precomputed `/pikmin2UP.sym` table + print to console
 int crashSymbolsTryPrint(JUTConsole* console, u32 address, bool beginWithNewline);
 
 } // namespace gz

--- a/release.py
+++ b/release.py
@@ -33,6 +33,7 @@ files_to_copy = [
     "root/sys/main.dol",
     "root/sys/boot.bin",
     "root/files/pikmin2UP.map",
+    "root/files/pikmin2UP.sym",
     "root/files/opening.bnr",
     "root/files/banner",
     "root/files/memoryCard/memoryCardHeader.szs",

--- a/src/JSystem/JUtility/JUTException.cpp
+++ b/src/JSystem/JUtility/JUTException.cpp
@@ -14,6 +14,7 @@
 #include "JSystem/JUtility/JUTGamePad.h"
 #include "stl/stdlib.h"
 #include "types.h"
+#include <p2gz/crashSymbols.h> // @P2GZ: fast crash log
 
 static JUTException::ExCallbackObject exCallbackObject;
 
@@ -330,7 +331,10 @@ void JUTException::showStack(OSContext* context)
 		sConsole->print_f("%08X:  %08X    %08X\n", stack, stack[0], stack[1]);
 		showMapInfo_subroutine(stack[1], false);
 		JUTConsoleManager* manager = JUTConsoleManager::sManager;
-		manager->drawDirect(true);
+		// @P2GZ: fast crash log
+		// draw without waiting a full VI retrace per line for Speed
+		// manager->drawDirect(true);
+		manager->drawDirect(false);
 		waitTime(mPrintWaitTime1);
 		stack = (u32*)stack[0];
 	}
@@ -447,6 +451,15 @@ bool JUTException::showMapInfo_subroutine(u32 address, bool begin_with_newline)
 		begin_with_newline = false;
 	}
 
+	// @P2GZ: fast crash log
+	// resolve addresses using the custom lookup table, instead of scanning the 4.2MB map for every bloody line lol
+	if (result == false) {
+		int symResult = gz::crashSymbolsTryPrint(sConsole, address, begin_with_newline);
+		if (symResult >= 0) {
+			return symResult == 1;
+		}
+	}
+
 	if (sMapFileList.getFirst() != sMapFileList.getEnd()) {
 		u32 out_addr;
 		u32 out_size;
@@ -493,7 +506,10 @@ void JUTException::showGPRMap(OSContext* context)
 			if (!res) { // inlined
 				sConsole->print("  no information\n");
 			}
-			JUTConsoleManager::getManager()->drawDirect(true);
+			// @P2GZ: fast crash log
+			// skip the per-line retrace wait
+			// JUTConsoleManager::getManager()->drawDirect(true);
+			JUTConsoleManager::getManager()->drawDirect(false);
 			waitTime(mPrintWaitTime1);
 		}
 	}

--- a/src/p2gz/crashSymbols.cpp
+++ b/src/p2gz/crashSymbols.cpp
@@ -1,0 +1,220 @@
+#include <p2gz/crashSymbols.h>
+#include <types.h>
+#include <Dolphin/dvd.h>
+#include <Dolphin/os.h>
+#include <JSystem/JUtility/JUTConsole.h>
+
+// Fast crash-handler symbol lookup. See tools/gen_crash_symbols.py.
+
+namespace gz {
+
+namespace {
+
+// ---- .sym layout (must match tools/gen_crash_symbols.py) ----
+const u32 SYM_MAGIC    = 'P2GZ';
+const u32 SYM_VERSION  = 1;
+const s32 HEADER_BLOCK = 512; // header + section-name table live in this first block
+const u32 ENTRY_SIZE   = 16;  // {u32 vaddr, size, nameOff, sectionId}
+const s32 INDEX_BLOCK  = 512; // index read/cache granularity (multiple of ENTRY_SIZE)
+const int MAX_SECTIONS = 16;
+const int MAX_NAME     = 80;  // display cap; long C++ names wrap on the console anyway
+const s32 NAME_BUF     = 192; // scratch for one aligned name read
+
+enum State { STATE_UNINIT, STATE_READY, STATE_FAILED };
+
+State sState = STATE_UNINIT;
+DVDFileInfo sFile;
+u32 sCount;
+u32 sIndexOffset;
+u32 sStringsOffset;
+u32 sFileLength;
+int sSectionCount;
+char* sSectionName[MAX_SECTIONS];
+
+// 32-byte-aligned scratch (over-allocate then align, like JUTDirectFile::mSectorStart)
+u8 sHeaderRaw[HEADER_BLOCK + 32];
+u8 sBlockRaw[INDEX_BLOCK + 32];
+u8 sNameRaw[NAME_BUF + 32];
+u8* sHeaderBuf;
+u8* sBlockBuf;
+u8* sNameBuf;
+u32 sCachedBlockOff; // file offset of the index block in sBlockBuf, or 0xFFFFFFFF
+
+inline u8* align32(u8* p)
+{
+	return (u8*)ALIGN_NEXT((u32)p, 32);
+}
+inline u32 rd32(const u8* p)
+{
+	return *(const u32*)p;
+}
+
+// Synchronous aligned DVD read. offset, length and dst must be 32-aligned.
+bool readAligned(u32 offset, void* dst, s32 length)
+{
+	BOOL enabled = OSEnableInterrupts();
+	BOOL ok      = DVDReadAsync(&sFile, dst, length, (s32)offset, nullptr);
+	if (ok) {
+		while (DVDGetCommandBlockStatus(&sFile.cBlock)) {
+			;
+		}
+	}
+	OSRestoreInterrupts(enabled);
+	return ok != 0;
+}
+
+bool readEntry(u32 i, u32* vaddr, u32* size, u32* nameOff, u32* sectionId)
+{
+	u32 byteOff  = sIndexOffset + i * ENTRY_SIZE;
+	u32 blockOff = ALIGN_PREV(byteOff, INDEX_BLOCK);
+	if (blockOff != sCachedBlockOff) {
+		if (!readAligned(blockOff, sBlockBuf, INDEX_BLOCK)) {
+			return false;
+		}
+		sCachedBlockOff = blockOff;
+	}
+	const u8* e = sBlockBuf + (byteOff - blockOff);
+	*vaddr      = rd32(e + 0);
+	*size       = rd32(e + 4);
+	*nameOff    = rd32(e + 8);
+	*sectionId  = rd32(e + 12);
+	return true;
+}
+
+// Read one symbol name from the string blob into `out`.
+void readName(u32 nameOff, char* out, int outCap)
+{
+	out[0]      = '\0';
+	u32 fileOff = sStringsOffset + nameOff;
+	if (fileOff >= sFileLength) {
+		return;
+	}
+
+	u32 alignOff = ALIGN_PREV(fileOff, 32);
+	u32 delta    = fileOff - alignOff;
+	s32 readLen  = (s32)ALIGN_NEXT(delta + (u32)outCap, 32);
+	if (readLen > NAME_BUF) {
+		readLen = NAME_BUF;
+	}
+	// keep the read within the file's sector-rounded extent
+	u32 fileEnd = ALIGN_NEXT(sFileLength, 32);
+	if (alignOff + (u32)readLen > fileEnd) {
+		readLen = (s32)(fileEnd - alignOff);
+	}
+	if (readLen <= (s32)delta) {
+		return;
+	}
+	if (!readAligned(alignOff, sNameBuf, readLen)) {
+		return;
+	}
+
+	const char* src = (const char*)sNameBuf + delta;
+	int max         = readLen - (int)delta;
+	if (max > outCap - 1) {
+		max = outCap - 1;
+	}
+	int i = 0;
+	for (; i < max && src[i] != '\0'; i++) {
+		out[i] = src[i];
+	}
+	out[i] = '\0';
+}
+
+bool init()
+{
+	BOOL enabled = OSEnableInterrupts();
+	BOOL opened  = DVDOpen((char*)"/pikmin2UP.sym", &sFile);
+	OSRestoreInterrupts(enabled);
+	if (!opened) {
+		return false;
+	}
+	sFileLength = sFile.length;
+
+	sHeaderBuf      = align32(sHeaderRaw);
+	sBlockBuf       = align32(sBlockRaw);
+	sNameBuf        = align32(sNameRaw);
+	sCachedBlockOff = 0xFFFFFFFF;
+
+	if (!readAligned(0, sHeaderBuf, HEADER_BLOCK)) {
+		return false;
+	}
+	if (rd32(sHeaderBuf + 0) != SYM_MAGIC || rd32(sHeaderBuf + 4) != SYM_VERSION) {
+		return false;
+	}
+	sCount         = rd32(sHeaderBuf + 8);
+	sIndexOffset   = rd32(sHeaderBuf + 12);
+	sStringsOffset = rd32(sHeaderBuf + 16);
+	sSectionCount  = (int)rd32(sHeaderBuf + 20);
+	if (sCount == 0 || sSectionCount <= 0 || sSectionCount > MAX_SECTIONS) {
+		return false;
+	}
+
+	// section-name table: sSectionCount amount of strings starting at 0x20
+	char* p   = (char*)sHeaderBuf + 0x20;
+	char* end = (char*)sHeaderBuf + HEADER_BLOCK;
+	for (int s = 0; s < sSectionCount; s++) {
+		sSectionName[s] = p;
+		while (p < end && *p != '\0') {
+			p++;
+		}
+		if (p >= end) {
+			return false; // bad table
+		}
+		p++;
+	}
+	return true;
+}
+
+} // namespace
+
+int crashSymbolsTryPrint(JUTConsole* console, u32 address, bool beginWithNewline)
+{
+	if (sState == STATE_UNINIT) {
+		sState = init() ? STATE_READY : STATE_FAILED;
+	}
+	if (sState != STATE_READY) {
+		return -1;
+	}
+
+	// binary search for the entry with the greatest start address <= `address`
+	s32 lo  = 0;
+	s32 hi  = (s32)sCount - 1;
+	s32 res = -1;
+	u32 vaddr;
+	u32 size;
+	u32 nameOff;
+	u32 sectionId;
+	while (lo <= hi) {
+		s32 mid = (lo + hi) >> 1;
+		if (!readEntry((u32)mid, &vaddr, &size, &nameOff, &sectionId)) {
+			return -1; // disc error -> let the caller fall back
+		}
+		if (vaddr <= address) {
+			res = mid;
+			lo  = mid + 1;
+		} else {
+			hi = mid - 1;
+		}
+	}
+	if (res < 0) {
+		return 0;
+	}
+	if (!readEntry((u32)res, &vaddr, &size, &nameOff, &sectionId)) {
+		return -1;
+	}
+	if (address >= vaddr + size) {
+		return 0; // falls in a gap between symbols
+	}
+
+	char name[MAX_NAME + 1];
+	readName(nameOff, name, sizeof(name));
+	const char* section = (sectionId < (u32)sSectionCount) ? sSectionName[sectionId] : "?";
+
+	if (beginWithNewline) {
+		console->print("\n");
+	}
+	console->print_f("  [%08X]: %s [%08X: %XH]\n  %s +%XH\n", address, section, vaddr, size, name, address - vaddr);
+	return 1;
+}
+
+} // namespace gz

--- a/src/p2gz/crashSymbols.cpp
+++ b/src/p2gz/crashSymbols.cpp
@@ -4,21 +4,21 @@
 #include <Dolphin/os.h>
 #include <JSystem/JUtility/JUTConsole.h>
 
-// Fast crash-handler symbol lookup. See tools/gen_crash_symbols.py.
+// Fast crash log symbol lookup (see tools/gen_crash_symbols.py)
 
 namespace gz {
 
 namespace {
 
-// ---- .sym layout (must match tools/gen_crash_symbols.py) ----
+// .sym layout (to match what tools/gen_crash_symbols.py generates)
 const u32 SYM_MAGIC    = 'P2GZ';
 const u32 SYM_VERSION  = 1;
-const s32 HEADER_BLOCK = 512; // header + section-name table live in this first block
-const u32 ENTRY_SIZE   = 16;  // {u32 vaddr, size, nameOff, sectionId}
-const s32 INDEX_BLOCK  = 512; // index read/cache granularity (multiple of ENTRY_SIZE)
+const s32 HEADER_BLOCK = 512;
+const u32 ENTRY_SIZE   = 16;
+const s32 INDEX_BLOCK  = 512;
 const int MAX_SECTIONS = 16;
-const int MAX_NAME     = 80;  // display cap; long C++ names wrap on the console anyway
-const s32 NAME_BUF     = 192; // scratch for one aligned name read
+const int MAX_NAME     = 80;
+const s32 NAME_BUF     = 192;
 
 enum State { STATE_UNINIT, STATE_READY, STATE_FAILED };
 
@@ -31,25 +31,25 @@ u32 sFileLength;
 int sSectionCount;
 char* sSectionName[MAX_SECTIONS];
 
-// 32-byte-aligned scratch (over-allocate then align, like JUTDirectFile::mSectorStart)
 u8 sHeaderRaw[HEADER_BLOCK + 32];
 u8 sBlockRaw[INDEX_BLOCK + 32];
 u8 sNameRaw[NAME_BUF + 32];
 u8* sHeaderBuf;
 u8* sBlockBuf;
 u8* sNameBuf;
-u32 sCachedBlockOff; // file offset of the index block in sBlockBuf, or 0xFFFFFFFF
+u32 sCachedBlockOff;
 
 inline u8* align32(u8* p)
 {
 	return (u8*)ALIGN_NEXT((u32)p, 32);
 }
-inline u32 rd32(const u8* p)
+
+inline u32 read32(const u8* p)
 {
 	return *(const u32*)p;
 }
 
-// Synchronous aligned DVD read. offset, length and dst must be 32-aligned.
+// synchronous aligned DVD read (NB: offset, length and dst need to be 32-aligned)
 bool readAligned(u32 offset, void* dst, s32 length)
 {
 	BOOL enabled = OSEnableInterrupts();
@@ -74,14 +74,14 @@ bool readEntry(u32 i, u32* vaddr, u32* size, u32* nameOff, u32* sectionId)
 		sCachedBlockOff = blockOff;
 	}
 	const u8* e = sBlockBuf + (byteOff - blockOff);
-	*vaddr      = rd32(e + 0);
-	*size       = rd32(e + 4);
-	*nameOff    = rd32(e + 8);
-	*sectionId  = rd32(e + 12);
+	*vaddr      = read32(e + 0);
+	*size       = read32(e + 4);
+	*nameOff    = read32(e + 8);
+	*sectionId  = read32(e + 12);
 	return true;
 }
 
-// Read one symbol name from the string blob into `out`.
+// read one symbol name into `out`
 void readName(u32 nameOff, char* out, int outCap)
 {
 	out[0]      = '\0';
@@ -96,7 +96,7 @@ void readName(u32 nameOff, char* out, int outCap)
 	if (readLen > NAME_BUF) {
 		readLen = NAME_BUF;
 	}
-	// keep the read within the file's sector-rounded extent
+
 	u32 fileEnd = ALIGN_NEXT(sFileLength, 32);
 	if (alignOff + (u32)readLen > fileEnd) {
 		readLen = (s32)(fileEnd - alignOff);
@@ -138,13 +138,13 @@ bool init()
 	if (!readAligned(0, sHeaderBuf, HEADER_BLOCK)) {
 		return false;
 	}
-	if (rd32(sHeaderBuf + 0) != SYM_MAGIC || rd32(sHeaderBuf + 4) != SYM_VERSION) {
+	if (read32(sHeaderBuf + 0) != SYM_MAGIC || read32(sHeaderBuf + 4) != SYM_VERSION) {
 		return false;
 	}
-	sCount         = rd32(sHeaderBuf + 8);
-	sIndexOffset   = rd32(sHeaderBuf + 12);
-	sStringsOffset = rd32(sHeaderBuf + 16);
-	sSectionCount  = (int)rd32(sHeaderBuf + 20);
+	sCount         = read32(sHeaderBuf + 8);
+	sIndexOffset   = read32(sHeaderBuf + 12);
+	sStringsOffset = read32(sHeaderBuf + 16);
+	sSectionCount  = (int)read32(sHeaderBuf + 20);
 	if (sCount == 0 || sSectionCount <= 0 || sSectionCount > MAX_SECTIONS) {
 		return false;
 	}
@@ -187,7 +187,7 @@ int crashSymbolsTryPrint(JUTConsole* console, u32 address, bool beginWithNewline
 	while (lo <= hi) {
 		s32 mid = (lo + hi) >> 1;
 		if (!readEntry((u32)mid, &vaddr, &size, &nameOff, &sectionId)) {
-			return -1; // disc error -> let the caller fall back
+			return -1;
 		}
 		if (vaddr <= address) {
 			res = mid;
@@ -203,7 +203,7 @@ int crashSymbolsTryPrint(JUTConsole* console, u32 address, bool beginWithNewline
 		return -1;
 	}
 	if (address >= vaddr + size) {
-		return 0; // falls in a gap between symbols
+		return 0;
 	}
 
 	char name[MAX_NAME + 1];

--- a/tools/gen_crash_symbols.py
+++ b/tools/gen_crash_symbols.py
@@ -1,32 +1,27 @@
 #!/usr/bin/env python3
-"""Generate a compact binary symbol table for the in-game crash handler.
+"""Generate a compact binary symbol table for the crash log, to resolve addresses faster.
 
-The exception handler (JUTException) used to resolve every stack-frame / register
-address by re-opening the 4.2 MB ``pikmin2UP.map`` and linearly scanning it from
-disc *for each address* - dozens of full-file scans per crash. This tool turns the
-map into ``pikmin2UP.sym``: a sorted, binary, big-endian table that the runtime can
-binary-search with a handful of tiny disc reads (see src/p2gz/crashSymbols.cpp).
+(See p2gz/crashSymbols.cpp)
 
-Format:
+Table format:
 
   header block, padded to HEADER_BLOCK (512 bytes), 32-byte-aligned start of file:
-    0x00 u32 magic            = 'P2GZ'
-    0x04 u32 version          = 1
-    0x08 u32 count            = number of symbol entries
-    0x0C u32 index_offset     = file offset of the entry array (== HEADER_BLOCK)
-    0x10 u32 strings_offset   = file offset of the string blob
-    0x14 u32 section_count
-    0x18 u32 reserved (0)
-    0x1C u32 reserved (0)
-    0x20 ...   section-name table: section_count null-terminated names
+    _00 u32 magic            = 'P2GZ'
+    _04 u32 version          = 1
+    _08 u32 count            = number of symbol entries
+    _0C u32 index_offset     = file offset of the entry array (== HEADER_BLOCK)
+    _10 u32 strings_offset   = file offset of the string blob
+    _14 u32 section_count
+    _18 u32 reserved (0)
+    _1C u32 reserved (0)
+    _20 ...   section-name table: section_count null-terminated names
   index array (at index_offset, 32-aligned): `count` entries, 16 bytes each,
-    sorted ascending by vaddr (16 divides 512 and 32 -> every entry sits inside a
-    single aligned disc block, so the runtime can read one block per probe):
-      0x00 u32 vaddr
-      0x04 u32 size
-      0x08 u32 name_off     (offset from strings_offset)
-      0x0C u32 section_id   (index into the section-name table)
-  string blob (at strings_offset): deduplicated null-terminated symbol names.
+    sorted ascending by vaddr:
+      _00 u32 vaddr
+      _04 u32 size
+      _08 u32 name_off     (offset from strings_offset)
+      _0C u32 section_id   (index into the section-name table)
+  string blob (at strings_offset): deduplicated null-terminated symbol names
 """
 
 import argparse
@@ -37,10 +32,10 @@ import sys
 
 MAGIC = 0x5032475A  # 'P2GZ'
 VERSION = 1
-HEADER_BLOCK = 512  # header + section table live in this first (aligned) block
+HEADER_BLOCK = 512
 ENTRY_SIZE = 16
 
-# Matches a real symbol line, e.g.
+# Regex to pull out a real symbol line from the map, e.g.
 #   "  00000030 000024 80003130  4 TRK_memcpy \tmem_TRK.o"
 # groups: file-offset, size, vaddr, alignment, rest(symbol [+ \tobject])
 _SYM_RE = re.compile(r"^\s+([0-9a-fA-F]{8})\s+([0-9a-fA-F]{6})\s+([0-9a-fA-F]{8})\s+\d+\s+(.*)$")
@@ -50,8 +45,8 @@ _SECTION_RE = re.compile(r"^(\S[\w.$]*) section layout")
 def parse_map(map_path):
     """Return (entries, section_names).
 
-    entries: list of (vaddr, size, name, section_id), unsorted.
-    section_names: list of section names indexed by section_id.
+    entries: list of (vaddr, size, name, section_id), unsorted
+    section_names: list of section names indexed by section_id
     """
     section_names = []
     section_id_of = {}
@@ -62,8 +57,7 @@ def parse_map(map_path):
         for line in f:
             line = line.rstrip("\n")
 
-            # The post-layout summary ("Memory map:", "Linker generated symbols:")
-            # is not symbol data - stop before we start mis-parsing it.
+            # "Memory map:" + "Linker generated symbols:" are junk, ignore
             if line.startswith("Memory map") or line.startswith("Linker generated"):
                 break
 
@@ -82,14 +76,13 @@ def parse_map(map_path):
             size_hex, vaddr_hex, rest = m.group(2), m.group(3), m.group(4)
             size = int(size_hex, 16)
             if size == 0:
-                continue  # entry-of-section labels and other zero-size markers
+                # entry-of-section labels and other zero-size markers
+                continue
 
-            # The symbol token is everything up to the tab/object-file or first space.
             name = rest.split("\t")[0].strip().split(" ")[0]
             if not name:
                 continue
-            # Section-contribution lines repeat the section name as the "symbol";
-            # skip them so they don't shadow the real per-symbol entries.
+            # section-contribution lines repeat the section name as the symbol, ignore
             if name == current_section:
                 continue
 
@@ -107,7 +100,7 @@ def parse_map(map_path):
 
 
 def dedup_by_vaddr(entries):
-    """Keep one entry per vaddr (the smallest size = most specific symbol)."""
+    """Keep one entry per vaddr"""
     best = {}
     for vaddr, size, name, sid in entries:
         prev = best.get(vaddr)
@@ -119,7 +112,7 @@ def dedup_by_vaddr(entries):
 
 
 def build_blob(entries):
-    """Build the deduplicated string blob; return (blob_bytes, name_off_of)."""
+    """Build deduplicated string blob - return (blob_bytes, name_off_of)"""
     blob = bytearray()
     name_off_of = {}
     for _, _, name, _ in entries:
@@ -130,7 +123,7 @@ def build_blob(entries):
 
 
 def build_section_table(section_names):
-    """Pack section names as null-terminated strings + assert they fit the header."""
+    """Safely pack section names as null-terminated strings"""
     table = bytearray()
     for s in section_names:
         table += s.encode("latin-1") + b"\x00"
@@ -148,7 +141,7 @@ def write_sym(out_path, entries, section_names):
     count = len(entries)
     index_offset = HEADER_BLOCK
     strings_offset = index_offset + count * ENTRY_SIZE
-    # 32-align the string blob so the runtime's aligned name reads stay simple.
+    # functions expect 32-bit-aligned names
     strings_offset = (strings_offset + 31) & ~31
 
     with open(out_path, "wb") as f:

--- a/tools/gen_crash_symbols.py
+++ b/tools/gen_crash_symbols.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Generate a compact binary symbol table for the in-game crash handler.
+
+The exception handler (JUTException) used to resolve every stack-frame / register
+address by re-opening the 4.2 MB ``pikmin2UP.map`` and linearly scanning it from
+disc *for each address* - dozens of full-file scans per crash. This tool turns the
+map into ``pikmin2UP.sym``: a sorted, binary, big-endian table that the runtime can
+binary-search with a handful of tiny disc reads (see src/p2gz/crashSymbols.cpp).
+
+Format:
+
+  header block, padded to HEADER_BLOCK (512 bytes), 32-byte-aligned start of file:
+    0x00 u32 magic            = 'P2GZ'
+    0x04 u32 version          = 1
+    0x08 u32 count            = number of symbol entries
+    0x0C u32 index_offset     = file offset of the entry array (== HEADER_BLOCK)
+    0x10 u32 strings_offset   = file offset of the string blob
+    0x14 u32 section_count
+    0x18 u32 reserved (0)
+    0x1C u32 reserved (0)
+    0x20 ...   section-name table: section_count null-terminated names
+  index array (at index_offset, 32-aligned): `count` entries, 16 bytes each,
+    sorted ascending by vaddr (16 divides 512 and 32 -> every entry sits inside a
+    single aligned disc block, so the runtime can read one block per probe):
+      0x00 u32 vaddr
+      0x04 u32 size
+      0x08 u32 name_off     (offset from strings_offset)
+      0x0C u32 section_id   (index into the section-name table)
+  string blob (at strings_offset): deduplicated null-terminated symbol names.
+"""
+
+import argparse
+import os
+import re
+import struct
+import sys
+
+MAGIC = 0x5032475A  # 'P2GZ'
+VERSION = 1
+HEADER_BLOCK = 512  # header + section table live in this first (aligned) block
+ENTRY_SIZE = 16
+
+# Matches a real symbol line, e.g.
+#   "  00000030 000024 80003130  4 TRK_memcpy \tmem_TRK.o"
+# groups: file-offset, size, vaddr, alignment, rest(symbol [+ \tobject])
+_SYM_RE = re.compile(r"^\s+([0-9a-fA-F]{8})\s+([0-9a-fA-F]{6})\s+([0-9a-fA-F]{8})\s+\d+\s+(.*)$")
+_SECTION_RE = re.compile(r"^(\S[\w.$]*) section layout")
+
+
+def parse_map(map_path):
+    """Return (entries, section_names).
+
+    entries: list of (vaddr, size, name, section_id), unsorted.
+    section_names: list of section names indexed by section_id.
+    """
+    section_names = []
+    section_id_of = {}
+    entries = []
+    current_section = None
+
+    with open(map_path, "r", encoding="latin-1") as f:
+        for line in f:
+            line = line.rstrip("\n")
+
+            # The post-layout summary ("Memory map:", "Linker generated symbols:")
+            # is not symbol data - stop before we start mis-parsing it.
+            if line.startswith("Memory map") or line.startswith("Linker generated"):
+                break
+
+            m = _SECTION_RE.match(line)
+            if m:
+                current_section = m.group(1).strip()
+                continue
+
+            if current_section is None:
+                continue
+
+            m = _SYM_RE.match(line)
+            if not m:
+                continue
+
+            size_hex, vaddr_hex, rest = m.group(2), m.group(3), m.group(4)
+            size = int(size_hex, 16)
+            if size == 0:
+                continue  # entry-of-section labels and other zero-size markers
+
+            # The symbol token is everything up to the tab/object-file or first space.
+            name = rest.split("\t")[0].strip().split(" ")[0]
+            if not name:
+                continue
+            # Section-contribution lines repeat the section name as the "symbol";
+            # skip them so they don't shadow the real per-symbol entries.
+            if name == current_section:
+                continue
+
+            vaddr = int(vaddr_hex, 16)
+
+            sid = section_id_of.get(current_section)
+            if sid is None:
+                sid = len(section_names)
+                section_id_of[current_section] = sid
+                section_names.append(current_section)
+
+            entries.append((vaddr, size, name, sid))
+
+    return entries, section_names
+
+
+def dedup_by_vaddr(entries):
+    """Keep one entry per vaddr (the smallest size = most specific symbol)."""
+    best = {}
+    for vaddr, size, name, sid in entries:
+        prev = best.get(vaddr)
+        if prev is None or size < prev[0]:
+            best[vaddr] = (size, name, sid)
+    out = [(v, s, n, sid) for v, (s, n, sid) in best.items()]
+    out.sort(key=lambda e: e[0])
+    return out
+
+
+def build_blob(entries):
+    """Build the deduplicated string blob; return (blob_bytes, name_off_of)."""
+    blob = bytearray()
+    name_off_of = {}
+    for _, _, name, _ in entries:
+        if name not in name_off_of:
+            name_off_of[name] = len(blob)
+            blob += name.encode("latin-1") + b"\x00"
+    return bytes(blob), name_off_of
+
+
+def build_section_table(section_names):
+    """Pack section names as null-terminated strings + assert they fit the header."""
+    table = bytearray()
+    for s in section_names:
+        table += s.encode("latin-1") + b"\x00"
+    if 0x20 + len(table) > HEADER_BLOCK:
+        raise SystemExit(
+            f"ERROR: section table ({len(table)}B) overflows header block; bump HEADER_BLOCK"
+        )
+    return bytes(table)
+
+
+def write_sym(out_path, entries, section_names):
+    blob, name_off_of = build_blob(entries)
+    section_table = build_section_table(section_names)
+
+    count = len(entries)
+    index_offset = HEADER_BLOCK
+    strings_offset = index_offset + count * ENTRY_SIZE
+    # 32-align the string blob so the runtime's aligned name reads stay simple.
+    strings_offset = (strings_offset + 31) & ~31
+
+    with open(out_path, "wb") as f:
+        header = struct.pack(
+            ">8I",
+            MAGIC,
+            VERSION,
+            count,
+            index_offset,
+            strings_offset,
+            len(section_names),
+            0,
+            0,
+        )
+        f.write(header)
+        f.write(section_table)
+        # pad header block
+        f.write(b"\x00" * (HEADER_BLOCK - 0x20 - len(section_table)))
+
+        for vaddr, size, name, sid in entries:
+            f.write(struct.pack(">4I", vaddr, size, name_off_of[name], sid))
+
+        # pad to strings_offset
+        pos = index_offset + count * ENTRY_SIZE
+        f.write(b"\x00" * (strings_offset - pos))
+        f.write(blob)
+
+    return count, strings_offset, len(blob)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("map", nargs="?", default=os.path.join("root", "files", "pikmin2UP.map"),
+                    help="input linker .map (default: root/files/pikmin2UP.map)")
+    ap.add_argument("-o", "--out", default=os.path.join("root", "files", "pikmin2UP.sym"),
+                    help="output .sym path (default: root/files/pikmin2UP.sym)")
+    args = ap.parse_args()
+
+    if not os.path.exists(args.map):
+        print(f"ERROR: map file not found: {args.map}", file=sys.stderr)
+        return 1
+
+    entries, section_names = parse_map(args.map)
+    if not entries:
+        print(f"ERROR: no symbols parsed from {args.map}", file=sys.stderr)
+        return 1
+
+    entries = dedup_by_vaddr(entries)
+    count, strings_offset, blob_len = write_sym(args.out, entries, section_names)
+
+    print(f"Crash symbol lookup file created: {count} symbols, {len(section_names)} sections ")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Currently on both console and Dolphin, the crash log takes forever to populate, as the game tries to re-parse the 4.2MB map file to resolve every single address line. This adds a Python script that makes a static lookup table out of the map file, and reroutes the crash handler to do a binary search on it instead when resolving addresses. This reduces the time the crash log takes to come up by a lot, and should make it less insane for people to share crash logs with us.


https://github.com/user-attachments/assets/4574160e-da95-4413-a44c-6680151ba008

