### PR TITLE
fix early blues trainer performance on console

### DIFF
--- a/src/p2gz/earlyBluesTrainer.cpp
+++ b/src/p2gz/earlyBluesTrainer.cpp
@@ -354,9 +354,6 @@ void EarlyBluesTrainer::capture_input(Controller* pad)
 	captured_button      = pad->getButton();
 	captured_button_down = pad->getButtonDown();
 
-	// Don't intercept inputs until the warp has finished and we're set up at the start position, so the
-	// player keeps full control during the warp/landing (e.g. to skip the landing cutscene with A). The
-	// A-toggle and reset handlers in update() are likewise gated behind pending_setup.
 	if (pending_setup) {
 		return;
 	}

--- a/src/p2gz/earlyBluesTrainer.cpp
+++ b/src/p2gz/earlyBluesTrainer.cpp
@@ -44,7 +44,7 @@ const f32 INSET_WIDTH  = 192.0f;
 const f32 INSET_HEIGHT = 144.0f;
 const f32 INSET_MARGIN = 24.0f;
 
-const f32 INSET_COLLISION_RADIUS = 1024.0f;
+const f32 INSET_COLLISION_RADIUS = 512.0f;
 
 const int B_HOLD_FRAMES = 20;
 
@@ -133,26 +133,34 @@ static void draw_inset_collision(Graphics& gfx, Viewport* vp, Game::Navi* navi)
 		return;
 	}
 
+	int total = 0;
+	for (Sys::TriIndexList* list = triLists; list; list = static_cast<Sys::TriIndexList*>(list->mNext)) {
+		total += list->getNum();
+	}
+	if (total == 0) {
+		return;
+	}
+
 	gfx.initPrimDraw(vp->getMatrix(true));
 
 	const Vector3f light_dir(0.408f, 0.816f, 0.408f);
 
+	GXBegin(GX_TRIANGLES, GX_VTXFMT0, (u16)(total * 3));
 	for (; triLists; triLists = static_cast<Sys::TriIndexList*>(triLists->mNext)) {
 		for (int i = 0; i < triLists->getNum(); i++) {
-			Sys::Triangle* tri  = triTable->getTriangle(triLists->mObjects[i]);
-			Vector3f& normal    = tri->mTrianglePlane.mNormal;
-			f32 lit             = normal.x * light_dir.x + normal.y * light_dir.y + normal.z * light_dir.z;
-			u8 shade            = (u8)(160.0f + 95.0f * lit);
+			Sys::Triangle* tri = triTable->getTriangle(triLists->mObjects[i]);
+			Vector3f& normal   = tri->mTrianglePlane.mNormal;
+			f32 lit            = normal.x * light_dir.x + normal.y * light_dir.y + normal.z * light_dir.z;
+			u8 shade           = (u8)(160.0f + 95.0f * lit);
 
-			GXBegin(GX_TRIANGLES, GX_VTXFMT0, 3);
 			for (int j = 0; j < 3; j++) {
 				Vector3f* vertex = vertTable->getVertex(tri->mVertices[j]);
 				GXPosition3f32(vertex->x, vertex->y, vertex->z);
 				GXColor4u8(shade, shade, shade, 255);
 			}
-			GXEnd();
 		}
 	}
+	GXEnd();
 }
 
 void EarlyBluesTrainer::stop()
@@ -340,11 +348,18 @@ void EarlyBluesTrainer::update()
 	}
 }
 
-// Disable whistling, switching captains, and throwing.
+// Disable whistling, switching captains, and throwing (A toggles the inset camera instead).
 void EarlyBluesTrainer::capture_input(Controller* pad)
 {
 	captured_button      = pad->getButton();
 	captured_button_down = pad->getButtonDown();
+
+	// Don't intercept inputs until the warp has finished and we're set up at the start position, so the
+	// player keeps full control during the warp/landing (e.g. to skip the landing cutscene with A). The
+	// A-toggle and reset handlers in update() are likewise gated behind pending_setup.
+	if (pending_setup) {
+		return;
+	}
 
 	u32 mask = Controller::PRESS_A | Controller::PRESS_B | Controller::PRESS_Y;
 	pad->mButton.mButton &= ~mask;

--- a/src/p2gz/earlyBluesTrainer.cpp
+++ b/src/p2gz/earlyBluesTrainer.cpp
@@ -46,7 +46,7 @@ const f32 INSET_MARGIN = 24.0f;
 
 const f32 INSET_COLLISION_RADIUS = 512.0f;
 
-const int B_HOLD_FRAMES = 30;
+const int B_HOLD_FRAMES = 20;
 
 const f32 DEATH_PLANE_Y = -300.0f;
 
@@ -348,7 +348,7 @@ void EarlyBluesTrainer::update()
 	}
 }
 
