### PR TITLE
Make sure treasures respawn when retrying a cave floor

### DIFF
--- a/src/p2gz/preset.cpp
+++ b/src/p2gz/preset.cpp
@@ -415,21 +415,21 @@ void Preset::TreasureState::restore(u8 dest_sublevel)
 		}
 		Game::playData->mCavePokoCount = cpoko;
 
-		// also restore treasures from before we entered the cave/current segment
-		if (mode == TM_Checkpoint) {
-			// NB: we only deal with treasure entries, not enemy entries
-			Game::PelletFirstMemory* zukan = Game::playData->mZukanStat;
-			if (zukan) {
-				zukan->mOtakara.clear();
-				for (u32 i = 0; i < zukan_otakara.len(); i++) {
-					zukan->mOtakara(zukan_otakara[i]) = Game::KindCounter::KCF_Earned;
-				}
-				zukan->mItem.clear();
-				for (u32 i = 0; i < zukan_item.len(); i++) {
-					zukan->mItem(zukan_item[i]) = Game::KindCounter::KCF_Earned;
-				}
+		// restore piklopedia on retry
+		Game::PelletFirstMemory* zukan = Game::playData->mZukanStat;
+		if (zukan) {
+			zukan->mOtakara.clear();
+			for (u32 i = 0; i < zukan_otakara.len(); i++) {
+				zukan->mOtakara(zukan_otakara[i]) = Game::KindCounter::KCF_Earned;
 			}
+			zukan->mItem.clear();
+			for (u32 i = 0; i < zukan_item.len(); i++) {
+				zukan->mItem(zukan_item[i]) = Game::KindCounter::KCF_Earned;
+			}
+		}
 
+		// also restore counts/pokos from before we entered the cave/current segment
+		if (mode == TM_Checkpoint) {
 			Game::PelletCropMemory* main = Game::playData->mMainCropMemory;
 			if (main) {
 				main->mOtakara.clear();

--- a/src/p2gz/presetMgr.cpp
+++ b/src/p2gz/presetMgr.cpp
@@ -204,14 +204,13 @@ void PresetMgr::fill_current_treasure_state(Preset* preset, WarpDestination dest
 	capture_crop(Game::playData->mCaveCropMemory, ts.cave_held);
 	ts.cave_poko_count = Game::playData->mCavePokoCount;
 
+	// save piklopedia state
+	capture_zukan(Game::playData->mZukanStat, ts.zukan_otakara, ts.zukan_item);
+
 	if (ts.mode == TM_Checkpoint) {
-		capture_zukan(Game::playData->mZukanStat, ts.zukan_otakara, ts.zukan_item);
 		ts.treasure_count = Game::playData->mTreasureCount;
 		ts.poko_count     = Game::playData->mPokoCount;
 		// per-course ground counts are reconstructed from the captured AG field overrides (above)
-	} else {
-		ts.zukan_otakara.clear();
-		ts.zukan_item.clear();
 	}
 
 	prev_heap->becomeCurrentHeap();


### PR DESCRIPTION
This fixes a bug where, when warping to Sublevel 1 of a cave, travelling to Sublevel 2 via the hole, then collecting treasures on the floor, the treasures would not respawn on retrying the floor via the quick retry - the piklopedia wasn't getting properly saved and reset. This makes sure that the piklopedia is always saved alongside the other preset info and restored properly.