### PR TITLE
Treasure editor bugfix

### DIFF
--- a/src/p2gz/treasureEditor.cpp
+++ b/src/p2gz/treasureEditor.cpp
@@ -530,6 +530,7 @@ Game::Pellet* birth_pellet(Game::PelletConfig* cfg, const char* config_name, int
 		arg.mDoSkipCreateModel = 0;
 		spawned_treasure       = Game::pelletMgr->birth(&arg);
 	}
+	p2gz->treasure_editor->printout_array(); 
 	return spawned_treasure;
 }
 

--- a/src/p2gz/treasureEditor.cpp
+++ b/src/p2gz/treasureEditor.cpp
@@ -530,7 +530,6 @@ Game::Pellet* birth_pellet(Game::PelletConfig* cfg, const char* config_name, int
 		arg.mDoSkipCreateModel = 0;
 		spawned_treasure       = Game::pelletMgr->birth(&arg);
 	}
-	p2gz->treasure_editor->printout_array(); 
 	return spawned_treasure;
 }
 

--- a/src/plugProjectKandoU/singleGS_CaveGame.cpp
+++ b/src/plugProjectKandoU/singleGS_CaveGame.cpp
@@ -255,6 +255,9 @@ void CaveState::check_SMenu(SingleGameSection* game)
 		gameSystem->setMoviePause(false, "sm-canc");
 		return;
 	case Screen::Game2DMgr::CHECK2D_SMenu_EscapeCave:
+		// @P2GZ: clear the array of loaded treasures when the player exits a cave the start menu  
+		p2gz->treasure_editor->clear_loaded_treasure_array();
+		
 		gameSystem->resetFlag(GAMESYS_IsGameWorldActive);
 		gameSystem->setMoviePause(false, "sm-giveup");
 		if (moviePlayer->mDemoState != DEMOSTATE_Inactive)

--- a/src/plugProjectKandoU/singleGS_MainGame.cpp
+++ b/src/plugProjectKandoU/singleGS_MainGame.cpp
@@ -539,6 +539,9 @@ void GameState::exec(SingleGameSection* game)
 		gameSystem->setPause(false, "sm-canc", 3);
 		break;
 	case Screen::Game2DMgr::CHECK2D_SMenu_GoToSunset:
+		// @P2GZ: clear the array of loaded treasures when the player goes to sunset 
+		p2gz->treasure_editor->clear_loaded_treasure_array();
+
 		gameSystem->resetFlag(GAMESYS_IsGameWorldActive);
 		gameSystem->setMoviePause(false, "sm-ugot");
 		gameSystem->setPause(false, "sm-ugot", 3);

--- a/src/plugProjectKandoU/singleGameSection.cpp
+++ b/src/plugProjectKandoU/singleGameSection.cpp
@@ -841,6 +841,10 @@ bool SingleGameSection::updateCaveMenus()
 			gameSystem->setMoviePause(false, "cave-yes");
 			mOpenMenuFlags &= ~1;
 			goCave(mCurrentCave);
+
+			// @P2GZ: clear the array of loaded treasures when the player enters a hole  
+			p2gz->treasure_editor->clear_loaded_treasure_array();
+
 			return true;
 		case Screen::Game2DMgr::CHECK2D_CaveInMenu_Cancel:
 			gameSystem->setPause(false, "cave-no", 3);
@@ -862,6 +866,10 @@ bool SingleGameSection::updateCaveMenus()
 			gameSystem->setMoviePause(false, "more-yes");
 			mOpenMenuFlags &= ~2;
 			goNextFloor(mHole);
+
+			// @P2GZ: clear the array of loaded treasures when the player goes to the next sublevel  
+			p2gz->treasure_editor->clear_loaded_treasure_array();
+
 			return true;
 		case Screen::Game2DMgr::CHECK2D_CaveMoreMenu_Cancel:
 			gameSystem->setPause(false, "more-no", 3);
@@ -879,6 +887,10 @@ bool SingleGameSection::updateCaveMenus()
 			gameSystem->setMoviePause(false, "kank-yes");
 			mOpenMenuFlags &= ~4;
 			goMainMap(mFountain);
+
+			// @P2GZ: clear the array of loaded treasures when the player exits a cave via a geyser  
+			p2gz->treasure_editor->clear_loaded_treasure_array();
+
 			return true;
 		case Screen::Game2DMgr::CHECK2D_KanketuMenu_MenuOpen:
 		case Screen::Game2DMgr::CHECK2D_KanketuMenu_Unused:


### PR DESCRIPTION
Fixes an issue where the array of loaded treasures was not getting properly cleared when exiting a cave via give up and escape, when entering a geyser/cave/hole, or when manually ending the day. 