-// Disable whistling, switching captains, and throwing (A toggles the inset camera instead).
+// Disable whistling, switching captains, and throwing.
 void EarlyBluesTrainer::capture_input(Controller* pad)
 {
 	captured_button      = pad->getButton();

--- a/src/p2gz/earlyBluesTrainer.cpp
+++ b/src/p2gz/earlyBluesTrainer.cpp
@@ -46,7 +46,7 @@ const f32 INSET_MARGIN = 24.0f;
 
 const f32 INSET_COLLISION_RADIUS = 512.0f;
 
-const int B_HOLD_FRAMES = 20;
+const int B_HOLD_FRAMES = 30;
 
 const f32 DEATH_PLANE_Y = -300.0f;
 

--- a/src/plugProjectKandoU/singleGS_MainGame.cpp
+++ b/src/plugProjectKandoU/singleGS_MainGame.cpp
@@ -469,13 +469,19 @@ void GameState::exec(SingleGameSection* game)
 		game->enableTimer(180.0f, DEMOTIMER_YouAppearLost);
 	}
 
-	if (moviePlayer->mDemoState == DEMOSTATE_Inactive && needRepayDemo()) {
-		startRepayDemo();
-	} else if (moviePlayer->mDemoState == DEMOSTATE_Inactive && p2gz->poko_editor->repay_demo_enabled) {
-		// @ P2GZ: alternate way to force % cutscenes to play. I'm not disturbing usual game logic if we want
-		// the hack to be playable more normally.
-		startRepayDemo();
-		p2gz->poko_editor->repay_demo_enabled = false;
+	// @P2GZ: suppress the % of debt ("poko") cutscene entirely while the early blues trainer is active.
+	// Both trigger paths must be gated together: gating only the needRepayDemo() branch just reroutes the
+	// trigger into the repay_demo_enabled else-if below. This gate is at the trigger (during the game
+	// update, where the trainer is still enabled), so it is race-free.
+	if (!p2gz->early_blues_trainer->is_enabled()) {
+		if (moviePlayer->mDemoState == DEMOSTATE_Inactive && needRepayDemo()) {
+			startRepayDemo();
+		} else if (moviePlayer->mDemoState == DEMOSTATE_Inactive && p2gz->poko_editor->repay_demo_enabled) {
+			// @ P2GZ: alternate way to force % cutscenes to play. I'm not disturbing usual game logic if we want
+			// the hack to be playable more normally.
+			startRepayDemo();
+			p2gz->poko_editor->repay_demo_enabled = false;
+		}
 	}
 
 	// Check if anything needs to be done following a % of debt cutscene

--- a/src/plugProjectKandoU/singleGS_MainGame.cpp
+++ b/src/plugProjectKandoU/singleGS_MainGame.cpp
@@ -469,10 +469,7 @@ void GameState::exec(SingleGameSection* game)
 		game->enableTimer(180.0f, DEMOTIMER_YouAppearLost);
 	}
 
-	// @P2GZ: suppress the % of debt ("poko") cutscene entirely while the early blues trainer is active.
-	// Both trigger paths must be gated together: gating only the needRepayDemo() branch just reroutes the
-	// trigger into the repay_demo_enabled else-if below. This gate is at the trigger (during the game
-	// update, where the trainer is still enabled), so it is race-free.
+	// @P2GZ: don't play percent cutscene after early blues trainer warp
 	if (!p2gz->early_blues_trainer->is_enabled()) {
 		if (moviePlayer->mDemoState == DEMOSTATE_Inactive && needRepayDemo()) {
 			startRepayDemo();


### PR DESCRIPTION
Also disables the percent cutscene after warping.