### PR TITLE
Fix wrong copy in Linux patcher

### DIFF
--- a/release_assets/patch.sh
+++ b/release_assets/patch.sh
@@ -37,8 +37,8 @@ if [ -f "$1" ]; then
 	echo "iso extracted..."
 	chmod -R o+rw "$drop/root"
 
-	cp -r -f $home/Patch/root/sys $drop/root/sys/
-	cp -r -f $home/Patch/root/files $drop/root/files/
+	cp -r -f $home/Patch/root/sys $drop/root
+	cp -r -f $home/Patch/root/files $drop/root
 
 	echo "Now building new iso..."
 	cd $home


### PR DESCRIPTION
It did create a subdirectory root/sys/sys instead of overwriting the files.

Tested on Ubuntu 26.04