### PR TITLE
fix camera position in find blue onion cutscene

### DIFF
--- a/src/sysGCU/moviePlayer.cpp
+++ b/src/sysGCU/moviePlayer.cpp
@@ -634,7 +634,7 @@ bool MoviePlayer::update(Controller* input1, Controller* input2)
 				if (norm > 10.0f) {
 					norm = 10.0f;
 				}
-				mCameraPosition = offset + (test * norm);
+				mCameraPosition = test + (offset * norm);
 				setTransform(mCameraPosition, mCameraAngle);
 			}
 		}


### PR DESCRIPTION
Our `moviePlayer.cpp` wasn't equivalent for some reason: https://github.com/projectPiki/pikmin2/blob/main/src/sysGCU/moviePlayer.cpp#L636