### PR TITLE
Fix some treasure editor crashes

### DIFF
--- a/include/p2gz/TreasureEditor.h
+++ b/include/p2gz/TreasureEditor.h
@@ -5,6 +5,10 @@
 #include <p2gz/gzCollections.h>
 #include <Game/Entities/PelletItem.h>
 
+namespace Game {
+struct PelletConfig;
+}
+
 namespace gz {
 
 struct TreasureEditor {
@@ -51,7 +55,21 @@ private:
 		Vector3f position;
 	};
 
+	// pointer to treasure that's already spawned in the current area, so we can reuse the model
+	struct SpawnedPellet {
+		SpawnedPellet()
+		    : name(nullptr)
+		    , pellet(nullptr)
+		{
+		}
+
+		const char* name; // pellet config
+		Game::Pellet* pellet;
+	};
+
 	Game::Pellet* spawn_treasure(const char* config_name);
+	Game::Pellet* birth_or_revive(Game::PelletConfig* cfg, const char* config_name, int kind);
+	void remember_spawned(const char* config_name, Game::Pellet* pellet);
 	void sync_treasure_option(const char* treasure_name, ToggleMenuOption* treasure_collected_opt);
 	void focus_treasure(const char* treasure_name);
 
@@ -62,6 +80,7 @@ private:
 	Game::Pellet* active_treasure;
 	Vector3f initial_position;          // used when moving a treasure
 	Vec<TreasureSpawn> spawn_positions; // spawn spots for treasures on the current (cave) floor
+	Vec<SpawnedPellet> spawned_pellets; // pellets spawned this area load, to re-use their for model
 	bool enabled;
 };
 

--- a/include/p2gz/TreasureEditor.h
+++ b/include/p2gz/TreasureEditor.h
@@ -2,6 +2,7 @@
 #define _TREASURE_EDITOR_H
 
 #include <p2gz/gzmenu.h>
+#include <p2gz/gzCollections.h>
 #include <Game/Entities/PelletItem.h>
 
 namespace gz {
@@ -17,6 +18,7 @@ public:
 	~TreasureEditor() { }
 
 	void init();
+	void update();
 	void sync();
 
 	void start_move(const char* treasure_name);
@@ -34,17 +36,32 @@ public:
 	void add(const char* config_name);
 	void clear_treasures();
 
-	void set_collected(const char* treasure_name, bool);
+	void set_collected(const char* treasure_name, ToggleMenuOption* collected_opt, bool collected);
 	void snap_to_nearest_waypoint();
 
 private:
+	// position of treasure in a cave (for respawning it)
+	struct TreasureSpawn {
+		TreasureSpawn()
+		    : name(nullptr)
+		{
+		}
+
+		const char* name; // pellet config
+		Vector3f position;
+	};
+
 	Game::Pellet* spawn_treasure(const char* config_name);
 	void sync_treasure_option(const char* treasure_name, ToggleMenuOption* treasure_collected_opt);
 	void focus_treasure(const char* treasure_name);
 
+	void record_spawn_position(const char* config_name, const Vector3f& position);
+	bool get_spawn_position(const char* config_name, Vector3f& out);
+
 	ListMenu* treasures;
 	Game::Pellet* active_treasure;
-	Vector3f initial_position; // used when moving a treasure
+	Vector3f initial_position;          // used when moving a treasure
+	Vec<TreasureSpawn> spawn_positions; // spawn spots for treasures on the current (cave) floor
 	bool enabled;
 };
 

--- a/include/p2gz/TreasureEditor.h
+++ b/include/p2gz/TreasureEditor.h
@@ -5,6 +5,8 @@
 #include <p2gz/gzCollections.h>
 #include <Game/Entities/PelletItem.h>
 
+const int MAX_LOADED_TREASURES = 16;
+
 namespace gz {
 
 struct TreasureEditor {
@@ -14,6 +16,9 @@ public:
 	    , active_treasure(nullptr)
 	    , enabled(false)
 	{
+		for (int i = 0; i < MAX_LOADED_TREASURES; i++) {
+			loaded_treasures[i] = 0;
+		}
 	}
 	~TreasureEditor() { }
 
@@ -38,6 +43,10 @@ public:
 
 	void set_collected(const char* treasure_name, ToggleMenuOption* collected_opt, bool collected);
 	void snap_to_nearest_waypoint();
+	void add_loaded_treasure(Game::Pellet* treasure);
+	Game::Pellet* search_loaded_treasure_index(int index_to_search);
+	void clear_loaded_treasure_array();
+	void printout_array(); // debug function 
 
 private:
 	// position of treasure in a cave (for respawning it)
@@ -63,6 +72,8 @@ private:
 	Vector3f initial_position;          // used when moving a treasure
 	Vec<TreasureSpawn> spawn_positions; // spawn spots for treasures on the current (cave) floor
 	bool enabled;
+
+	Game::Pellet* loaded_treasures[16];
 };
 
 } // namespace gz

--- a/include/p2gz/TreasureEditor.h
+++ b/include/p2gz/TreasureEditor.h
@@ -5,10 +5,6 @@
 #include <p2gz/gzCollections.h>
 #include <Game/Entities/PelletItem.h>
 
-namespace Game {
-struct PelletConfig;
-}
-
 namespace gz {
 
 struct TreasureEditor {
@@ -55,21 +51,7 @@ private:
 		Vector3f position;
 	};
 
-	// pointer to treasure that's already spawned in the current area, so we can reuse the model
-	struct SpawnedPellet {
-		SpawnedPellet()
-		    : name(nullptr)
-		    , pellet(nullptr)
-		{
-		}
-
-		const char* name; // pellet config
-		Game::Pellet* pellet;
-	};
-
 	Game::Pellet* spawn_treasure(const char* config_name);
-	Game::Pellet* birth_or_revive(Game::PelletConfig* cfg, const char* config_name, int kind);
-	void remember_spawned(const char* config_name, Game::Pellet* pellet);
 	void sync_treasure_option(const char* treasure_name, ToggleMenuOption* treasure_collected_opt);
 	void focus_treasure(const char* treasure_name);
 
@@ -80,7 +62,6 @@ private:
 	Game::Pellet* active_treasure;
 	Vector3f initial_position;          // used when moving a treasure
 	Vec<TreasureSpawn> spawn_positions; // spawn spots for treasures on the current (cave) floor
-	Vec<SpawnedPellet> spawned_pellets; // pellets spawned this area load, to re-use their for model
 	bool enabled;
 };
 

--- a/include/p2gz/gzmenu.h
+++ b/include/p2gz/gzmenu.h
@@ -112,6 +112,8 @@ public:
 	bool get_selection() { return on; }
 	void set_selection(bool selected) { on = selected; }
 
