### PR TITLE
Don't try and draw spawn points above ground

### DIFF
--- a/src/p2gz/caveDebugInfo.cpp
+++ b/src/p2gz/caveDebugInfo.cpp
@@ -1,5 +1,6 @@
 #include <p2gz/CaveDebugInfo.h>
 #include <p2gz/DrawHelpers.h>
+#include <p2gz/Utility.h>
 #include <Game/Cave/RandMapMgr.h>
 
 using namespace gz;
@@ -11,9 +12,16 @@ CaveDebugInfo::CaveDebugInfo()
 
 void CaveDebugInfo::draw()
 {
-	if (draw_spawn_points) {
-		do_draw_spawn_points();
+	if (!draw_spawn_points) {
+		return;
 	}
+
+	// spawn points only exist inside caves - trying to draw them above-ground crashes
+	if (!in_cave_play() || !Game::Cave::randMapMgr || !Game::Cave::randMapMgr->mGenerator) {
+		return;
+	}
+
+	do_draw_spawn_points();
 }
 
 void CaveDebugInfo::do_draw_spawn_points()

--- a/src/p2gz/gzmenu.cpp
+++ b/src/p2gz/gzmenu.cpp
@@ -338,6 +338,9 @@ void GZMenu::open()
 	get_option("captain")->visible = in_gameplay;
 	get_option("level")->visible   = in_gameplay;
 
+	// spawn points only exist in caves, so don't offer the viewer above ground
+	get_option("debug info/spawn point viewer")->visible = in_cave_gameplay();
+
 	layer = root_layer;
 	layer->reset_selection();
 	breadcrumbs.clear();


### PR DESCRIPTION
Fixes #306 by guarding the spawn point drawer appropriately, and hiding the toggle for spawn point viewer above-ground.