### PR TITLE
Easier Linux build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,9 @@ sudo xattr -rd com.apple.quarantine '/Applications/Wine Crossover.app'
 - For non-x86(_64) platforms: Install wine from your package manager.
   - For x86(_64), [wibo](https://github.com/decompals/wibo), a minimal 32-bit Windows binary wrapper, will be automatically downloaded and used.
 
+Note that the Flatpack version of Dolphin can't open `main.dol` files because of Flatpack's sandboxing.
+You'll need to create an .iso file.
+
 Building
 --------
 
@@ -102,3 +105,8 @@ To add or replace uncompressed asset files:
 - Add `assets/path/to/asset` to the `P2GZ_CUSTOM_ASSETS_UNCOMPRESSED` array in `build.py`.
 
 Once built, the new DOL will exist at `root/sys/main.dol`, along with a Dolphin-readable directory of all game files.
+
+To create an .iso file, run:
+```sh
+python3 build.py --iso
+``` 

--- a/build.py
+++ b/build.py
@@ -58,6 +58,7 @@ parser.add_argument(
     "--map", "-m", action="store_true", help="Compile a map file for easier debugging"
 )
 parser.add_argument("--test", "-t", action="store_true", help="Compile testing code")
+parser.add_argument("--iso", "-i", action="store_true", help="Create a patched p2gz.iso")
 args = parser.parse_args()
 
 if args.restart_dolphin:
@@ -87,21 +88,19 @@ except IndexError:
     print("ERROR: No .iso file found in the current directory")
     exit()
 
+# Find nodtool, or use the vendored one when not installed
+nodtool = "nodtool"
+if shutil.which("nodtool") is None:
+    print("nodtool is not installed on your system. Using the one in release_assets.")
+    if platform.system() == "Windows":
+        nodtool = os.path.join(os.getcwd(),"release_assets/nodtool.win64.exe")
+    if platform.system() == "Linux":
+        nodtool = os.path.join(os.getcwd(),"release_assets/nodtool.linux")
+    if platform.system() == "Darwin":
+        nodtool = os.path.join(os.getcwd(),"release_assets/nodtool.macos")
+
 if not os.path.exists(os.path.join(os.getcwd(), "root")):
     print(f"Extracting {iso}")
-    
-    # Find nodtool, or use the vendored one
-    if shutil.which("nodtool") is not None:
-        nodtool = "nodtool"
-    else:
-        print("nodtool is not installed on your system. Using the one in release_assets.")
-        if platform.system() == "Windows":
-            nodtool = os.path.join(os.getcwd(),"release_assets/nodtool.win64.exe")
-        if platform.system() == "Linux":
-            nodtool = os.path.join(os.getcwd(),"release_assets/nodtool.linux")
-        if platform.system() == "Darwin":
-            nodtool = os.path.join(os.getcwd(),"release_assets/nodtool.macos")
-
     subprocess.run(f'{nodtool} extract "{iso}" root', shell=True, check=True)
 
     # add extracted dol to correct directory so dtk can find it
@@ -192,6 +191,9 @@ if args.map:
     # build the custom compact crash-handler symbol table from the map
     subprocess.run("python3 tools/gen_crash_symbols.py", shell=True)
 
+if args.iso:
+    print("Creating patched .iso")
+    subprocess.run(f'{nodtool} makegcn root p2gz.iso', shell=True, check=True)
 
 print(f"Done! Build took {round(time.time() - start_time, 2)}s")
 

--- a/build.py
+++ b/build.py
@@ -94,6 +94,7 @@ if not os.path.exists(os.path.join(os.getcwd(), "root")):
     if shutil.which("nodtool") is not None:
         nodtool = "nodtool"
     else:
+        print("nodtool is not installed on your system. Using the one in release_assets.")
         if platform.system() == "Windows":
             nodtool = os.path.join(os.getcwd(),"release_assets/nodtool.win64.exe")
         if platform.system() == "Linux":
@@ -110,6 +111,14 @@ if not os.path.exists(os.path.join(os.getcwd(), "root")):
     for file in glob.glob(os.path.join(NEW_ISO_ASSETS, "files", "thp", "*.thp")):
         os.remove(file)
 
+# Check that cubetool is installed
+if shutil.which("cube") is None:
+    print("ERROR: cube is not installed. Install it with")
+    print("`cargo install cubetool`")
+    print("See https://github.com/mayabyte/cube")
+    print("")
+    exit()
+
 # patch compressed assets (anything with a .szs file type)
 for compressed_dir in P2GZ_CUSTOM_ASSETS_COMPRESSED:
     # Creates a directory for the szs file - anything in the directory are the szs file's uncompressed contents
@@ -119,20 +128,20 @@ for compressed_dir in P2GZ_CUSTOM_ASSETS_COMPRESSED:
 
     # patching existing asset
     if os.path.exists(iso_archive):
-        subprocess.run(f"cube extract {iso_archive} -o {iso_dir}", shell=True)
-        subprocess.run(f"rm {iso_archive}", shell=True)
+        subprocess.run(f"cube extract {iso_archive} -o {iso_dir}", shell=True, check=True)
+        subprocess.run(f"rm {iso_archive}", shell=True, check=True)
 
         print(f"Copying {asset_archive} to {iso_archive}")
         shutil.copytree(compressed_dir, iso_dir, dirs_exist_ok=True)
 
-        subprocess.run(f"cube pack -d --arc-extension szs {iso_dir}", shell=True)
+        subprocess.run(f"cube pack -d --arc-extension szs {iso_dir}", shell=True, check=True)
 
     # adding custom asset
     else:
         print(f"Copying {asset_archive} to {iso_archive}")
         shutil.copytree(compressed_dir, iso_dir, dirs_exist_ok=True)
 
-        subprocess.run(f"cube pack -d --arc-extension szs {iso_dir}", shell=True)
+        subprocess.run(f"cube pack -d --arc-extension szs {iso_dir}", shell=True, check=True)
 
 # patch non-compressed assets
 for path in P2GZ_CUSTOM_ASSETS_UNCOMPRESSED:
@@ -164,9 +173,9 @@ if args.map:
 if args.test:
     config_cmd += " --test"
 
-subprocess.run(config_cmd, shell=True)
+subprocess.run(config_cmd, shell=True, check=True)
 
-subprocess.run("ninja", shell=True)
+subprocess.run("ninja", shell=True, check=True)
 shutil.copy2("build/GPVE01/main.dol", "root/sys/main.dol")
 
 if args.map:

--- a/build.py
+++ b/build.py
@@ -67,7 +67,7 @@ if args.restart_dolphin:
         subprocess.run("pkill -f dolphin-emu", shell=True)
 
 if args.clean:
-    shutil.rmtree(os.path.join(os.getcwd(), "root"))
+    shutil.rmtree(NEW_ISO_ASSETS, ignore_errors=True)
     subprocess.run("ninja -t clean", shell=True)
 
 start_time = time.time()
@@ -89,7 +89,19 @@ except IndexError:
 
 if not os.path.exists(os.path.join(os.getcwd(), "root")):
     print(f"Extracting {iso}")
-    subprocess.run(f'nodtool extract "{iso}" root', shell=True)
+    
+    # Find nodtool, or use the vendored one
+    if shutil.which("nodtool") is not None:
+        nodtool = "nodtool"
+    else:
+        if platform.system() == "Windows":
+            nodtool = os.path.join(os.getcwd(),"release_assets/nodtool.win64.exe")
+        if platform.system() == "Linux":
+            nodtool = os.path.join(os.getcwd(),"release_assets/nodtool.linux")
+        if platform.system() == "Darwin":
+            nodtool = os.path.join(os.getcwd(),"release_assets/nodtool.macos")
+
+    subprocess.run(f'{nodtool} extract "{iso}" root', shell=True, check=True)
 
     # add extracted dol to correct directory so dtk can find it
     shutil.copy2("root/sys/main.dol", "orig/GPVE01/sys/main.dol")


### PR DESCRIPTION
I struggled to get this project to work on Linux. It was mostly the environment setup. Now it works :)

* Exit early when certain commands fail, for better debuggability
* Use vendored nodtool instead of having the user fiddle with PATH
* Give help how to install cube
* Option to create .iso in build.py directly

I have not tested this on Windows.