+	void set_on_selected(IDelegate1<bool>* delegate) { on_selected = delegate; }
+
 	// like set_selection, but also fires the bound delegate so the live state follows the display
 	void set_value(bool value)
 	{
@@ -308,13 +310,14 @@ public:
 
 	virtual MenuOption* cur_option()
 	{
-		{
-			if (options.len() > 0)
-				return options[selected];
-			else {
-				return nullptr;
-			}
+		if (options.len() == 0) {
+			return nullptr;
 		}
+		// clamp so we never index out of bounds
+		if (selected >= options.len()) {
+			selected = options.len() - 1;
+		}
+		return options[selected];
 	}
 
 	ListMenu* push(MenuOption* option);

--- a/include/p2gz/p2gz.h
+++ b/include/p2gz/p2gz.h
@@ -49,8 +49,6 @@ public:
 	void draw_2d();
 	void draw();
 
-	void show_callout(const char* message);
-
 	static void draw_version();
 
 	// our own persistent controller so we don't crash the game on new file starting (don't ask)
@@ -97,15 +95,7 @@ public:
 	bool in_save_file;
 
 private:
-	void draw_callout();
-
 	bool inited;
-
-	// global callout messages for when things are Bad and the user should know
-	static const int CALLOUT_MAX_LENGTH = 64;
-
-	char callout_message[CALLOUT_MAX_LENGTH];
-	int callout_frames_remaining;
 };
 
 // global instance

--- a/include/p2gz/p2gz.h
+++ b/include/p2gz/p2gz.h
@@ -49,6 +49,8 @@ public:
 	void draw_2d();
 	void draw();
 
+	void show_callout(const char* message);
+
 	static void draw_version();
 
 	// our own persistent controller so we don't crash the game on new file starting (don't ask)
@@ -95,7 +97,15 @@ public:
 	bool in_save_file;
 
 private:
+	void draw_callout();
+
 	bool inited;
+
+	// global callout messages for when things are Bad and the user should know
+	static const int CALLOUT_MAX_LENGTH = 64;
+
+	char callout_message[CALLOUT_MAX_LENGTH];
+	int callout_frames_remaining;
 };
 
 // global instance

--- a/src/p2gz/gzmenu.cpp
+++ b/src/p2gz/gzmenu.cpp
@@ -516,6 +516,16 @@ void ListMenu::clear()
 
 void ListMenu::update()
 {
+	// clamp in case list size has changed (from sync etc)
+	if (options.len() > 0) {
+		if (scroll >= options.len()) {
+			scroll = 0;
+		}
+		if (selected >= options.len()) {
+			selected = options.len() - 1;
+		}
+	}
+
 	// Make sure the selection starts in bounds in case it was changed from somewhere else
 	if (selected < scroll) {
 		selected = scroll;

--- a/src/p2gz/p2gz.cpp
+++ b/src/p2gz/p2gz.cpp
@@ -130,6 +130,7 @@ void P2GZ::update()
 	segment_history->update();
 	dismiss_positions->update();
 	navi_tools->update();
+	treasure_editor->update();
 	empress_trainer->update();
 	early_blues_trainer->update();
 	navi_debug_info->update();

--- a/src/p2gz/p2gz.cpp
+++ b/src/p2gz/p2gz.cpp
@@ -24,18 +24,13 @@
 
 using namespace gz;
 
-// duration for temp red callout text to appear
-static const int CALLOUT_DURATION_FRAMES = 30;
-
 P2GZ* p2gz;
 
 P2GZ::P2GZ()
 {
-	inited                   = false;
-	in_save_file             = true;
-	callout_frames_remaining = 0;
-	callout_message[0]       = '\0';
-	JKRHeap* prev_heap       = sys->mSysHeap->becomeCurrentHeap();
+	inited             = false;
+	in_save_file       = true;
+	JKRHeap* prev_heap = sys->mSysHeap->becomeCurrentHeap();
 
 	// Setup all our P2GZ menus/features here
 	collision_viewer     = new CollisionViewer();
@@ -143,10 +138,6 @@ void P2GZ::update()
 	warp->update_lockout_frames();
 	race_mode->update();
 
-	if (callout_frames_remaining > 0) {
-		callout_frames_remaining--;
-	}
-
 	// Menu must update last so button presses for menu interactions don't
 	// inadvertantly do things in other systems on the same frame they're pressed.
 	// NEW - we use the menu lock to prevent this issue for update calls outside of this function (such as graphical updates)
@@ -171,9 +162,6 @@ void P2GZ::draw_2d()
 	early_blues_trainer->draw_status();
 	navi_debug_info->draw();
 	race_mode->draw_2d();
-
-	// draw last so it sits on top of everything else (i.e. the menu it's triggered from lol)
-	draw_callout();
 }
 
 // Anything that needs to be drawn in 3D space should be drawn here.
@@ -211,32 +199,3 @@ void P2GZ::draw_version()
 	j2d.print((System::getRenderModeWidth() / 2) - (width / 2), 424.0f, "v.%s", P2GZ_VERSION);
 }
 
-// temp red callout text for errors the player should Know About
-void P2GZ::show_callout(const char* message)
-{
-	strncpy(callout_message, message, CALLOUT_MAX_LENGTH - 1);
-	callout_message[CALLOUT_MAX_LENGTH - 1] = '\0';
-	callout_frames_remaining                = CALLOUT_DURATION_FRAMES;
-}
-
-void P2GZ::draw_callout()
-{
-	if (callout_frames_remaining <= 0 || callout_message[0] == '\0') {
-		return;
-	}
-
-	J2DPrint j2d(gP2JMEMgr->mFont, 0.0f);
-	j2d.initiate();
-
-	j2d.mGlyphWidth  = 20.0f;
-	j2d.mGlyphHeight = 20.0f;
-
-	JUtility::TColor color = JUtility::TColor(230, 40, 40, 255);
-	j2d.mCharColor.set(color);
-	j2d.mGradientColor.set(color);
-
-	// centre horizontally and vertically
-	f32 width = j2d.getWidth("%s", callout_message);
-	j2d.print((System::getRenderModeWidth() / 2) - (width / 2), (System::getRenderModeHeight() / 2) - (j2d.mGlyphHeight / 2), "%s",
-	          callout_message);
-}

--- a/src/p2gz/p2gz.cpp
+++ b/src/p2gz/p2gz.cpp
@@ -24,13 +24,18 @@
 
 using namespace gz;
 
+// duration for temp red callout text to appear
+static const int CALLOUT_DURATION_FRAMES = 30;
+
 P2GZ* p2gz;
 
 P2GZ::P2GZ()
 {
-	inited             = false;
-	in_save_file       = true;
-	JKRHeap* prev_heap = sys->mSysHeap->becomeCurrentHeap();
+	inited                   = false;
+	in_save_file             = true;
+	callout_frames_remaining = 0;
+	callout_message[0]       = '\0';
+	JKRHeap* prev_heap       = sys->mSysHeap->becomeCurrentHeap();
 
 	// Setup all our P2GZ menus/features here
 	collision_viewer     = new CollisionViewer();
@@ -138,6 +143,10 @@ void P2GZ::update()
 	warp->update_lockout_frames();
 	race_mode->update();
 
+	if (callout_frames_remaining > 0) {
+		callout_frames_remaining--;
+	}
+
 	// Menu must update last so button presses for menu interactions don't
 	// inadvertantly do things in other systems on the same frame they're pressed.
 	// NEW - we use the menu lock to prevent this issue for update calls outside of this function (such as graphical updates)
@@ -162,6 +171,9 @@ void P2GZ::draw_2d()
 	early_blues_trainer->draw_status();
 	navi_debug_info->draw();
 	race_mode->draw_2d();
+
+	// draw last so it sits on top of everything else (i.e. the menu it's triggered from lol)
+	draw_callout();
 }
 
 // Anything that needs to be drawn in 3D space should be drawn here.
@@ -197,4 +209,34 @@ void P2GZ::draw_version()
 	// automagically determine where to print it so it's centered
 	f32 width = j2d.getWidth("v.%s", P2GZ_VERSION);
 	j2d.print((System::getRenderModeWidth() / 2) - (width / 2), 424.0f, "v.%s", P2GZ_VERSION);
+}
+
+// temp red callout text for errors the player should Know About
+void P2GZ::show_callout(const char* message)
+{
+	strncpy(callout_message, message, CALLOUT_MAX_LENGTH - 1);
+	callout_message[CALLOUT_MAX_LENGTH - 1] = '\0';
+	callout_frames_remaining                = CALLOUT_DURATION_FRAMES;
+}
+
+void P2GZ::draw_callout()
+{
+	if (callout_frames_remaining <= 0 || callout_message[0] == '\0') {
+		return;
+	}
+
+	J2DPrint j2d(gP2JMEMgr->mFont, 0.0f);
+	j2d.initiate();
+
+	j2d.mGlyphWidth  = 20.0f;
+	j2d.mGlyphHeight = 20.0f;
+
+	JUtility::TColor color = JUtility::TColor(230, 40, 40, 255);
+	j2d.mCharColor.set(color);
+	j2d.mGradientColor.set(color);
+
+	// centre horizontally and vertically
+	f32 width = j2d.getWidth("%s", callout_message);
+	j2d.print((System::getRenderModeWidth() / 2) - (width / 2), (System::getRenderModeHeight() / 2) - (j2d.mGlyphHeight / 2), "%s",
+	          callout_message);
 }

--- a/src/p2gz/p2gz.cpp
+++ b/src/p2gz/p2gz.cpp
@@ -24,13 +24,18 @@
 
 using namespace gz;
 
+// duration for temp red callout text to appear
+static const int CALLOUT_DURATION_FRAMES = 30;
+
 P2GZ* p2gz;
 
 P2GZ::P2GZ()
 {
-	inited             = false;
-	in_save_file       = true;
-	JKRHeap* prev_heap = sys->mSysHeap->becomeCurrentHeap();
+	inited                   = false;
+	in_save_file             = true;
+	callout_frames_remaining = 0;
+	callout_message[0]       = '\0';
+	JKRHeap* prev_heap       = sys->mSysHeap->becomeCurrentHeap();
 
 	// Setup all our P2GZ menus/features here
 	collision_viewer     = new CollisionViewer();
@@ -138,6 +143,10 @@ void P2GZ::update()
 	warp->update_lockout_frames();
 	race_mode->update();
 
+	if (callout_frames_remaining > 0) {
+		callout_frames_remaining--;
+	}
+
 	// Menu must update last so button presses for menu interactions don't
 	// inadvertantly do things in other systems on the same frame they're pressed.
 	// NEW - we use the menu lock to prevent this issue for update calls outside of this function (such as graphical updates)
@@ -162,6 +171,9 @@ void P2GZ::draw_2d()
 	early_blues_trainer->draw_status();
 	navi_debug_info->draw();
 	race_mode->draw_2d();
+
+	// draw last so it sits on top of everything else (i.e. the menu it's triggered from lol)
+	draw_callout();
 }
 
 // Anything that needs to be drawn in 3D space should be drawn here.
@@ -199,3 +211,32 @@ void P2GZ::draw_version()
 	j2d.print((System::getRenderModeWidth() / 2) - (width / 2), 424.0f, "v.%s", P2GZ_VERSION);
 }
 
+// temp red callout text for errors the player should Know About
+void P2GZ::show_callout(const char* message)
+{
+	strncpy(callout_message, message, CALLOUT_MAX_LENGTH - 1);
+	callout_message[CALLOUT_MAX_LENGTH - 1] = '\0';
+	callout_frames_remaining                = CALLOUT_DURATION_FRAMES;
+}
+
+void P2GZ::draw_callout()
+{
+	if (callout_frames_remaining <= 0 || callout_message[0] == '\0') {
+		return;
+	}
+
+	J2DPrint j2d(gP2JMEMgr->mFont, 0.0f);
+	j2d.initiate();
+
+	j2d.mGlyphWidth  = 20.0f;
+	j2d.mGlyphHeight = 20.0f;
+
+	JUtility::TColor color = JUtility::TColor(230, 40, 40, 255);
+	j2d.mCharColor.set(color);
+	j2d.mGradientColor.set(color);
+
+	// centre horizontally and vertically
+	f32 width = j2d.getWidth("%s", callout_message);
+	j2d.print((System::getRenderModeWidth() / 2) - (width / 2), (System::getRenderModeHeight() / 2) - (j2d.mGlyphHeight / 2), "%s",
+	          callout_message);
+}

--- a/src/p2gz/treasureEditor.cpp
+++ b/src/p2gz/treasureEditor.cpp
@@ -272,10 +272,64 @@ void TreasureEditor::snap_to_nearest_waypoint()
 	p2gz->freecam->set_position(pos);
 }
 
+// no generator in caves => record each treasure's position on spawn so we can respawn it
+void TreasureEditor::update()
+{
+	if (!in_cave_play()) {
+		return;
+	}
+
+	Iterator<Game::PelletOtakara::Object> treasureIterator(Game::PelletOtakara::mgr);
+	CI_LOOP(treasureIterator)
+	{
+		Game::PelletOtakara::Object* treasure = *treasureIterator;
+		if (treasure->isAlive()) {
+			record_spawn_position(treasure->getConfigName(), treasure->getPosition());
+		}
+	}
+
+	Iterator<Game::PelletItem::Object> upgradeIterator(Game::PelletItem::mgr);
+	CI_LOOP(upgradeIterator)
+	{
+		Game::PelletItem::Object* treasure = *upgradeIterator;
+		if (treasure->isAlive()) {
+			record_spawn_position(treasure->getConfigName(), treasure->getPosition());
+		}
+	}
+}
+
+void TreasureEditor::record_spawn_position(const char* config_name, const Vector3f& position)
+{
+	for (size_t i = 0; i < spawn_positions.len(); i++) {
+		if (strcmp(spawn_positions[i].name, config_name) == 0) {
+			// already recorded
+			return;
+		}
+	}
+
+	TreasureSpawn entry;
+	entry.name     = config_name;
+	entry.position = position;
+	spawn_positions.push(entry);
+}
+
+bool TreasureEditor::get_spawn_position(const char* config_name, Vector3f& out)
+{
+	for (size_t i = 0; i < spawn_positions.len(); i++) {
+		if (strcmp(spawn_positions[i].name, config_name) == 0) {
+			out = spawn_positions[i].position;
+			return true;
+		}
+	}
+	return false;
+}
+
 void TreasureEditor::sync()
 {
-	// Rebuild from scratch so the list reflects the current area (no stale cross-area entries).
-	clear_treasures();
+	// clear menu to avoid stale copies (but not treasure positions)
+	if (treasures) {
+		treasures->clear();
+	}
 
 	// Live treasures (uncollected / currently spawned), plus exploration-kit upgrades.
 	Iterator<Game::PelletOtakara::Object> treasureIterator(Game::PelletOtakara::mgr);
@@ -290,6 +344,13 @@ void TreasureEditor::sync()
 	{
 		Game::PelletItem::Object* treasure = *upgradeIterator;
 		add(treasure);
+	}
+
+	// add each cave treasure to the spawn list when available
+	if (in_cave_play()) {
+		for (size_t i = 0; i < spawn_positions.len(); i++) {
+			add(spawn_positions[i].name);
+		}
 	}
 
 	// Add treasures that have already been collected by finding them in the generator cache.
@@ -350,8 +411,10 @@ void TreasureEditor::add(const char* treasure_name)
 	JKRHeap* prev_heap = sys->mSysHeap->becomeCurrentHeap();
 
 	// clang-format off
-	ToggleMenuOption* collected_opt = new ToggleMenuOption(
-		"collected", false, new CurriedDelegate1<TreasureEditor, const char*, bool>(this, &set_collected, treasure_name));
+	// delay attaching delegate, since it needs a pointer back to the option
+	ToggleMenuOption* collected_opt = new ToggleMenuOption("collected", false, nullptr);
+	collected_opt->set_on_selected(
+		new CurriedDelegate2<TreasureEditor, const char*, ToggleMenuOption*, bool>(this, &set_collected, treasure_name, collected_opt));
 
 	OpenSubMenuOption* treasure_opt = new OpenSubMenuOption(treasure_name, (new ListMenu(
 	    new BoundDelegate2<TreasureEditor, const char*, ToggleMenuOption*>(this, &sync_treasure_option, treasure_name, collected_opt)))
@@ -422,17 +485,26 @@ void TreasureEditor::sync_treasure_option(const char* treasure_name, ToggleMenuO
 	treasure_collected_opt->set_selection(!treasure || !treasure->isAlive());
 }
 
+// min size of the largest (contiguous) free block we require before spawning a treasure
+static const u32 MIN_FREE_HEAP_FOR_SPAWN = 0x4000; // i.e. 16KB
+
+// true if the current heap has room for a treasure model
+static bool heap_has_room_for_spawn()
+{
+	JKRHeap* heap = JKRHeap::getCurrentHeap();
+	if (!heap) {
+		// default to spawning, just in case
+		return true;
+	}
+	return heap->getFreeSize() >= MIN_FREE_HEAP_FOR_SPAWN;
+}
+
 Game::Pellet* birth_pellet(Game::PelletConfig* cfg, const char* config_name, int kind)
 {
-	// spawning treasures allocates memory for models, but they don't free properly until next reload
-	// so players don't crash the game by spawning the same treasure over and over, set a minimum heap size
-	// (if we're below the heap size, don't spawn the treasure + print to log)
-	const u32 MIN_FREE_HEAP_FOR_SPAWN = 0x4000; // 16KB margin
-	JKRHeap* heap                     = JKRHeap::getCurrentHeap();
-	u32 free_size                     = heap ? heap->getTotalFreeSize() : 0xFFFFFFFF; // if we can't tell, don't block it
-	if (free_size < MIN_FREE_HEAP_FOR_SPAWN) {
+	if (!heap_has_room_for_spawn()) {
 		// indicate why a treasure isn't spawning for when we go insane later trying to trace it
-		OSReport("couldn't spawn treasure %s: heap too low (%u bytes free)\n", config_name, free_size);
+		OSReport("couldn't spawn treasure %s: heap too low (largest free block %u bytes)\n", config_name,
+		         JKRHeap::getCurrentHeap() ? JKRHeap::getCurrentHeap()->getFreeSize() : 0);
 		return nullptr;
 	}
 
@@ -505,10 +577,14 @@ Game::Pellet* TreasureEditor::spawn_treasure(const char* config_name)
 			return nullptr;
 		}
 
-		// We don't know which spawn point the treasure spawned at, so just place it on the active captain.
-		Game::Navi* navi = p2gz->navi_tools->active_navi();
-		f32 y            = Game::mapMgr->getMinY(navi->mPosition) + (pellet->getCylinderHeight() * 0.5f);
-		Vector3f pos     = Vector3f(navi->mPosition.x, y, navi->mPosition.z);
+		// respawn at the treasure's recorded floor spawn spot
+		// (default to current captain's position if we didn't get a spawn spot, such as for treasures in enemies)
+		Vector3f pos;
+		if (!get_spawn_position(config_name, pos)) {
+			Game::Navi* navi = p2gz->navi_tools->active_navi();
+			f32 y            = Game::mapMgr->getMinY(navi->mPosition) + (pellet->getCylinderHeight() * 0.5f);
+			pos              = Vector3f(navi->mPosition.x, y, navi->mPosition.z);
+		}
 		pellet->setPosition(pos, false);
 		return pellet;
 	} else {
@@ -516,21 +592,53 @@ Game::Pellet* TreasureEditor::spawn_treasure(const char* config_name)
 	}
 }
 
+// clear the buried-treasure holder (ItemTreasure::Item) for this treasure, if it has one
+static void release_buried_holder(const char* config_name)
+{
+	Iterator<Game::BaseItem> buriedIterator(Game::ItemTreasure::mgr);
+	CI_LOOP(buriedIterator)
+	{
+		Game::ItemTreasure::Item* item = static_cast<Game::ItemTreasure::Item*>(*buriedIterator);
+		// skip dead pellets
+		if (!item->isAlive() || !item->mPellet || !item->mPellet->isAlive()) {
+			continue;
+		}
+		if (strcmp(config_name, item->mPellet->getConfigName()) == 0) {
+			item->mTotalLife = 0.0f;
+			item->releasePellet();
+		}
+	}
+}
+
 // Toggle whether the given treasure is collected. Disables move and sets collected.
-void TreasureEditor::set_collected(const char* treasure_name, bool collected)
+void TreasureEditor::set_collected(const char* treasure_name, ToggleMenuOption* collected_opt, bool collected)
 {
 	Game::Creature* creature = find_treasure(treasure_name);
 	if (collected) {
+		// kill the pellet
 		if (!creature || !creature->isAlive()) {
 			return;
 		}
+
+		// if it's buried, dig it up first so the holder dies with it
+		release_buried_holder(treasure_name);
 
 		Game::PelletKillArg arg;
 		arg.mFlags    = Game::CKILL_DontCountAsDeath;
 		arg.mDoRevive = false;
 		creature->kill(&arg);
 	} else {
+		// spawn a new pellet
+		// this leaks due to the model, so just perma show "collected" when the heap is too low so we don't crash
 		if (creature && creature->isAlive()) {
+			return;
+		}
+		if (!heap_has_room_for_spawn()) {
+			OSReport("couldn't un-collect treasure %s: heap too low to spawn\n", treasure_name);
+			if (collected_opt) {
+				// keep toggle in sync with the actual treasure state
+				collected_opt->set_selection(true);
+			}
 			return;
 		}
 		spawn_treasure(treasure_name);
@@ -544,4 +652,6 @@ void TreasureEditor::clear_treasures()
 	if (treasures) {
 		treasures->clear();
 	}
+	// drop remembered spawn spots from the level we're leaving
+	spawn_positions.clear();
 }

--- a/src/p2gz/treasureEditor.cpp
+++ b/src/p2gz/treasureEditor.cpp
@@ -15,6 +15,20 @@
 
 using namespace gz;
 
+// min size of the largest (contiguous) free block we require before spawning a treasure
+static const u32 MIN_FREE_HEAP_FOR_SPAWN = 0x4000; // i.e. 16KB
+
+// true if the current heap has room for a treasure model
+static bool heap_has_room_for_spawn()
+{
+	JKRHeap* heap = JKRHeap::getCurrentHeap();
+	if (!heap) {
+		// default to spawning, just in case
+		return true;
+	}
+	return heap->getFreeSize() >= MIN_FREE_HEAP_FOR_SPAWN;
+}
+
 void TreasureEditor::init()
 {
 	treasures = static_cast<ListMenu*>(p2gz->menu->get_option("level/treasures")->get_sub_menu());
@@ -236,6 +250,10 @@ void TreasureEditor::start_move(const char* treasure_name)
 
 	if (!active_treasure) {
 		OSReport("couldn't find treasure %s to move\n", treasure_name);
+		// most likely the treasure couldn't be spawned because the heap is too low
+		if (!heap_has_room_for_spawn()) {
+			p2gz->show_callout("No Memory To Spawn Treasure");
+		}
 		return;
 	}
 
@@ -485,20 +503,6 @@ void TreasureEditor::sync_treasure_option(const char* treasure_name, ToggleMenuO
 	treasure_collected_opt->set_selection(!treasure || !treasure->isAlive());
 }
 
-// min size of the largest (contiguous) free block we require before spawning a treasure
-static const u32 MIN_FREE_HEAP_FOR_SPAWN = 0x4000; // i.e. 16KB
-
-// true if the current heap has room for a treasure model
-static bool heap_has_room_for_spawn()
-{
-	JKRHeap* heap = JKRHeap::getCurrentHeap();
-	if (!heap) {
-		// default to spawning, just in case
-		return true;
-	}
-	return heap->getFreeSize() >= MIN_FREE_HEAP_FOR_SPAWN;
-}
-
 Game::Pellet* birth_pellet(Game::PelletConfig* cfg, const char* config_name, int kind)
 {
 	if (!heap_has_room_for_spawn()) {
@@ -515,6 +519,13 @@ Game::Pellet* birth_pellet(Game::PelletConfig* cfg, const char* config_name, int
 	arg.mPelletIndex        = cfg->mParams.mIndex;
 	arg.mPelView            = nullptr;
 	return Game::pelletMgr->birth(&arg);
+}
+
+// place pellet so it doesn't clip into the ground
+static void place_pellet_on_floor(Game::Pellet* pellet, Vector3f pos)
+{
+	pos.y = Game::mapMgr->getMinY(pos) + pellet->getCylinderHeight() * 0.5f;
+	pellet->setPosition(pos, false);
 }
 
 Game::Pellet* TreasureEditor::spawn_treasure(const char* config_name)
@@ -549,7 +560,7 @@ Game::Pellet* TreasureEditor::spawn_treasure(const char* config_name)
 					if (!pellet) {
 						return nullptr;
 					}
-					pellet->setPosition(gen->mPosition, false);
+					place_pellet_on_floor(pellet, gen->mPosition + gen->mOffset);
 					gen->mCreature     = pellet;
 					pellet->mGenerator = gen;
 					return pellet;
@@ -565,7 +576,7 @@ Game::Pellet* TreasureEditor::spawn_treasure(const char* config_name)
 					if (!pellet) {
 						return nullptr;
 					}
-					pellet->setPosition(gen->mPosition, false);
+					place_pellet_on_floor(pellet, gen->mPosition + gen->mOffset);
 					return pellet;
 				}
 			}
@@ -635,6 +646,8 @@ void TreasureEditor::set_collected(const char* treasure_name, ToggleMenuOption* 
 		}
 		if (!heap_has_room_for_spawn()) {
 			OSReport("couldn't un-collect treasure %s: heap too low to spawn\n", treasure_name);
+			// let the user know why nothing appeared
+			p2gz->show_callout("No Memory To Spawn Treasure");
 			if (collected_opt) {
 				// keep toggle in sync with the actual treasure state
 				collected_opt->set_selection(true);

--- a/src/p2gz/treasureEditor.cpp
+++ b/src/p2gz/treasureEditor.cpp
@@ -370,13 +370,49 @@ void TreasureEditor::focus_treasure(const char* treasure_name)
 {
 	Game::Creature* treasure = find_treasure(treasure_name);
 
-	// Move camera to treasure if we found it
+	// work out where to point the camera
+	// - a spawned treasure uses its pellet position
+	// - a collected/despawned treasure uses its generator position (where it will respawn)
+	Vector3f target;
+	bool have_target = false;
 	if (treasure) {
-		Game::PlayCamera* camera = Game::cameraMgr->mCameraObjList[p2gz->navi_tools->active_navi()->getNaviID()];
-		if (camera) {
-			treasure->mLod.setFlag(AILOD_IsVisibleBoth);
-			camera->mGoalPosition = treasure->getPosition();
+		treasure->mLod.setFlag(AILOD_IsVisibleBoth);
+		target      = treasure->getPosition();
+		have_target = true;
+	} else if (in_above_ground_play()) {
+		FOREACH_NODE(Game::Generator, Game::generatorCache->getFirstGenerator(), gen)
+		{
+			if (!gen->mObject) {
+				continue;
+			}
+			Game::PelletConfig* cfg = nullptr;
+			if (gen->mObject->mTypeID == 'pelt') {
+				Game::GenPellet* gen_pellet = static_cast<Game::GenPellet*>(gen->mObject);
+				if (gen_pellet->mGenParm) {
+					cfg = Game::PelletList::Mgr::mInstance->getConfig(gen_pellet->mPelType)->getPelletConfig(gen_pellet->mGenParm->mIndex);
+				}
+			} else if (gen->mObject->mTypeID == 'teki') {
+				Game::GenObjectEnemy* gen_enemy = static_cast<Game::GenObjectEnemy*>(gen->mObject);
+				if (!gen_enemy->mOtakaraItemCode.isNull()) {
+					cfg = Game::PelletList::Mgr::mInstance->getConfig(gen_enemy->mOtakaraItemCode.getPelletKind())
+					          ->getPelletConfig(gen_enemy->mOtakaraItemCode.getPelletIndex());
+				}
+			}
+			if (cfg && strcmp(cfg->mParams.mName.mData, treasure_name) == 0) {
+				target      = gen->mPosition;
+				have_target = true;
+				break;
+			}
 		}
+	}
+
+	if (!have_target) {
+		return;
+	}
+
+	Game::PlayCamera* camera = Game::cameraMgr->mCameraObjList[p2gz->navi_tools->active_navi()->getNaviID()];
+	if (camera) {
+		camera->mGoalPosition = target;
 	}
 }
 
@@ -388,6 +424,18 @@ void TreasureEditor::sync_treasure_option(const char* treasure_name, ToggleMenuO
 
 Game::Pellet* birth_pellet(Game::PelletConfig* cfg, const char* config_name, int kind)
 {
+	// spawning treasures allocates memory for models, but they don't free properly until next reload
+	// so players don't crash the game by spawning the same treasure over and over, set a minimum heap size
+	// (if we're below the heap size, don't spawn the treasure + print to log)
+	const u32 MIN_FREE_HEAP_FOR_SPAWN = 0x4000; // 16KB margin
+	JKRHeap* heap                     = JKRHeap::getCurrentHeap();
+	u32 free_size                     = heap ? heap->getTotalFreeSize() : 0xFFFFFFFF; // if we can't tell, don't block it
+	if (free_size < MIN_FREE_HEAP_FOR_SPAWN) {
+		// indicate why a treasure isn't spawning for when we go insane later trying to trace it
+		OSReport("couldn't spawn treasure %s: heap too low (%u bytes free)\n", config_name, free_size);
+		return nullptr;
+	}
+
 	Game::PelletInitArg arg;
 	arg.mDontCheckCollected = true;
 	arg.mTextIdentifier     = const_cast<char*>(config_name);
@@ -415,6 +463,9 @@ Game::Pellet* TreasureEditor::spawn_treasure(const char* config_name)
 	if (in_above_ground_play()) {
 		FOREACH_NODE(Game::Generator, Game::generatorCache->getFirstGenerator(), gen)
 		{
+			if (!gen->mObject) {
+				continue;
+			}
 			if (gen->mObject->mTypeID == 'pelt') {
 				Game::GenPellet* gen_pellet = static_cast<Game::GenPellet*>(gen->mObject);
 				int treasure_id             = gen_pellet->mGenParm->mIndex;
@@ -422,9 +473,14 @@ Game::Pellet* TreasureEditor::spawn_treasure(const char* config_name)
 				const char* treasure_name
 				    = Game::PelletList::Mgr::mInstance->getConfig(kind)->getPelletConfig(treasure_id)->mParams.mName.mData;
 				if ((!gen->mCreature || !gen->mCreature->isAlive()) && strcmp(treasure_name, config_name) == 0) {
-					gen->generate();
-					GZEXPECT(gen->mCreature, "treasure generator failed");
-					return static_cast<Game::Pellet*>(gen->mCreature);
+					Game::Pellet* pellet = birth_pellet(cfg, config_name, kind);
+					if (!pellet) {
+						return nullptr;
+					}
+					pellet->setPosition(gen->mPosition, false);
+					gen->mCreature     = pellet;
+					pellet->mGenerator = gen;
+					return pellet;
 				}
 			} else if (gen->mObject->mTypeID == 'teki') {
 				Game::GenObjectEnemy* gen_obj_enemy = static_cast<Game::GenObjectEnemy*>(gen->mObject);
@@ -434,6 +490,9 @@ Game::Pellet* TreasureEditor::spawn_treasure(const char* config_name)
 					// dying or when not spawned. This is left as an improvement for the future.
 					// Instead we just spawn the treasure where the enemy would be.
 					Game::Pellet* pellet = birth_pellet(cfg, config_name, kind);
+					if (!pellet) {
+						return nullptr;
+					}
 					pellet->setPosition(gen->mPosition, false);
 					return pellet;
 				}
@@ -442,6 +501,9 @@ Game::Pellet* TreasureEditor::spawn_treasure(const char* config_name)
 		GZEXPECT(false, "no suitable pellet or teki generator found for treasure %s", config_name);
 	} else if (in_cave_play()) {
 		Game::Pellet* pellet = birth_pellet(cfg, config_name, kind);
+		if (!pellet) {
+			return nullptr;
+		}
 
 		// We don't know which spawn point the treasure spawned at, so just place it on the active captain.
 		Game::Navi* navi = p2gz->navi_tools->active_navi();
@@ -463,7 +525,9 @@ void TreasureEditor::set_collected(const char* treasure_name, bool collected)
 			return;
 		}
 
-		Game::CreatureKillArg arg(Game::CKILL_DontCountAsDeath);
+		Game::PelletKillArg arg;
+		arg.mFlags    = Game::CKILL_DontCountAsDeath;
+		arg.mDoRevive = false;
 		creature->kill(&arg);
 	} else {
 		if (creature && creature->isAlive()) {

--- a/src/p2gz/treasureEditor.cpp
+++ b/src/p2gz/treasureEditor.cpp
@@ -530,7 +530,6 @@ Game::Pellet* birth_pellet(Game::PelletConfig* cfg, const char* config_name, int
 		arg.mDoSkipCreateModel = 0;
 		spawned_treasure       = Game::pelletMgr->birth(&arg);
 	}
-	p2gz->treasure_editor->printout_array();
 	return spawned_treasure;
 }
 

--- a/src/p2gz/treasureEditor.cpp
+++ b/src/p2gz/treasureEditor.cpp
@@ -249,11 +249,8 @@ void TreasureEditor::start_move(const char* treasure_name)
 	}
 
 	if (!active_treasure) {
+		// heap is likely exhausted
 		OSReport("couldn't find treasure %s to move\n", treasure_name);
-		// most likely the treasure couldn't be spawned because the heap is too low
-		if (!heap_has_room_for_spawn()) {
-			p2gz->show_callout("No Memory To Spawn Treasure");
-		}
 		return;
 	}
 
@@ -521,6 +518,58 @@ Game::Pellet* birth_pellet(Game::PelletConfig* cfg, const char* config_name, int
 	return Game::pelletMgr->birth(&arg);
 }
 
+// remember a pellet we just spawned so we can revive it (and reuse its model) later
+void TreasureEditor::remember_spawned(const char* config_name, Game::Pellet* pellet)
+{
+	for (size_t i = 0; i < spawned_pellets.len(); i++) {
+		if (strcmp(spawned_pellets[i].name, config_name) == 0) {
+			spawned_pellets[i].pellet = pellet;
+			return;
+		}
+	}
+
+	SpawnedPellet entry;
+	entry.name   = config_name;
+	entry.pellet = pellet;
+	spawned_pellets.push(entry);
+}
+
+// birth a fresh pellet, or revive one we spawned earlier this area load.
+Game::Pellet* TreasureEditor::birth_or_revive(Game::PelletConfig* cfg, const char* config_name, int kind)
+{
+	// try to revive a pellet we spawned earlier for this treasure
+	for (size_t i = 0; i < spawned_pellets.len(); i++) {
+		if (strcmp(spawned_pellets[i].name, config_name) != 0) {
+			continue;
+		}
+
+		Game::Pellet* prev = spawned_pellets[i].pellet;
+		// only safe to reuse if the pellet is dead, still has its model, and still holds this
+		// treasure's config
+		if (prev && !prev->isAlive() && prev->mModel && strcmp(prev->getConfigName(), config_name) == 0) {
+			prev->mMgr->setComeAlive(prev);
+
+			Game::PelletInitArg arg;
+			arg.mDontCheckCollected = true;
+			arg.mTextIdentifier     = const_cast<char*>(config_name);
+			arg.mPelletType         = kind;
+			arg.mPelletIndex        = cfg->mParams.mIndex;
+			arg.mPelView            = nullptr;
+			arg.mDoSkipCreateModel  = 1;
+			prev->init(&arg);
+			return prev;
+		}
+		break;
+	}
+
+	// no reusable pellet, birth a new one
+	Game::Pellet* pellet = birth_pellet(cfg, config_name, kind);
+	if (pellet) {
+		remember_spawned(config_name, pellet);
+	}
+	return pellet;
+}
+
 // place pellet so it doesn't clip into the ground
 static void place_pellet_on_floor(Game::Pellet* pellet, Vector3f pos)
 {
@@ -556,7 +605,7 @@ Game::Pellet* TreasureEditor::spawn_treasure(const char* config_name)
 				const char* treasure_name
 				    = Game::PelletList::Mgr::mInstance->getConfig(kind)->getPelletConfig(treasure_id)->mParams.mName.mData;
 				if ((!gen->mCreature || !gen->mCreature->isAlive()) && strcmp(treasure_name, config_name) == 0) {
-					Game::Pellet* pellet = birth_pellet(cfg, config_name, kind);
+					Game::Pellet* pellet = birth_or_revive(cfg, config_name, kind);
 					if (!pellet) {
 						return nullptr;
 					}
@@ -572,7 +621,7 @@ Game::Pellet* TreasureEditor::spawn_treasure(const char* config_name)
 					// Respawning the enemy is difficult because many of them are handled differently after
 					// dying or when not spawned. This is left as an improvement for the future.
 					// Instead we just spawn the treasure where the enemy would be.
-					Game::Pellet* pellet = birth_pellet(cfg, config_name, kind);
+					Game::Pellet* pellet = birth_or_revive(cfg, config_name, kind);
 					if (!pellet) {
 						return nullptr;
 					}
@@ -583,7 +632,7 @@ Game::Pellet* TreasureEditor::spawn_treasure(const char* config_name)
 		}
 		GZEXPECT(false, "no suitable pellet or teki generator found for treasure %s", config_name);
 	} else if (in_cave_play()) {
-		Game::Pellet* pellet = birth_pellet(cfg, config_name, kind);
+		Game::Pellet* pellet = birth_or_revive(cfg, config_name, kind);
 		if (!pellet) {
 			return nullptr;
 		}
@@ -639,22 +688,20 @@ void TreasureEditor::set_collected(const char* treasure_name, ToggleMenuOption* 
 		arg.mDoRevive = false;
 		creature->kill(&arg);
 	} else {
-		// spawn a new pellet
-		// this leaks due to the model, so just perma show "collected" when the heap is too low so we don't crash
+		// (re)spawn the pellet
+		// a new spawn can still fail if the heap is actually exhausted
+		// in that case, leave toggle saying "collected"
 		if (creature && creature->isAlive()) {
 			return;
 		}
-		if (!heap_has_room_for_spawn()) {
+		if (!spawn_treasure(treasure_name)) {
 			OSReport("couldn't un-collect treasure %s: heap too low to spawn\n", treasure_name);
-			// let the user know why nothing appeared
-			p2gz->show_callout("No Memory To Spawn Treasure");
 			if (collected_opt) {
 				// keep toggle in sync with the actual treasure state
 				collected_opt->set_selection(true);
 			}
 			return;
 		}
-		spawn_treasure(treasure_name);
 		focus_treasure(treasure_name);
 	}
 }
@@ -667,4 +714,6 @@ void TreasureEditor::clear_treasures()
 	}
 	// drop remembered spawn spots from the level we're leaving
 	spawn_positions.clear();
+	// drop remembered spawn pellets from the level we're leaving
+	spawned_pellets.clear();
 }

--- a/src/p2gz/treasureEditor.cpp
+++ b/src/p2gz/treasureEditor.cpp
@@ -518,7 +518,20 @@ Game::Pellet* birth_pellet(Game::PelletConfig* cfg, const char* config_name, int
 	arg.mPelletType         = kind;
 	arg.mPelletIndex        = cfg->mParams.mIndex;
 	arg.mPelView            = nullptr;
-	return Game::pelletMgr->birth(&arg);
+
+	Game::Pellet* spawned_treasure = p2gz->treasure_editor->search_loaded_treasure_index(cfg->mParams.mIndex);
+
+	// Creating a model takes up memory, so only do it if we absolutely have to. 
+	if (spawned_treasure) {
+		arg.mDoSkipCreateModel = 1;
+		spawned_treasure->mMgr->setComeAlive(spawned_treasure);
+		spawned_treasure->init(&arg);
+	} else {
+		arg.mDoSkipCreateModel = 0;
+		spawned_treasure       = Game::pelletMgr->birth(&arg);
+	}
+	p2gz->treasure_editor->printout_array();
+	return spawned_treasure;
 }
 
 // place pellet so it doesn't clip into the ground
@@ -667,4 +680,48 @@ void TreasureEditor::clear_treasures()
 	}
 	// drop remembered spawn spots from the level we're leaving
 	spawn_positions.clear();
+}
+
+void TreasureEditor::add_loaded_treasure(Game::Pellet* treasure)
+{
+	for (int i = 0; i < MAX_LOADED_TREASURES; i++) {
+		if (loaded_treasures[i] == treasure) {
+			return;
+		}
+
+		if (loaded_treasures[i] == nullptr) {
+			loaded_treasures[i] = treasure;
+			return;
+		}
+	}
+}
+
+Game::Pellet* TreasureEditor::search_loaded_treasure_index(int index_to_search)
+{
+	for (int i = 0; i < MAX_LOADED_TREASURES; i++) {
+		if (loaded_treasures[i] && (loaded_treasures[i]->getConfigIndex() == index_to_search)) {
+			return loaded_treasures[i];
+		}
+	}
+	return nullptr;
+}
+
+void TreasureEditor::clear_loaded_treasure_array()
+{
+	for (int i = 0; i < MAX_LOADED_TREASURES; i++) {
+		loaded_treasures[i] = nullptr;
+	}
+}
+
+// Debug function. Displays the loaded treasure array.
+void TreasureEditor::printout_array()
+{
+	for (int i = 0; i < MAX_LOADED_TREASURES; i++) {
+		if (loaded_treasures[i]) {
+			OSReport("Entry number %d has index %d and name %s \n", i, loaded_treasures[i]->getConfigIndex(),
+			         loaded_treasures[i]->getConfigName());
+		} else {
+			OSReport("Entry number %d is empty \n", i);
+		}
+	}
 }

--- a/src/p2gz/treasureEditor.cpp
+++ b/src/p2gz/treasureEditor.cpp
@@ -249,8 +249,11 @@ void TreasureEditor::start_move(const char* treasure_name)
 	}
 
 	if (!active_treasure) {
-		// heap is likely exhausted
 		OSReport("couldn't find treasure %s to move\n", treasure_name);
+		// most likely the treasure couldn't be spawned because the heap is too low
+		if (!heap_has_room_for_spawn()) {
+			p2gz->show_callout("No Memory To Spawn Treasure");
+		}
 		return;
 	}
 
@@ -518,58 +521,6 @@ Game::Pellet* birth_pellet(Game::PelletConfig* cfg, const char* config_name, int
 	return Game::pelletMgr->birth(&arg);
 }
 
-// remember a pellet we just spawned so we can revive it (and reuse its model) later
-void TreasureEditor::remember_spawned(const char* config_name, Game::Pellet* pellet)
-{
-	for (size_t i = 0; i < spawned_pellets.len(); i++) {
-		if (strcmp(spawned_pellets[i].name, config_name) == 0) {
-			spawned_pellets[i].pellet = pellet;
-			return;
-		}
-	}
-
-	SpawnedPellet entry;
-	entry.name   = config_name;
-	entry.pellet = pellet;
-	spawned_pellets.push(entry);
-}
-
-// birth a fresh pellet, or revive one we spawned earlier this area load.
-Game::Pellet* TreasureEditor::birth_or_revive(Game::PelletConfig* cfg, const char* config_name, int kind)
-{
-	// try to revive a pellet we spawned earlier for this treasure
-	for (size_t i = 0; i < spawned_pellets.len(); i++) {
-		if (strcmp(spawned_pellets[i].name, config_name) != 0) {
-			continue;
-		}
-
-		Game::Pellet* prev = spawned_pellets[i].pellet;
-		// only safe to reuse if the pellet is dead, still has its model, and still holds this
-		// treasure's config
-		if (prev && !prev->isAlive() && prev->mModel && strcmp(prev->getConfigName(), config_name) == 0) {
-			prev->mMgr->setComeAlive(prev);
-
-			Game::PelletInitArg arg;
-			arg.mDontCheckCollected = true;
-			arg.mTextIdentifier     = const_cast<char*>(config_name);
-			arg.mPelletType         = kind;
-			arg.mPelletIndex        = cfg->mParams.mIndex;
-			arg.mPelView            = nullptr;
-			arg.mDoSkipCreateModel  = 1;
-			prev->init(&arg);
-			return prev;
-		}
-		break;
-	}
-
-	// no reusable pellet, birth a new one
-	Game::Pellet* pellet = birth_pellet(cfg, config_name, kind);
-	if (pellet) {
-		remember_spawned(config_name, pellet);
-	}
-	return pellet;
-}
-
 // place pellet so it doesn't clip into the ground
 static void place_pellet_on_floor(Game::Pellet* pellet, Vector3f pos)
 {
@@ -605,7 +556,7 @@ Game::Pellet* TreasureEditor::spawn_treasure(const char* config_name)
 				const char* treasure_name
 				    = Game::PelletList::Mgr::mInstance->getConfig(kind)->getPelletConfig(treasure_id)->mParams.mName.mData;
 				if ((!gen->mCreature || !gen->mCreature->isAlive()) && strcmp(treasure_name, config_name) == 0) {
-					Game::Pellet* pellet = birth_or_revive(cfg, config_name, kind);
+					Game::Pellet* pellet = birth_pellet(cfg, config_name, kind);
 					if (!pellet) {
 						return nullptr;
 					}
@@ -621,7 +572,7 @@ Game::Pellet* TreasureEditor::spawn_treasure(const char* config_name)
 					// Respawning the enemy is difficult because many of them are handled differently after
 					// dying or when not spawned. This is left as an improvement for the future.
 					// Instead we just spawn the treasure where the enemy would be.
-					Game::Pellet* pellet = birth_or_revive(cfg, config_name, kind);
+					Game::Pellet* pellet = birth_pellet(cfg, config_name, kind);
 					if (!pellet) {
 						return nullptr;
 					}
@@ -632,7 +583,7 @@ Game::Pellet* TreasureEditor::spawn_treasure(const char* config_name)
 		}
 		GZEXPECT(false, "no suitable pellet or teki generator found for treasure %s", config_name);
 	} else if (in_cave_play()) {
-		Game::Pellet* pellet = birth_or_revive(cfg, config_name, kind);
+		Game::Pellet* pellet = birth_pellet(cfg, config_name, kind);
 		if (!pellet) {
 			return nullptr;
 		}
@@ -688,20 +639,22 @@ void TreasureEditor::set_collected(const char* treasure_name, ToggleMenuOption* 
 		arg.mDoRevive = false;
 		creature->kill(&arg);
 	} else {
-		// (re)spawn the pellet
-		// a new spawn can still fail if the heap is actually exhausted
-		// in that case, leave toggle saying "collected"
+		// spawn a new pellet
+		// this leaks due to the model, so just perma show "collected" when the heap is too low so we don't crash
 		if (creature && creature->isAlive()) {
 			return;
 		}
-		if (!spawn_treasure(treasure_name)) {
+		if (!heap_has_room_for_spawn()) {
 			OSReport("couldn't un-collect treasure %s: heap too low to spawn\n", treasure_name);
+			// let the user know why nothing appeared
+			p2gz->show_callout("No Memory To Spawn Treasure");
 			if (collected_opt) {
 				// keep toggle in sync with the actual treasure state
 				collected_opt->set_selection(true);
 			}
 			return;
 		}
+		spawn_treasure(treasure_name);
 		focus_treasure(treasure_name);
 	}
 }
@@ -714,6 +667,4 @@ void TreasureEditor::clear_treasures()
 	}
 	// drop remembered spawn spots from the level we're leaving
 	spawn_positions.clear();
-	// drop remembered spawn pellets from the level we're leaving
-	spawned_pellets.clear();
 }

--- a/src/p2gz/warp.cpp
+++ b/src/p2gz/warp.cpp
@@ -424,6 +424,9 @@ void Warp::do_warp()
 	if (p2gz->collision_viewer->is_enabled()) {
 		p2gz->collision_viewer->handle_warp();
 	}
+
+	// Treasure editor: clear the array of loaded treasures
+	p2gz->treasure_editor->clear_loaded_treasure_array();
 }
 
 void Warp::reset_cave_treasure_collections(Game::SingleGameSection* game)

--- a/src/plugProjectKandoU/pelletMgr.cpp
+++ b/src/plugProjectKandoU/pelletMgr.cpp
@@ -836,6 +836,7 @@ void Pellet::onInit(CreatureInitArg* initArg)
 	// @P2GZ: treasure editor
 	if (getKind() == PelletType::Treasure || getKind() == PelletType::Upgrade) {
 		p2gz->treasure_editor->add(this);
+		p2gz->treasure_editor->add_loaded_treasure(this);
 	}
 }
 


### PR DESCRIPTION
This fixes a few treasure editor-related crashes and bugs:
- Fixes a crash when trying to respawn a previously collected treasure
- Fixes a bug where respawning a treasure over and over would cause the pellet count to fall out of sync with the actual spawned count
- Patches a heap crash when toggling a treasure to collected/uncollected too many times by preventing the player from spawning any more. This resets on area reload. This one is caused by how pellets are destructed in the game, and would require a lot more meddling than I'm comfortable doing right now. If we want to add some warning text or something we can, but I think it's unlikely people will hit the silent limit without them actively fucking around.